### PR TITLE
Use JUnit assumeTrue() to 'ignore' specific tests when an attempt to add...

### DIFF
--- a/Source/JNA/waffle-tests/src-test/waffle/servlet/ImpersonateTests.java
+++ b/Source/JNA/waffle-tests/src-test/waffle/servlet/ImpersonateTests.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.IOException;
 import java.security.Principal;
@@ -32,6 +33,7 @@ public class ImpersonateTests {
 
 	private NegotiateSecurityFilter _filter = null;
 	private LMAccess.USER_INFO_1 _userInfo;
+    private int resultOfNetAddUser;
 
 	@Before
 	public void setUp() {
@@ -47,18 +49,23 @@ public class ImpersonateTests {
 		_userInfo.usri1_name = new WString(MockWindowsAccount.TEST_USER_NAME);
 		_userInfo.usri1_password = new WString(MockWindowsAccount.TEST_PASSWORD);
 		_userInfo.usri1_priv = LMAccess.USER_PRIV_USER;
-		assertEquals(LMErr.NERR_Success,
-				Netapi32.INSTANCE.NetUserAdd(null, 1, _userInfo, null));
+
+        resultOfNetAddUser = Netapi32.INSTANCE.NetUserAdd(null, 1, _userInfo, null);
+        // ignore test if not able to add user (need to be administrator to do this).
+        assumeTrue(LMErr.NERR_Success == resultOfNetAddUser);
 	}
 
 	@After
 	public void tearDown() {
 		_filter.destroy();
 
-		assertEquals(
-				LMErr.NERR_Success,
-				Netapi32.INSTANCE.NetUserDel(null,
-						_userInfo.usri1_name.toString()));
+        if (LMErr.NERR_Success ==
+                resultOfNetAddUser) {
+            assertEquals(
+                    LMErr.NERR_Success,
+                    Netapi32.INSTANCE.NetUserDel(null,
+                            _userInfo.usri1_name.toString()));
+        }
 	}
 
 	@Test

--- a/Source/JNA/waffle-tests/src-test/waffle/windows/auth/WindowsAuthProviderTests.java
+++ b/Source/JNA/waffle-tests/src-test/waffle/windows/auth/WindowsAuthProviderTests.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import org.junit.Test;
 
@@ -63,7 +64,8 @@ public class WindowsAuthProviderTests {
 		userInfo.usri1_name = new WString("WaffleTestUser");
 		userInfo.usri1_password = new WString("!WAFFLEP$$Wrd0");
 		userInfo.usri1_priv = LMAccess.USER_PRIV_USER;
-		assertEquals(LMErr.NERR_Success,
+        // ignore test if not able to add user (need to be administrator to do this).
+		assumeTrue(LMErr.NERR_Success ==
 				Netapi32.INSTANCE.NetUserAdd(null, 1, userInfo, null));
 		try {
 			IWindowsAuthProvider prov = new WindowsAuthProviderImpl();
@@ -88,7 +90,8 @@ public class WindowsAuthProviderTests {
 		userInfo.usri1_name = new WString(MockWindowsAccount.TEST_USER_NAME);
 		userInfo.usri1_password = new WString(MockWindowsAccount.TEST_PASSWORD);
 		userInfo.usri1_priv = LMAccess.USER_PRIV_USER;
-		assertEquals(LMErr.NERR_Success,
+		// ignore test if not able to add user (need to be administrator to do this).
+        assumeTrue(LMErr.NERR_Success ==
 				Netapi32.INSTANCE.NetUserAdd(null, 1, userInfo, null));
 		try {
 			IWindowsAuthProvider prov = new WindowsAuthProviderImpl();


### PR DESCRIPTION
... a new user fails. This allows the entire test suite to succeed when run as a non-admin user.
