### PR TITLE
Fix clean ant script

### DIFF
--- a/Source/JNA/build/build.xml
+++ b/Source/JNA/build/build.xml
@@ -122,8 +122,10 @@
 			<include name="*.jar" />
 		</fileset>
 	</path>
-	<taskdef resource="emma_ant.properties" classpathref="emma.classpath" />
-	<target name="instrument">
+	<target name="emma-ant">
+		<taskdef resource="emma_ant.properties" classpathref="emma.classpath" />
+	</target>
+	<target name="instrument" depends="emma-ant">
 		<echo message="Instrumenting ${waffle.lib}" />
 		<path id="build.classpath">
 			<pathelement path="${waffle.lib}" />
@@ -136,7 +138,7 @@
 			<fileset dir="${waffle.cover}/lib" includes="**/*" />
 		</copy>
 	</target>
-	<target name="cover-report">
+	<target name="cover-report" depends="emma-ant">
 		<emma>
 			<report sourcepath="${waffle.src}">
 				<fileset dir="${waffle.cover}">

--- a/Source/JNA/waffle-http/.classpath
+++ b/Source/JNA/waffle-http/.classpath
@@ -3,15 +3,6 @@
 	<classpathentry excluding="**/.svn|**/.svn/*" kind="src" path="src"/>
 	<classpathentry excluding="**/.svn|**/.svn/*" kind="src" path="src-test"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry kind="lib" path="/thirdparty/jna/jna.jar"/>
-	<classpathentry kind="lib" path="/thirdparty/jna/platform.jar"/>
-	<classpathentry kind="lib" path="/thirdparty/slf4j/slf4j-api-1.6.6.jar"/>
-	<classpathentry kind="lib" path="/thirdparty/slf4j/jcl-over-slf4j-1.6.6.jar"/>
-	<classpathentry kind="lib" path="/thirdparty/groboutils/lib/GroboUtils-5-core.jar"/>
-	<classpathentry kind="lib" path="/thirdparty/logback/logback-classic-1.0.6.jar"/>
-	<classpathentry kind="lib" path="/thirdparty/logback/logback-core-1.0.6.jar"/>
-	<classpathentry kind="lib" path="/thirdparty/guava/guava-12.0.1.jar"/>
-	<classpathentry kind="lib" path="/thirdparty/javax/servlet2.5/servlet-api-2.5.jar"/>
 	<classpathentry kind="lib" path="/thirdparty/_lib/jar/javax.servlet/2.5/servlet-api-2.5.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/Source/JNA/waffle-servlet3/src-test/waffle/servlet/NegotiateSecurityFilterTests.java
+++ b/Source/JNA/waffle-servlet3/src-test/waffle/servlet/NegotiateSecurityFilterTests.java
@@ -76,7 +76,7 @@ public class NegotiateSecurityFilterTests extends TestCase {
 		assertEquals("Negotiate", wwwAuthenticates[0]);
 		assertEquals("NTLM", wwwAuthenticates[1]);
 		assertTrue(wwwAuthenticates[2].startsWith("Basic realm=\""));
-		assertEquals(2, response.getHeaderNames().length);
+		assertEquals(2, response.getHeaderNames().size());
 		assertEquals("keep-alive", response.getHeader("Connection"));
 		assertEquals(401, response.getStatus());
 	}
@@ -109,7 +109,7 @@ public class NegotiateSecurityFilterTests extends TestCase {
 			assertTrue(response.getHeader("WWW-Authenticate").startsWith(
 					securityPackage + " "));
 			assertEquals("keep-alive", response.getHeader("Connection"));
-			assertEquals(2, response.getHeaderNames().length);
+			assertEquals(2, response.getHeaderNames().size());
 			assertEquals(401, response.getStatus());
 		} finally {
 			if (clientContext != null) {
@@ -160,14 +160,14 @@ public class NegotiateSecurityFilterTests extends TestCase {
 						.size() > 0);
 
 				if (authenticated) {
-					assertTrue(response.getHeaderNames().length >= 0);
+					assertTrue(response.getHeaderNames().size() >= 0);
 					break;
 				}
 
 				assertTrue(response.getHeader("WWW-Authenticate").startsWith(
 						securityPackage + " "));
 				assertEquals("keep-alive", response.getHeader("Connection"));
-				assertEquals(2, response.getHeaderNames().length);
+				assertEquals(2, response.getHeaderNames().size());
 				assertEquals(401, response.getStatus());
 				String continueToken = response.getHeader("WWW-Authenticate")
 						.substring(securityPackage.length() + 1);
@@ -239,7 +239,7 @@ public class NegotiateSecurityFilterTests extends TestCase {
 				.getHeaderValues("WWW-Authenticate");
 		assertEquals(1, wwwAuthenticates.length);
 		assertTrue(wwwAuthenticates[0].startsWith("NTLM "));
-		assertEquals(2, response.getHeaderNames().length);
+		assertEquals(2, response.getHeaderNames().size());
 		assertEquals("keep-alive", response.getHeader("Connection"));
 		assertEquals(401, response.getStatus());
 	}
@@ -263,7 +263,7 @@ public class NegotiateSecurityFilterTests extends TestCase {
 				.getHeaderValues("WWW-Authenticate");
 		assertEquals(1, wwwAuthenticates.length);
 		assertTrue(wwwAuthenticates[0].startsWith("NTLM "));
-		assertEquals(2, response.getHeaderNames().length);
+		assertEquals(2, response.getHeaderNames().size());
 		assertEquals("keep-alive", response.getHeader("Connection"));
 		assertEquals(401, response.getStatus());
 	}

--- a/Source/JNA/waffle-tomcat5/src-test/waffle/apache/catalina/SimpleServletContext.java
+++ b/Source/JNA/waffle-tomcat5/src-test/waffle/apache/catalina/SimpleServletContext.java
@@ -119,20 +119,12 @@ public class SimpleServletContext implements ServletContext {
 	}
 
 	@Override
-<<<<<<< HEAD
-	public Enumeration<?> getServletNames() {
-=======
 	public Enumeration<String> getServletNames() {
->>>>>>> c19bf1ac239c28d737626f054a2b0f6272a28965
 		return null;
 	}
 
 	@Override
-<<<<<<< HEAD
-	public Enumeration<?> getServlets() {
-=======
 	public Enumeration<Servlet> getServlets() {
->>>>>>> c19bf1ac239c28d737626f054a2b0f6272a28965
 		return null;
 	}
 


### PR DESCRIPTION
Fixed clean ant script
Fixed 3 bugs that showed up from most resent build.  Not sure what
happened.

Daniel,
I guess you got rid of 1.5-ivy version...anyway fixed the ant piece for clean build.  The taskdef for emma just needed to be wrapped.  I couldn't run this for a few reasons.  Three files had issues.  Two of them appeared to not have the original changes and another had some issue with a merge.  Not sure if that was cause I did something exactly when you were or what occurred.  Maybe it occurred when getting rid of 1.5-ivy branch?  Anyway, 4 files here.  If you need me to rebase against 1.5 and try again I can do so.  I also couldn't run the git commands in the ant script so I was unable to run a full build.  However, that is probably mute since this fix corrects deleting everything without error.

I do have additional things after this all gets sync'd.  I ran both findbugs / pmd against the project.  This pointed out a number of items such as boolean getters needed to be is\* instead.  Would that be a breaking change to fix those?  Majority of other issues were all in unit tests.  PMD made lots of suggestions to change test cases and led me to figure out all test cases are really version 3 junit so in the next set, I have them all converted fully to junit 4.  Everything is working there but I'm sure it will take me a bit to rebase and get everything in working order.

Thanks,

Jeremy
