### PR TITLE
Logging around unit tests

### DIFF
--- a/Source/JNA/waffle-tests/src/test/java/waffle/servlet/NegotiateSecurityFilterLoadTests.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/servlet/NegotiateSecurityFilterLoadTests.java
@@ -26,8 +26,8 @@ import org.junit.Test;
  */
 public class NegotiateSecurityFilterLoadTests {
 
-    @Rule
-    public ContiPerfRule contiPerfRule = new ContiPerfRule();
+	@Rule
+	public ContiPerfRule contiPerfRule = new ContiPerfRule();
 
 	private NegotiateSecurityFilterTests _tests = new NegotiateSecurityFilterTests();
 

--- a/Source/JNA/waffle-tests/src/test/java/waffle/windows/auth/WindowsAuthProviderTests.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/windows/auth/WindowsAuthProviderTests.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,16 +48,18 @@ public class WindowsAuthProviderTests {
 
 	private Logger _log = LoggerFactory.getLogger(WindowsAuthProviderTests.class);
 
-	// @Test
-	// public void testLogonGuestUser() {
-	// IWindowsAuthProvider prov = new WindowsAuthProviderImpl();
-	// IWindowsIdentity identity = prov.logonUser("garbage", "garbage");
-	// _log.debug("Fqn: {}", identity.getFqn());
-	// _log.debug("Guest: {}", identity.isGuest());
-	// assertTrue(identity.getFqn().endsWith("\\Guest"));
-	// assertTrue(identity.isGuest());
-	// identity.dispose();
-	// }
+	// TODO This was commented out, uncommented and ignore until I can determine if this is valid
+	@Ignore
+	@Test
+	public void testLogonGuestUser() {
+		IWindowsAuthProvider prov = new WindowsAuthProviderImpl();
+		IWindowsIdentity identity = prov.logonUser("garbage", "garbage");
+		_log.debug("Fqn: {}", identity.getFqn());
+		_log.debug("Guest: {}", Boolean.valueOf(identity.isGuest()));
+		assertTrue(identity.getFqn().endsWith("\\Guest"));
+		assertTrue(identity.isGuest());
+		identity.dispose();
+	}
 
 	@Test
 	public void testLogonUser() {
@@ -172,6 +175,7 @@ public class WindowsAuthProviderTests {
 					serverContext = provider.acceptSecurityToken(connectionId,
 						clientContext.getToken(), securityPackage);
 				} catch (Exception e) {
+					_log.error("{}", e);
 					break;
 				}
 
@@ -281,6 +285,7 @@ public class WindowsAuthProviderTests {
 					serverContext = provider.acceptSecurityToken(connectionId,
 						clientContext.getToken(), securityPackage);
 				} catch (Exception e) {
+					_log.error("{}", e);
 					break;
 				}
 

--- a/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/MixedAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/MixedAuthenticatorTests.java
@@ -21,7 +21,6 @@ import org.apache.catalina.Realm;
 import org.apache.catalina.deploy.LoginConfig;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import waffle.apache.catalina.SimpleContext;

--- a/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
@@ -22,6 +22,8 @@ import org.apache.catalina.Realm;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import waffle.apache.catalina.SimpleContext;
 import waffle.apache.catalina.SimpleHttpRequest;
@@ -46,6 +48,8 @@ import com.sun.jna.platform.win32.Sspi.SecBufferDesc;
  * @author dblock[at]dblock[dot]org
  */
 public class NegotiateAuthenticatorTests {
+
+	private static final Logger logger = LoggerFactory.getLogger(NegotiateAuthenticatorTests.class);
 
 	NegotiateAuthenticator _authenticator = null;
 
@@ -180,6 +184,7 @@ public class NegotiateAuthenticatorTests {
 					authenticated = _authenticator.authenticate(request, response,
 						null);
 				} catch (Exception e) {
+					logger.error("{}", e);
 					return;
 				}
 

--- a/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
@@ -22,6 +22,8 @@ import org.apache.catalina.Realm;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import waffle.apache.catalina.SimpleContext;
 import waffle.apache.catalina.SimpleHttpRequest;
@@ -44,6 +46,8 @@ import com.sun.jna.platform.win32.Sspi.SecBufferDesc;
  * @author dblock[at]dblock[dot]org
  */
 public class NegotiateAuthenticatorTests {
+
+	private static final Logger logger = LoggerFactory.getLogger(NegotiateAuthenticatorTests.class);
 
 	private NegotiateAuthenticator _authenticator;
 
@@ -178,6 +182,7 @@ public class NegotiateAuthenticatorTests {
 					authenticated = _authenticator.authenticate(request, response,
 						null);
 				} catch (Exception e) {
+					logger.error("{}", e);
 					return;
 				}
 

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
@@ -22,8 +22,9 @@ import org.apache.catalina.LifecycleException;
 import org.apache.catalina.Realm;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import waffle.apache.catalina.SimpleContext;
 import waffle.apache.catalina.SimpleEngine;
@@ -48,6 +49,8 @@ import com.sun.jna.platform.win32.Sspi.SecBufferDesc;
  * @author dblock[at]dblock[dot]org
  */
 public class NegotiateAuthenticatorTests {
+
+	private static final Logger logger = LoggerFactory.getLogger(NegotiateAuthenticatorTests.class);
 
 	private NegotiateAuthenticator _authenticator;
 
@@ -187,6 +190,7 @@ public class NegotiateAuthenticatorTests {
 					authenticated = _authenticator.authenticate(request, response,
 						null);
 				} catch (Exception e) {
+					logger.error("{}", e);
 					return;
 				}
 

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
@@ -23,6 +23,8 @@ import org.apache.catalina.Realm;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import waffle.apache.catalina.SimpleContext;
 import waffle.apache.catalina.SimpleEngine;
@@ -47,6 +49,8 @@ import com.sun.jna.platform.win32.Sspi.SecBufferDesc;
  * @author dblock[at]dblock[dot]org
  */
 public class NegotiateAuthenticatorTests {
+
+	private static final Logger logger = LoggerFactory.getLogger(NegotiateAuthenticatorTests.class);
 
 	private NegotiateAuthenticator _authenticator;
 
@@ -185,6 +189,7 @@ public class NegotiateAuthenticatorTests {
 				try {
 					authenticated = _authenticator.authenticate(request, response);
 				} catch (Exception e) {
+					logger.error("{}", e);
 					return;
 				}
 


### PR DESCRIPTION
Some unit tests that were previously found to now be failing were
isolated with try catch blocks.  Added additional logging around those
try catch blocks to write the stack trace until the issue can be found
and resolved.
