### PR TITLE
Enabled regular expression manipulation of Remote User

### DIFF
--- a/Docs/ServletSingleSignOnSecurityFilter.md
+++ b/Docs/ServletSingleSignOnSecurityFilter.md
@@ -38,6 +38,28 @@ The filter can be configured with the following `init-param` options.
 * waffle.servlet.spi.NegotiateSecurityFilterProvider/protocols: A list of security protocols supported by the `NegotiateSecurityFilterProvider`. Can be one of or a combination of Negotiate and NTLM. 
 * waffle.servlet.spi.BasicSecurityFilterProvider/realm: The name of the Realm for BASIC authentication. 
 * impersonate: Allow impersonation. When true the remote user will be impersonated. Note that there is no mapping between the Windows native threads, under which the impersonation takes place, and the Java threads. Thus you'll need to use Windows native APIs to perform impersonated actions. Any action done in Java will still be performed with the user account running the servlet container. 
+* remoteUserRegEx [Optional]: A string containing a regular expression pattern.
+* remoteUserReplacement [Optional]: A string used to replace strings matching the pattern.
+
+remoteUserRegEx and remoteUserReplacement are used in combination to manipulate the principal name returned in the REMOTE_USER http header.  When Waffle is being used to replace an existing authentication mechanism these two parameters can be used to manipulate the returned REMOTE_USER format to match the outgoing mechanism to avoid additional downstream code changes.
+
+Remote User Manipulation Example
+--------------------------------
+``` xml
+<filter>
+...
+  <init-param>
+    <param-name>remoteUserRegEx</param-name>
+    <param-value>$.*\\(.*)^</param-value>
+  </init-param>
+  <init-param>
+    <param-name>remoteUserReplacement</param-name>
+    <param-value>prefix$1suffix</param-value>
+  </init-param>
+...
+</filter>
+```
+For a principal name of `DOMAIN\USER` this configuration would make Waffle to return `prefixUSERsuffix` in REMOTE_USER.
 
 Filter Configuration Example
 ----------------------------

--- a/Source/JNA/waffle-jna/src/waffle/servlet/AutoDisposableWindowsPrincipal.java
+++ b/Source/JNA/waffle-jna/src/waffle/servlet/AutoDisposableWindowsPrincipal.java
@@ -33,6 +33,13 @@ public class AutoDisposableWindowsPrincipal extends WindowsPrincipal implements
 		super(windowsIdentity, principalFormat, roleFormat);
 	}
 
+	public AutoDisposableWindowsPrincipal(IWindowsIdentity windowsIdentity,
+			PrincipalFormat principalFormat, PrincipalFormat roleFormat,
+			String remoteUserRegEx, String remoteUserReplacement) {
+		super(windowsIdentity, principalFormat, roleFormat, remoteUserRegEx,
+				remoteUserReplacement);
+	}
+
 	@Override
 	public void valueBound(HttpSessionBindingEvent evt) {
 	}

--- a/Source/JNA/waffle-jna/src/waffle/servlet/NegotiateRequestWrapper.java
+++ b/Source/JNA/waffle-jna/src/waffle/servlet/NegotiateRequestWrapper.java
@@ -54,7 +54,7 @@ public class NegotiateRequestWrapper extends HttpServletRequestWrapper {
 	 */
 	@Override
 	public String getRemoteUser() {
-		return _principal.getName();
+		return _principal.getRemoteUser();
 	}
 
 	/**

--- a/Source/JNA/waffle-jna/src/waffle/servlet/NegotiateSecurityFilter.java
+++ b/Source/JNA/waffle-jna/src/waffle/servlet/NegotiateSecurityFilter.java
@@ -58,6 +58,8 @@ public class NegotiateSecurityFilter implements Filter {
 	private IWindowsAuthProvider _auth;
 	private boolean _allowGuestLogin = true;
 	private boolean _impersonate = false;
+	private String _remoteUserRegEx="";
+	private String _remoteUserReplacement="";
 	private static final String PRINCIPAL_SESSION_KEY = NegotiateSecurityFilter.class
 			.getName() + ".PRINCIPAL";
 
@@ -133,10 +135,11 @@ public class NegotiateSecurityFilter implements Filter {
 				WindowsPrincipal windowsPrincipal = null;
 				if (_impersonate) {
 					windowsPrincipal = new AutoDisposableWindowsPrincipal(
-							windowsIdentity, _principalFormat, _roleFormat);
+							windowsIdentity, _principalFormat, _roleFormat, _remoteUserRegEx,
+							_remoteUserReplacement);
 				} else {
 					windowsPrincipal = new WindowsPrincipal(windowsIdentity,
-							_principalFormat, _roleFormat);
+							_principalFormat, _roleFormat, _remoteUserRegEx, _remoteUserReplacement);
 				}
 
 				_log.debug("roles: " + windowsPrincipal.getRolesString());
@@ -273,6 +276,10 @@ public class NegotiateSecurityFilter implements Filter {
 					providerNames = parameterValue.split("\\s+");
 				} else if (parameterName.equals("authProvider")) {
 					authProvider = parameterValue;
+				} else if (parameterName.equals("remoteUserRegEx")) {
+					_remoteUserRegEx = parameterValue;
+				} else if (parameterName.equals("remoteUserReplacement")) {
+					_remoteUserReplacement = parameterValue;
 				} else {
 					implParameters.put(parameterName, parameterValue);
 				}

--- a/Source/JNA/waffle-jna/src/waffle/servlet/WindowsPrincipal.java
+++ b/Source/JNA/waffle-jna/src/waffle/servlet/WindowsPrincipal.java
@@ -34,6 +34,7 @@ public class WindowsPrincipal implements Principal, Serializable {
 
 	private static final long serialVersionUID = 1L;
 	private String _fqn;
+	private String _remoteUser;
 	private byte[] _sid;
 	private String _sidString;
 	private List<String> _roles;
@@ -47,7 +48,7 @@ public class WindowsPrincipal implements Principal, Serializable {
 	 *            Windows identity.
 	 */
 	public WindowsPrincipal(IWindowsIdentity windowsIdentity) {
-		this(windowsIdentity, PrincipalFormat.fqn, PrincipalFormat.fqn);
+		this(windowsIdentity, PrincipalFormat.fqn, PrincipalFormat.fqn, "", "");
 	}
 
 	/**
@@ -62,9 +63,36 @@ public class WindowsPrincipal implements Principal, Serializable {
 	 */
 	public WindowsPrincipal(IWindowsIdentity windowsIdentity,
 			PrincipalFormat principalFormat, PrincipalFormat roleFormat) {
+		this(windowsIdentity, PrincipalFormat.fqn, PrincipalFormat.fqn, "", "");
+	}
+
+	/**
+	 * A windows principal.
+	 *
+	 * @param windowsIdentity
+	 *            Windows identity.
+	 * @param principalFormat
+	 *            Principal format.
+	 * @param roleFormat
+	 *            Role format.
+	 * @param remoteUserRegEx
+	 *            String containing regular expression pattern to match against Remote User.
+	 * @param remoteUserReplacement
+	 *            String that will replace matching patterns in Remote User.
+	 */
+	public WindowsPrincipal(IWindowsIdentity windowsIdentity,
+			PrincipalFormat principalFormat, PrincipalFormat roleFormat, String remoteUserRegEx, String remoteUserReplacement) {
 		_identity = windowsIdentity;
 		_fqn = windowsIdentity.getFqn();
 		_sid = windowsIdentity.getSid();
+		if (remoteUserRegEx.equals("")||remoteUserReplacement.equals(""))
+		{
+			_remoteUser = _fqn;
+		}
+		else
+		{
+			_remoteUser = _fqn.replaceAll(remoteUserRegEx, remoteUserReplacement);
+		}
 		_sidString = windowsIdentity.getSidString();
 		_groups = getGroups(windowsIdentity.getGroups());
 		_roles = getRoles(windowsIdentity, principalFormat, roleFormat);
@@ -211,6 +239,10 @@ public class WindowsPrincipal implements Principal, Serializable {
 	@Override
 	public String getName() {
 		return _fqn;
+	}
+
+	public String getRemoteUser() {
+		return _remoteUser;
 	}
 
 	/** Underlying identity */


### PR DESCRIPTION
I have made an amendment to allow the REMOTE_USER to be manipulated using a regular expression.  This is so that Waffle can be used as a drop in replacement for an existing authentication mechanism that returned REMOTE_USER in a different format to the fully qualified principal name.
