### PR TITLE
add pom.xml files to create a .war and deploy demo filter web app to local tomcat

### DIFF
--- a/Source/JNA/demo/pom.xml
+++ b/Source/JNA/demo/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.github.dblock.waffle</groupId>
+        <artifactId>waffle-parent</artifactId>
+        <version>1.5</version>
+        <relativePath>../build</relativePath>
+    </parent>
+
+    <artifactId>waffle-demo-parent</artifactId>
+
+    <packaging>pom</packaging>
+
+    <name>waffle-demo-parent</name>
+
+    <modules>
+        <module>waffle-filter</module>
+    </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.github.dblock.waffle</groupId>
+                <artifactId>waffle-jna</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.dblock.waffle</groupId>
+                <artifactId>waffle-tomcat6</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.dblock.waffle</groupId>
+                <artifactId>waffle-tomcat7</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+
+    <dependencies>
+        <dependency>
+            <groupId>com.github.dblock.waffle</groupId>
+            <artifactId>waffle-jna</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-war-plugin</artifactId>
+                    <version>2.3</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.tomcat.maven</groupId>
+                    <artifactId>tomcat6-maven-plugin</artifactId>
+                    <version>2.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.tomcat.maven</groupId>
+                    <artifactId>tomcat7-maven-plugin</artifactId>
+                    <version>2.0</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+</project>

--- a/Source/JNA/demo/waffle-filter/pom.xml
+++ b/Source/JNA/demo/waffle-filter/pom.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.github.dblock.waffle</groupId>
+        <artifactId>waffle-demo-parent</artifactId>
+        <version>1.5</version>
+    </parent>
+
+    <artifactId>waffle-filter-demo</artifactId>
+
+    <packaging>war</packaging>
+
+    <name>waffle-filter-demo</name>
+
+
+    <dependencies>
+        <dependency>
+            <groupId>com.github.dblock.waffle</groupId>
+            <artifactId>waffle-tomcat6</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+
+    <build>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.tomcat.maven</groupId>
+                <artifactId>tomcat6-maven-plugin</artifactId>
+                <configuration>
+                    <!-- requires matching block in .m2/settings.xml:
+            <servers>
+            ...
+                <server>
+                    <id>mylocalserver</id>
+                    <username>tomcat</username>
+                    <password>tomcat</password>
+                </server>
+
+                    Also requires user/perms in tomcat/conf/tomcat-users.xml:
+
+                      <role rolename="tomcat"/>
+                      <user username="tomcat" password="tomcat" roles="tomcat,manager-gui,manager-script,manager-jmx,manager-status"/>
+
+                    Note: To remote debug tomcat on port 8000, use: bin/catalina.sh jpda start
+                    -->
+                    <server>mylocalserver</server>
+                </configuration>
+            </plugin>
+
+
+            <plugin>
+                <artifactId>maven-war-plugin</artifactId>
+                <configuration>
+                    <!-- could remove these if we used the maven convention for webapp dir layout. -->
+                    <warSourceDirectory>.</warSourceDirectory>
+                    <warSourceExcludes>pom.xml,target</warSourceExcludes>
+
+                    <webXml>WEB-INF/web.xml</webXml>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+<!--
+Setup
+
+* To deploy to a local running tomcat 6 instance, make the following changes:
+
+ 1. Add a server block to .m2/settings.xml:
+
+            <servers>
+            ...
+                <server>
+                    <id>mylocalserver</id>
+                    <username>tomcat</username>
+                    <password>tomcat</password>
+                </server>
+
+ 2. Add user/perms in tomcat/conf/tomcat-users.xml:
+
+                      <role rolename="tomcat"/>
+                      <user username="tomcat" password="tomcat" roles="tomcat,manager-gui,manager-script,manager-jmx,manager-status"/>
+
+ 3. Deploy to the local tomcat 6 instance using:
+
+        mvn clean package tomcat6:redeploy
+
+   The app will be available at:
+
+        http://localhost:8080/waffle-filter-demo/
+
+ 4. You can launch a locally installed tomcat with remote debugging enabled on port 8000 using:
+
+        apache-tomcat-6.0.35$ bin/catalina.sh jpda start
+
+-->
+</project>

--- a/Source/JNA/pom.xml
+++ b/Source/JNA/pom.xml
@@ -30,5 +30,7 @@
     -->
     <module>waffle-tomcat6</module>
     <module>waffle-tomcat7</module>
+
+    <module>demo</module>
   </modules>
 </project>


### PR DESCRIPTION
Not sure if this is of interest, but while walking through the howto docs, I decided to create some simple maven poms that will package the waffle-filter-demo into a war, and allow deployment to a local tomcat instance.

BTW, the new maven pom.xml files throughout the rest of the project worked very well for me. I was able to do "mvn install" (and even "mvn install -DskipTests" on linux). Very nice. 

After a successful "mvn install" of the Source/JNA tree, it was very simple to use use my new demo poms to deploy to tomcat and single-step debug through the waffle filter code.

-dr
