### PR TITLE
Error in InitializeSecurityContext: 'The buffers supplied to a function was too small

### DIFF
--- a/Source/JNAWindowsAuthProvider/src/waffle/windows/auth/impl/WindowsSecurityContextImpl.java
+++ b/Source/JNAWindowsAuthProvider/src/waffle/windows/auth/impl/WindowsSecurityContextImpl.java
@@ -99,6 +99,13 @@ public class WindowsSecurityContextImpl implements IWindowsSecurityContext {
     			targetName, new NativeLong(Sspi.ISC_REQ_CONNECTION), new NativeLong(0), 
     			new NativeLong(Sspi.SECURITY_NATIVE_DREP), continueToken, new NativeLong(0), _ctx, _token, 
     			_attr, null);
+        if (continueToken != null && continueToken.pBuffers != null) {
+        	for (SecBuffer buffer : continueToken.pBuffers) {
+        		if (buffer.pvBuffer != null) {
+        			Secur32.INSTANCE.FreeContextBuffer(buffer.pvBuffer);
+        		}
+        	}
+        }
     	switch(rc) {
     	case W32Errors.SEC_I_CONTINUE_NEEDED:
     		_continue = true;


### PR DESCRIPTION
This error was observed when using waffle for Single Sign On using
Kerberos.

Free buffers additionally on each iteration of the InitializeSecurityContext.
