### PR TITLE
pom: update versions to 1.6-SNAPSHOT

### DIFF
--- a/Source/JNA/build/pom.xml
+++ b/Source/JNA/build/pom.xml
@@ -16,7 +16,7 @@
   
   <groupId>com.github.dblock.waffle</groupId>
   <artifactId>waffle-parent</artifactId>
-  <version>1.5</version>
+  <version>1.6-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>waffle-parent</name>

--- a/Source/JNA/demo/pom.xml
+++ b/Source/JNA/demo/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.github.dblock.waffle</groupId>
         <artifactId>waffle-parent</artifactId>
-        <version>1.5</version>
+        <version>1.6-SNAPSHOT</version>
         <relativePath>../build</relativePath>
     </parent>
 

--- a/Source/JNA/demo/waffle-filter/pom.xml
+++ b/Source/JNA/demo/waffle-filter/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.github.dblock.waffle</groupId>
         <artifactId>waffle-demo-parent</artifactId>
-        <version>1.5</version>
+        <version>1.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>waffle-filter-demo</artifactId>

--- a/Source/JNA/pom.xml
+++ b/Source/JNA/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.github.dblock.waffle</groupId>
     <artifactId>waffle-parent</artifactId>
-    <version>1.5</version>
+    <version>1.6-SNAPSHOT</version>
     <relativePath>build</relativePath>
   </parent>
   <artifactId>waffle-pom</artifactId>

--- a/Source/JNA/waffle-jetty/pom.xml
+++ b/Source/JNA/waffle-jetty/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.github.dblock.waffle</groupId>
     <artifactId>waffle-parent</artifactId>
-    <version>1.5</version>
+    <version>1.6-SNAPSHOT</version>
     <relativePath>../build</relativePath>
   </parent>
   <artifactId>waffle-jetty</artifactId>

--- a/Source/JNA/waffle-jna/pom.xml
+++ b/Source/JNA/waffle-jna/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.github.dblock.waffle</groupId>
     <artifactId>waffle-parent</artifactId>
-    <version>1.5</version>
+    <version>1.6-SNAPSHOT</version>
     <relativePath>../build</relativePath>
   </parent>
   <artifactId>waffle-jna</artifactId>

--- a/Source/JNA/waffle-shiro/pom.xml
+++ b/Source/JNA/waffle-shiro/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.github.dblock.waffle</groupId>
     <artifactId>waffle-parent</artifactId>
-    <version>1.5</version>
+    <version>1.6-SNAPSHOT</version>
     <relativePath>../build</relativePath>
   </parent>
   <artifactId>waffle-shiro</artifactId>

--- a/Source/JNA/waffle-spring-security2/pom.xml
+++ b/Source/JNA/waffle-spring-security2/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.github.dblock.waffle</groupId>
     <artifactId>waffle-parent</artifactId>
-    <version>1.5</version>
+    <version>1.6-SNAPSHOT</version>
     <relativePath>../build</relativePath>
   </parent>
   <artifactId>waffle-spring-security2</artifactId>

--- a/Source/JNA/waffle-spring-security3/pom.xml
+++ b/Source/JNA/waffle-spring-security3/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.github.dblock.waffle</groupId>
     <artifactId>waffle-parent</artifactId>
-    <version>1.5</version>
+    <version>1.6-SNAPSHOT</version>
     <relativePath>../build</relativePath>
   </parent>
   <artifactId>waffle-spring-security3</artifactId>

--- a/Source/JNA/waffle-tests/pom.xml
+++ b/Source/JNA/waffle-tests/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.github.dblock.waffle</groupId>
     <artifactId>waffle-parent</artifactId>
-    <version>1.5</version>
+    <version>1.6-SNAPSHOT</version>
     <relativePath>../build</relativePath>
   </parent>
   <artifactId>waffle-tests</artifactId>

--- a/Source/JNA/waffle-tomcat5/pom.xml
+++ b/Source/JNA/waffle-tomcat5/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.github.dblock.waffle</groupId>
     <artifactId>waffle-parent</artifactId>
-    <version>1.5</version>
+    <version>1.6-SNAPSHOT</version>
     <relativePath>../build</relativePath>
   </parent>
   <artifactId>waffle-tomcat5</artifactId>

--- a/Source/JNA/waffle-tomcat6/pom.xml
+++ b/Source/JNA/waffle-tomcat6/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.github.dblock.waffle</groupId>
     <artifactId>waffle-parent</artifactId>
-    <version>1.5</version>
+    <version>1.6-SNAPSHOT</version>
     <relativePath>../build</relativePath>
   </parent>
   <artifactId>waffle-tomcat6</artifactId>

--- a/Source/JNA/waffle-tomcat7/pom.xml
+++ b/Source/JNA/waffle-tomcat7/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.github.dblock.waffle</groupId>
     <artifactId>waffle-parent</artifactId>
-    <version>1.5</version>
+    <version>1.6-SNAPSHOT</version>
     <relativePath>../build</relativePath>
   </parent>
   <artifactId>waffle-tomcat7</artifactId>


### PR DESCRIPTION
This should put them in the state that the maven release plugin expects for performing the 1.6 release.
