### PR TITLE
Application Security License

### DIFF
--- a/Source/JNA/waffle-jetty/src/main/java/waffle/jetty/package-info.java
+++ b/Source/JNA/waffle-jetty/src/main/java/waffle/jetty/package-info.java
@@ -1,4 +1,17 @@
 /**
+ * Waffle (https://github.com/dblock/waffle)
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Application Security, Inc.
+ */
+/**
  * Nothing for now, but in the future, this would include:
  *
  * <a href="http://dev.eclipse.org/svnroot/rt/org.eclipse.jetty/jetty/trunk/jetty-security/src/main/java/org/eclipse/jetty/security/Authenticator.java">org/eclipse/jetty/security/Authenticator.java</a><br/>

--- a/Source/JNA/waffle-jetty/src/test/java/waffle/jetty/StartEmbeddedJetty.java
+++ b/Source/JNA/waffle-jetty/src/test/java/waffle/jetty/StartEmbeddedJetty.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.jetty;
 
 import java.io.File;

--- a/Source/JNA/waffle-jetty/src/test/java/waffle/jetty/StartEmbeddedJettyValidateNTLMGroup.java
+++ b/Source/JNA/waffle-jetty/src/test/java/waffle/jetty/StartEmbeddedJettyValidateNTLMGroup.java
@@ -1,3 +1,16 @@
+/**
+ * Waffle (https://github.com/dblock/waffle)
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Application Security, Inc.
+ */
 package waffle.jetty;
 
 import java.io.IOException;

--- a/Source/JNA/waffle-jna/src/main/java/waffle/jaas/RolePrincipal.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/jaas/RolePrincipal.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.jaas;
 
 import java.io.Serializable;

--- a/Source/JNA/waffle-jna/src/main/java/waffle/jaas/UserPrincipal.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/jaas/UserPrincipal.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.jaas;
 
 import java.io.Serializable;

--- a/Source/JNA/waffle-jna/src/main/java/waffle/jaas/WindowsLoginModule.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/jaas/WindowsLoginModule.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.jaas;
 
 import java.io.IOException;

--- a/Source/JNA/waffle-jna/src/main/java/waffle/servlet/AutoDisposableWindowsPrincipal.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/servlet/AutoDisposableWindowsPrincipal.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.servlet;
 
 import javax.servlet.http.HttpSessionBindingEvent;

--- a/Source/JNA/waffle-jna/src/main/java/waffle/servlet/NegotiateRequestWrapper.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/servlet/NegotiateRequestWrapper.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.servlet;
 
 import java.security.Principal;

--- a/Source/JNA/waffle-jna/src/main/java/waffle/servlet/NegotiateSecurityFilter.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/servlet/NegotiateSecurityFilter.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.servlet;
 
 import java.io.IOException;

--- a/Source/JNA/waffle-jna/src/main/java/waffle/servlet/WaffleInfoServlet.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/servlet/WaffleInfoServlet.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.servlet;
 
 import java.io.IOException;

--- a/Source/JNA/waffle-jna/src/main/java/waffle/servlet/WindowsPrincipal.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/servlet/WindowsPrincipal.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.servlet;
 
 import java.io.Serializable;

--- a/Source/JNA/waffle-jna/src/main/java/waffle/servlet/spi/BasicSecurityFilterProvider.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/servlet/spi/BasicSecurityFilterProvider.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.servlet.spi;
 
 import java.io.IOException;

--- a/Source/JNA/waffle-jna/src/main/java/waffle/servlet/spi/NegotiateSecurityFilterProvider.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/servlet/spi/NegotiateSecurityFilterProvider.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.servlet.spi;
 
 import java.io.IOException;

--- a/Source/JNA/waffle-jna/src/main/java/waffle/servlet/spi/SecurityFilterProvider.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/servlet/spi/SecurityFilterProvider.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.servlet.spi;
 
 import java.io.IOException;

--- a/Source/JNA/waffle-jna/src/main/java/waffle/servlet/spi/SecurityFilterProviderCollection.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/servlet/spi/SecurityFilterProviderCollection.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.servlet.spi;
 
 import java.io.IOException;

--- a/Source/JNA/waffle-jna/src/main/java/waffle/util/AuthorizationHeader.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/util/AuthorizationHeader.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.util;
 
 import javax.servlet.http.HttpServletRequest;

--- a/Source/JNA/waffle-jna/src/main/java/waffle/util/Base64.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/util/Base64.java
@@ -1,3 +1,16 @@
+/**
+ * Waffle (https://github.com/dblock/waffle)
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Application Security, Inc.
+ */
 /* Encodes and decodes to and from Base64 notation.
  * Copyright (C) 2003 "Eric Glass" <jcifs at samba dot org>
  *

--- a/Source/JNA/waffle-jna/src/main/java/waffle/util/NtlmMessage.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/util/NtlmMessage.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.util;
 
 /**

--- a/Source/JNA/waffle-jna/src/main/java/waffle/util/NtlmServletRequest.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/util/NtlmServletRequest.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.util;
 
 import javax.servlet.http.HttpServletRequest;

--- a/Source/JNA/waffle-jna/src/main/java/waffle/util/SPNegoMessage.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/util/SPNegoMessage.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.util;
 
 /**

--- a/Source/JNA/waffle-jna/src/main/java/waffle/util/WaffleInfo.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/util/WaffleInfo.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.util;
 
 import java.awt.Desktop;

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/IWindowsAccount.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/IWindowsAccount.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.windows.auth;
 
 /**

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/IWindowsAuthProvider.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/IWindowsAuthProvider.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.windows.auth;
 
 /**

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/IWindowsComputer.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/IWindowsComputer.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.windows.auth;
 
 /**

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/IWindowsCredentialsHandle.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/IWindowsCredentialsHandle.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.windows.auth;
 
 import com.sun.jna.platform.win32.Sspi.CredHandle;

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/IWindowsDomain.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/IWindowsDomain.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.windows.auth;
 
 /**

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/IWindowsIdentity.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/IWindowsIdentity.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.windows.auth;
 
 /**

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/IWindowsImpersonationContext.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/IWindowsImpersonationContext.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.windows.auth;
 
 /**

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/IWindowsSecurityContext.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/IWindowsSecurityContext.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.windows.auth;
 
 import com.sun.jna.platform.win32.Sspi;

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/PrincipalFormat.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/PrincipalFormat.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.windows.auth;
 
 /**

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/WindowsAccount.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/WindowsAccount.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.windows.auth;
 
 import java.io.Serializable;

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsAccountImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsAccountImpl.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.windows.auth.impl;
 
 import waffle.windows.auth.IWindowsAccount;

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsAuthProviderImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsAuthProviderImpl.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.windows.auth.impl;
 
 import java.net.InetAddress;

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsComputerImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsComputerImpl.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.windows.auth.impl;
 
 import java.util.ArrayList;

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsCredentialsHandleImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsCredentialsHandleImpl.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.windows.auth.impl;
 
 import waffle.windows.auth.IWindowsCredentialsHandle;
@@ -94,8 +94,8 @@ public class WindowsCredentialsHandleImpl implements IWindowsCredentialsHandle {
     }
 
     /**
-	 * 
-	 */
+     * Get CredHandle.
+     */
     @Override
     public CredHandle getHandle() {
         return _handle;

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsDomainImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsDomainImpl.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.windows.auth.impl;
 
 import waffle.windows.auth.IWindowsDomain;

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsIdentityImpersonationContextImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsIdentityImpersonationContextImpl.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.windows.auth.impl;
 
 import com.sun.jna.platform.win32.Advapi32;

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsIdentityImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsIdentityImpl.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.windows.auth.impl;
 
 import java.util.ArrayList;

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsSecurityContextImpersonationContextImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsSecurityContextImpersonationContextImpl.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.windows.auth.impl;
 
 import com.sun.jna.platform.win32.Secur32;

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsSecurityContextImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsSecurityContextImpl.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.windows.auth.impl;
 
 import waffle.windows.auth.IWindowsCredentialsHandle;

--- a/Source/JNA/waffle-jna/src/test/java/waffle/jaas/RolePrincipalTests.java
+++ b/Source/JNA/waffle-jna/src/test/java/waffle/jaas/RolePrincipalTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.jaas;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-jna/src/test/java/waffle/jaas/UserPrincipalTests.java
+++ b/Source/JNA/waffle-jna/src/test/java/waffle/jaas/UserPrincipalTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.jaas;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-jna/src/test/java/waffle/servlet/spi/SecurityFilterProviderCollectionTests.java
+++ b/Source/JNA/waffle-jna/src/test/java/waffle/servlet/spi/SecurityFilterProviderCollectionTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.servlet.spi;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-jna/src/test/java/waffle/util/Base64Tests.java
+++ b/Source/JNA/waffle-jna/src/test/java/waffle/util/Base64Tests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.util;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-jna/src/test/java/waffle/util/NtlmMessageTests.java
+++ b/Source/JNA/waffle-jna/src/test/java/waffle/util/NtlmMessageTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.util;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-jna/src/test/java/waffle/util/SPNegoMessageTests.java
+++ b/Source/JNA/waffle-jna/src/test/java/waffle/util/SPNegoMessageTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.util;
 
 import static org.junit.Assert.assertFalse;

--- a/Source/JNA/waffle-jna/src/test/java/waffle/util/WaffleInfoTests.java
+++ b/Source/JNA/waffle-jna/src/test/java/waffle/util/WaffleInfoTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.util;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-jna/src/test/java/waffle/windows/auth/PrincipalFormatTests.java
+++ b/Source/JNA/waffle-jna/src/test/java/waffle/windows/auth/PrincipalFormatTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.windows.auth;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-jna/src/test/java/waffle/windows/auth/WindowsAccountTests.java
+++ b/Source/JNA/waffle-jna/src/test/java/waffle/windows/auth/WindowsAccountTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.windows.auth;
 
 import static org.junit.Assert.assertTrue;

--- a/Source/JNA/waffle-jna/src/test/java/waffle/windows/auth/WindowsCredentialsHandleTests.java
+++ b/Source/JNA/waffle-jna/src/test/java/waffle/windows/auth/WindowsCredentialsHandleTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.windows.auth;
 
 import static org.junit.Assert.assertNotNull;

--- a/Source/JNA/waffle-jna/src/test/java/waffle/windows/auth/WindowsSecurityContextTests.java
+++ b/Source/JNA/waffle-jna/src/test/java/waffle/windows/auth/WindowsSecurityContextTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.windows.auth;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-parent/license.txt
+++ b/Source/JNA/waffle-parent/license.txt
@@ -1,0 +1,11 @@
+Waffle (https://github.com/dblock/waffle)
+
+Copyright (c) 2010 - 2014 Application Security, Inc.
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+    Application Security, Inc.

--- a/Source/JNA/waffle-parent/pom.xml
+++ b/Source/JNA/waffle-parent/pom.xml
@@ -428,6 +428,29 @@
                     <artifactId>maven-java-formatter-plugin</artifactId>
                     <version>0.4</version>
                 </plugin>
+                <plugin>
+                    <groupId>com.mycila</groupId>
+                    <artifactId>license-maven-plugin</artifactId>
+                    <version>2.6</version>
+                    <configuration>
+                        <header>../waffle-parent/license.txt</header>
+                        <excludes>
+                            <exclude>target/**</exclude>
+                            <exclude>**/.gitignore</exclude>
+                            <exclude>**/*.txt</exclude>
+                            <exclude>**/*.xml</exclude>
+                            <exclude>**/*.properties</exclude>
+                            <exclude>**/*.html</exclude>
+                            <exclude>**/*.css</exclude>
+                        </excludes>
+                        <includes>
+                            <include>**/*.java</include>
+                        </includes>
+                        <mapping>
+                            <java>JAVADOC_STYLE</java>
+                        </mapping>
+                    </configuration>
+                </plugin>
                 <!-- Report Only -->
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -729,6 +752,18 @@
                         <phase>test</phase>
                         <goals>
                             <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>format</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/AbstractWaffleRealm.java
+++ b/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/AbstractWaffleRealm.java
@@ -1,13 +1,16 @@
-/*******************************************************************************
+/**
+ * Waffle (https://github.com/dblock/waffle)
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     David M. Carr
- *******************************************************************************/
-
+ *     Application Security, Inc.
+ */
 package waffle.shiro;
 
 import org.apache.shiro.authc.AuthenticationException;

--- a/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/GroupMappingWaffleRealm.java
+++ b/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/GroupMappingWaffleRealm.java
@@ -1,13 +1,16 @@
-/*******************************************************************************
+/**
+ * Waffle (https://github.com/dblock/waffle)
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     David M. Carr
- *******************************************************************************/
-
+ *     Application Security, Inc.
+ */
 package waffle.shiro;
 
 import java.util.Collection;

--- a/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/WaffleFqnPrincipal.java
+++ b/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/WaffleFqnPrincipal.java
@@ -1,13 +1,16 @@
-/*******************************************************************************
+/**
+ * Waffle (https://github.com/dblock/waffle)
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     David M. Carr
- *******************************************************************************/
-
+ *     Application Security, Inc.
+ */
 package waffle.shiro;
 
 import java.io.Serializable;

--- a/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/dynamic/DynamicAuthenticationFilter.java
+++ b/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/dynamic/DynamicAuthenticationFilter.java
@@ -1,13 +1,16 @@
-/*******************************************************************************
+/**
+ * Waffle (https://github.com/dblock/waffle)
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     Dan Rollo
- *******************************************************************************/
-
+ *     Application Security, Inc.
+ */
 package waffle.shiro.dynamic;
 
 import waffle.shiro.negotiate.NegotiateAuthenticationFilter;

--- a/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/negotiate/AuthenticationInProgressException.java
+++ b/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/negotiate/AuthenticationInProgressException.java
@@ -1,13 +1,16 @@
-/*******************************************************************************
+/**
+ * Waffle (https://github.com/dblock/waffle)
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     Dan Rollo
- *******************************************************************************/
-
+ *     Application Security, Inc.
+ */
 package waffle.shiro.negotiate;
 
 /**

--- a/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/negotiate/NegotiateAuthenticationFilter.java
+++ b/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/negotiate/NegotiateAuthenticationFilter.java
@@ -1,13 +1,16 @@
-/*******************************************************************************
+/**
+ * Waffle (https://github.com/dblock/waffle)
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     Dan Rollo
- *******************************************************************************/
-
+ *     Application Security, Inc.
+ */
 package waffle.shiro.negotiate;
 
 /**
@@ -59,14 +62,15 @@ public class NegotiateAuthenticationFilter extends AuthenticatingFilter {
     // http://waffle.codeplex.com/discussions/254748
     // setspn -A HTTP/<server-fqdn> <user_tomcat_running_under>
     private static final List<String> protocols           = new ArrayList<String>();
-    {
-        protocols.add("Negotiate");
-        protocols.add("NTLM");
-    }
 
     private String                    failureKeyAttribute = FormAuthenticationFilter.DEFAULT_ERROR_KEY_ATTRIBUTE_NAME;
 
     private String                    rememberMeParam     = FormAuthenticationFilter.DEFAULT_REMEMBER_ME_PARAM;
+
+    public NegotiateAuthenticationFilter() {
+        NegotiateAuthenticationFilter.protocols.add("Negotiate");
+        NegotiateAuthenticationFilter.protocols.add("NTLM");
+    }
 
     public String getRememberMeParam() {
         return rememberMeParam;

--- a/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/negotiate/NegotiateAuthenticationRealm.java
+++ b/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/negotiate/NegotiateAuthenticationRealm.java
@@ -1,13 +1,16 @@
-/*******************************************************************************
+/**
+ * Waffle (https://github.com/dblock/waffle)
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     Dan Rollo
- *******************************************************************************/
-
+ *     Application Security, Inc.
+ */
 package waffle.shiro.negotiate;
 
 /**

--- a/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/negotiate/NegotiateAuthenticationStrategy.java
+++ b/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/negotiate/NegotiateAuthenticationStrategy.java
@@ -1,3 +1,16 @@
+/**
+ * Waffle (https://github.com/dblock/waffle)
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Application Security, Inc.
+ */
 package waffle.shiro.negotiate;
 
 import org.apache.shiro.authc.AuthenticationException;

--- a/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/negotiate/NegotiateInfo.java
+++ b/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/negotiate/NegotiateInfo.java
@@ -1,13 +1,16 @@
-/*******************************************************************************
+/**
+ * Waffle (https://github.com/dblock/waffle)
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     Dan Rollo
- *******************************************************************************/
-
+ *     Application Security, Inc.
+ */
 package waffle.shiro.negotiate;
 
 /**

--- a/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/negotiate/NegotiateToken.java
+++ b/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/negotiate/NegotiateToken.java
@@ -1,13 +1,16 @@
-/*******************************************************************************
+/**
+ * Waffle (https://github.com/dblock/waffle)
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     Dan Rollo
- *******************************************************************************/
-
+ *     Application Security, Inc.
+ */
 package waffle.shiro.negotiate;
 
 /**

--- a/Source/JNA/waffle-shiro/src/test/java/waffle/shiro/GroupMappingWaffleRealmTests.java
+++ b/Source/JNA/waffle-shiro/src/test/java/waffle/shiro/GroupMappingWaffleRealmTests.java
@@ -1,13 +1,16 @@
-/*******************************************************************************
+/**
+ * Waffle (https://github.com/dblock/waffle)
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     David M. Carr
- *******************************************************************************/
-
+ *     Application Security, Inc.
+ */
 package waffle.shiro;
 
 import static org.hamcrest.CoreMatchers.equalTo;

--- a/Source/JNA/waffle-shiro/src/test/java/waffle/shiro/dynamic/DynamicAuthenticationFilterTest.java
+++ b/Source/JNA/waffle-shiro/src/test/java/waffle/shiro/dynamic/DynamicAuthenticationFilterTest.java
@@ -1,13 +1,16 @@
-/*******************************************************************************
+/**
+ * Waffle (https://github.com/dblock/waffle)
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     Dan Rollo
- *******************************************************************************/
-
+ *     Application Security, Inc.
+ */
 package waffle.shiro.dynamic;
 
 import javax.servlet.RequestDispatcher;

--- a/Source/JNA/waffle-shiro/src/test/java/waffle/shiro/negotiate/NegotiateAuthenticationFilterTest.java
+++ b/Source/JNA/waffle-shiro/src/test/java/waffle/shiro/negotiate/NegotiateAuthenticationFilterTest.java
@@ -1,13 +1,16 @@
-/*******************************************************************************
+/**
+ * Waffle (https://github.com/dblock/waffle)
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     Dan Rollo
- *******************************************************************************/
-
+ *     Application Security, Inc.
+ */
 package waffle.shiro.negotiate;
 
 import org.apache.shiro.codec.Base64;

--- a/Source/JNA/waffle-shiro/src/test/java/waffle/shiro/negotiate/NegotiateAuthenticationRealmTest.java
+++ b/Source/JNA/waffle-shiro/src/test/java/waffle/shiro/negotiate/NegotiateAuthenticationRealmTest.java
@@ -1,13 +1,16 @@
-/*******************************************************************************
+/**
+ * Waffle (https://github.com/dblock/waffle)
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     Dan Rollo
- *******************************************************************************/
-
+ *     Application Security, Inc.
+ */
 package waffle.shiro.negotiate;
 
 import junit.framework.TestCase;

--- a/Source/JNA/waffle-shiro/src/test/java/waffle/shiro/negotiate/NegotiateAuthenticationStrategyTest.java
+++ b/Source/JNA/waffle-shiro/src/test/java/waffle/shiro/negotiate/NegotiateAuthenticationStrategyTest.java
@@ -1,3 +1,16 @@
+/**
+ * Waffle (https://github.com/dblock/waffle)
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Application Security, Inc.
+ */
 package waffle.shiro.negotiate;
 
 import org.apache.shiro.realm.Realm;

--- a/Source/JNA/waffle-spring-security2/src/main/java/waffle/spring/FqnGrantedAuthorityFactory.java
+++ b/Source/JNA/waffle-spring-security2/src/main/java/waffle/spring/FqnGrantedAuthorityFactory.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.spring;
 
 import org.springframework.security.GrantedAuthority;

--- a/Source/JNA/waffle-spring-security2/src/main/java/waffle/spring/GrantedAuthorityFactory.java
+++ b/Source/JNA/waffle-spring-security2/src/main/java/waffle/spring/GrantedAuthorityFactory.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.spring;
 
 import org.springframework.security.GrantedAuthority;

--- a/Source/JNA/waffle-spring-security2/src/main/java/waffle/spring/GuestLoginDisabledAuthenticationException.java
+++ b/Source/JNA/waffle-spring-security2/src/main/java/waffle/spring/GuestLoginDisabledAuthenticationException.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.spring;
 
 import org.springframework.security.AuthenticationException;

--- a/Source/JNA/waffle-spring-security2/src/main/java/waffle/spring/NegotiateSecurityFilter.java
+++ b/Source/JNA/waffle-spring-security2/src/main/java/waffle/spring/NegotiateSecurityFilter.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,8 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
-
+ */
 package waffle.spring;
 
 import java.io.IOException;

--- a/Source/JNA/waffle-spring-security2/src/main/java/waffle/spring/NegotiateSecurityFilterEntryPoint.java
+++ b/Source/JNA/waffle-spring-security2/src/main/java/waffle/spring/NegotiateSecurityFilterEntryPoint.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.spring;
 
 import java.io.IOException;

--- a/Source/JNA/waffle-spring-security2/src/main/java/waffle/spring/WindowsAuthenticationProvider.java
+++ b/Source/JNA/waffle-spring-security2/src/main/java/waffle/spring/WindowsAuthenticationProvider.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.spring;
 
 import org.slf4j.Logger;

--- a/Source/JNA/waffle-spring-security2/src/main/java/waffle/spring/WindowsAuthenticationToken.java
+++ b/Source/JNA/waffle-spring-security2/src/main/java/waffle/spring/WindowsAuthenticationToken.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.spring;
 
 import java.util.ArrayList;

--- a/Source/JNA/waffle-spring-security2/src/test/java/waffle/spring/FqnGrantedAuthorityFactoryTests.java
+++ b/Source/JNA/waffle-spring-security2/src/test/java/waffle/spring/FqnGrantedAuthorityFactoryTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.spring;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-spring-security2/src/test/java/waffle/spring/NegotiateSecurityFilterEntryPointTests.java
+++ b/Source/JNA/waffle-spring-security2/src/test/java/waffle/spring/NegotiateSecurityFilterEntryPointTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.spring;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-spring-security2/src/test/java/waffle/spring/NegotiateSecurityFilterTests.java
+++ b/Source/JNA/waffle-spring-security2/src/test/java/waffle/spring/NegotiateSecurityFilterTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.spring;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-spring-security2/src/test/java/waffle/spring/WindowsAuthenticationProviderTests.java
+++ b/Source/JNA/waffle-spring-security2/src/test/java/waffle/spring/WindowsAuthenticationProviderTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.spring;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-spring-security2/src/test/java/waffle/spring/WindowsAuthenticationTokenTests.java
+++ b/Source/JNA/waffle-spring-security2/src/test/java/waffle/spring/WindowsAuthenticationTokenTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.spring;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/FqnGrantedAuthorityFactory.java
+++ b/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/FqnGrantedAuthorityFactory.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.spring;
 
 import org.springframework.security.core.GrantedAuthority;

--- a/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/GrantedAuthorityFactory.java
+++ b/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/GrantedAuthorityFactory.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.spring;
 
 import org.springframework.security.core.GrantedAuthority;

--- a/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/GuestLoginDisabledAuthenticationException.java
+++ b/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/GuestLoginDisabledAuthenticationException.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.spring;
 
 import org.springframework.security.core.AuthenticationException;

--- a/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/NegotiateSecurityFilter.java
+++ b/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/NegotiateSecurityFilter.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,8 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
-
+ */
 package waffle.spring;
 
 import java.io.IOException;

--- a/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/NegotiateSecurityFilterEntryPoint.java
+++ b/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/NegotiateSecurityFilterEntryPoint.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.spring;
 
 import java.io.IOException;

--- a/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/WindowsAuthenticationProvider.java
+++ b/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/WindowsAuthenticationProvider.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.spring;
 
 import org.slf4j.Logger;

--- a/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/WindowsAuthenticationToken.java
+++ b/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/WindowsAuthenticationToken.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.spring;
 
 import java.util.ArrayList;

--- a/Source/JNA/waffle-spring-security3/src/test/java/waffle/spring/FqnGrantedAuthorityFactoryTests.java
+++ b/Source/JNA/waffle-spring-security3/src/test/java/waffle/spring/FqnGrantedAuthorityFactoryTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.spring;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-spring-security3/src/test/java/waffle/spring/NegotiateSecurityFilterEntryPointTests.java
+++ b/Source/JNA/waffle-spring-security3/src/test/java/waffle/spring/NegotiateSecurityFilterEntryPointTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.spring;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-spring-security3/src/test/java/waffle/spring/NegotiateSecurityFilterTests.java
+++ b/Source/JNA/waffle-spring-security3/src/test/java/waffle/spring/NegotiateSecurityFilterTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.spring;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-spring-security3/src/test/java/waffle/spring/WindowsAuthenticationProviderTests.java
+++ b/Source/JNA/waffle-spring-security3/src/test/java/waffle/spring/WindowsAuthenticationProviderTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.spring;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-spring-security3/src/test/java/waffle/spring/WindowsAuthenticationTokenTests.java
+++ b/Source/JNA/waffle-spring-security3/src/test/java/waffle/spring/WindowsAuthenticationTokenTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.spring;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/FqnGrantedAuthorityFactory.java
+++ b/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/FqnGrantedAuthorityFactory.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.spring;
 
 import org.springframework.security.core.GrantedAuthority;

--- a/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/GrantedAuthorityFactory.java
+++ b/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/GrantedAuthorityFactory.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.spring;
 
 import org.springframework.security.core.GrantedAuthority;

--- a/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/GuestLoginDisabledAuthenticationException.java
+++ b/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/GuestLoginDisabledAuthenticationException.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.spring;
 
 import org.springframework.security.core.AuthenticationException;

--- a/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/NegotiateSecurityFilter.java
+++ b/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/NegotiateSecurityFilter.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,8 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
-
+ */
 package waffle.spring;
 
 import java.io.IOException;

--- a/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/NegotiateSecurityFilterEntryPoint.java
+++ b/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/NegotiateSecurityFilterEntryPoint.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.spring;
 
 import java.io.IOException;

--- a/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/WindowsAuthenticationProvider.java
+++ b/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/WindowsAuthenticationProvider.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.spring;
 
 import org.slf4j.Logger;

--- a/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/WindowsAuthenticationToken.java
+++ b/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/WindowsAuthenticationToken.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.spring;
 
 import java.util.ArrayList;

--- a/Source/JNA/waffle-spring-security4/src/test/java/waffle/spring/FqnGrantedAuthorityFactoryTests.java
+++ b/Source/JNA/waffle-spring-security4/src/test/java/waffle/spring/FqnGrantedAuthorityFactoryTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.spring;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-spring-security4/src/test/java/waffle/spring/NegotiateSecurityFilterEntryPointTests.java
+++ b/Source/JNA/waffle-spring-security4/src/test/java/waffle/spring/NegotiateSecurityFilterEntryPointTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.spring;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-spring-security4/src/test/java/waffle/spring/NegotiateSecurityFilterTests.java
+++ b/Source/JNA/waffle-spring-security4/src/test/java/waffle/spring/NegotiateSecurityFilterTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.spring;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-spring-security4/src/test/java/waffle/spring/WindowsAuthenticationProviderTests.java
+++ b/Source/JNA/waffle-spring-security4/src/test/java/waffle/spring/WindowsAuthenticationProviderTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.spring;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-spring-security4/src/test/java/waffle/spring/WindowsAuthenticationTokenTests.java
+++ b/Source/JNA/waffle-spring-security4/src/test/java/waffle/spring/WindowsAuthenticationTokenTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.spring;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsAccount.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsAccount.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.mock;
 
 import waffle.windows.auth.IWindowsAccount;

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsAuthProvider.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsAuthProvider.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.mock;
 
 import java.util.ArrayList;

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsIdentity.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsIdentity.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.mock;
 
 import java.util.ArrayList;

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsImpersonationContext.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsImpersonationContext.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.mock;
 
 import waffle.windows.auth.IWindowsImpersonationContext;

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsSecurityContext.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsSecurityContext.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.mock;
 
 import java.util.ArrayList;

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleFilterChain.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleFilterChain.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.mock.http;
 
 import java.io.IOException;

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleFilterConfig.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleFilterConfig.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.mock.http;
 
 import java.util.ArrayList;

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleHttpRequest.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleHttpRequest.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.mock.http;
 
 import java.security.Principal;
@@ -51,11 +51,11 @@ public class SimpleHttpRequest extends HttpServletRequestWrapper {
         _remotePort = nextRemotePort();
     }
 
-    public synchronized static int nextRemotePort() {
+    public static synchronized int nextRemotePort() {
         return ++_remotePort_s;
     }
 
-    public synchronized static void resetRemotePort() {
+    public static synchronized void resetRemotePort() {
         _remotePort_s = 0;
     }
 

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleHttpResponse.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleHttpResponse.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.mock.http;
 
 import java.io.ByteArrayOutputStream;

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleHttpSession.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleHttpSession.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.mock.http;
 
 import java.util.Enumeration;

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleRequestDispatcher.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleRequestDispatcher.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.mock.http;
 
 import java.io.IOException;

--- a/Source/JNA/waffle-tests/src/test/java/waffle/jaas/UsernamePasswordCallbackHandler.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/jaas/UsernamePasswordCallbackHandler.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.jaas;
 
 import java.io.IOException;

--- a/Source/JNA/waffle-tests/src/test/java/waffle/jaas/WindowsLoginModuleTests.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/jaas/WindowsLoginModuleTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.jaas;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-tests/src/test/java/waffle/servlet/BasicSecurityFilterTests.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/servlet/BasicSecurityFilterTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.servlet;
 
 import static org.junit.Assert.assertTrue;

--- a/Source/JNA/waffle-tests/src/test/java/waffle/servlet/ImpersonateTests.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/servlet/ImpersonateTests.java
@@ -1,3 +1,16 @@
+/**
+ * Waffle (https://github.com/dblock/waffle)
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Application Security, Inc.
+ */
 package waffle.servlet;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-tests/src/test/java/waffle/servlet/NegotiateSecurityFilterLoadTests.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/servlet/NegotiateSecurityFilterLoadTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.servlet;
 
 import org.databene.contiperf.PerfTest;

--- a/Source/JNA/waffle-tests/src/test/java/waffle/servlet/NegotiateSecurityFilterTests.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/servlet/NegotiateSecurityFilterTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.servlet;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-tests/src/test/java/waffle/servlet/WaffleInfoServletTests.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/servlet/WaffleInfoServletTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.servlet;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-tests/src/test/java/waffle/servlet/WindowsPrincipalTests.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/servlet/WindowsPrincipalTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.servlet;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-tests/src/test/java/waffle/util/AuthorizationHeaderTests.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/util/AuthorizationHeaderTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.util;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-tests/src/test/java/waffle/util/NtlmServletRequestTests.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/util/NtlmServletRequestTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.util;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-tests/src/test/java/waffle/windows/auth/WindowsAuthProviderLoadTests.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/windows/auth/WindowsAuthProviderLoadTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.windows.auth;
 
 import org.databene.contiperf.PerfTest;

--- a/Source/JNA/waffle-tests/src/test/java/waffle/windows/auth/WindowsAuthProviderTests.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/windows/auth/WindowsAuthProviderTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.windows.auth;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-tomcat5/src/main/java/waffle/apache/GenericWindowsPrincipal.java
+++ b/Source/JNA/waffle-tomcat5/src/main/java/waffle/apache/GenericWindowsPrincipal.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache;
 
 import java.util.ArrayList;

--- a/Source/JNA/waffle-tomcat5/src/main/java/waffle/apache/MixedAuthenticator.java
+++ b/Source/JNA/waffle-tomcat5/src/main/java/waffle/apache/MixedAuthenticator.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache;
 
 import java.io.IOException;

--- a/Source/JNA/waffle-tomcat5/src/main/java/waffle/apache/NegotiateAuthenticator.java
+++ b/Source/JNA/waffle-tomcat5/src/main/java/waffle/apache/NegotiateAuthenticator.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache;
 
 import java.io.IOException;

--- a/Source/JNA/waffle-tomcat5/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
+++ b/Source/JNA/waffle-tomcat5/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache;
 
 import java.io.IOException;

--- a/Source/JNA/waffle-tomcat5/src/main/java/waffle/apache/WindowsRealm.java
+++ b/Source/JNA/waffle-tomcat5/src/main/java/waffle/apache/WindowsRealm.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache;
 
 import java.security.Principal;

--- a/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/MixedAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/MixedAuthenticatorTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/WaffleAuthenticatorBaseTest.java
+++ b/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/WaffleAuthenticatorBaseTest.java
@@ -1,3 +1,16 @@
+/**
+ * Waffle (https://github.com/dblock/waffle)
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Application Security, Inc.
+ */
 package waffle.apache;
 
 import org.apache.catalina.connector.Request;

--- a/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/WindowsAccountTests.java
+++ b/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/WindowsAccountTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/WindowsRealmTests.java
+++ b/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/WindowsRealmTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/catalina/SimpleContext.java
+++ b/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/catalina/SimpleContext.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache.catalina;
 
 import java.beans.PropertyChangeListener;

--- a/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/catalina/SimpleFilterChain.java
+++ b/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/catalina/SimpleFilterChain.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache.catalina;
 
 import java.io.IOException;

--- a/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/catalina/SimpleHttpRequest.java
+++ b/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/catalina/SimpleHttpRequest.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache.catalina;
 
 import java.security.Principal;

--- a/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/catalina/SimpleHttpResponse.java
+++ b/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/catalina/SimpleHttpResponse.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache.catalina;
 
 import java.util.ArrayList;

--- a/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/catalina/SimpleHttpSession.java
+++ b/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/catalina/SimpleHttpSession.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache.catalina;
 
 import java.util.Enumeration;

--- a/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/catalina/SimpleRealm.java
+++ b/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/catalina/SimpleRealm.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache.catalina;
 
 import java.security.Principal;

--- a/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/catalina/SimpleRequestDispatcher.java
+++ b/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/catalina/SimpleRequestDispatcher.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache.catalina;
 
 import java.io.IOException;

--- a/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/catalina/SimpleServletContext.java
+++ b/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/catalina/SimpleServletContext.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache.catalina;
 
 import java.io.InputStream;

--- a/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/GenericWindowsPrincipal.java
+++ b/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/GenericWindowsPrincipal.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache;
 
 import java.util.ArrayList;

--- a/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/MixedAuthenticator.java
+++ b/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/MixedAuthenticator.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache;
 
 import java.io.IOException;

--- a/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/NegotiateAuthenticator.java
+++ b/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/NegotiateAuthenticator.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache;
 
 import java.io.IOException;

--- a/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
+++ b/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache;
 
 import java.io.IOException;

--- a/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/WindowsRealm.java
+++ b/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/WindowsRealm.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache;
 
 import java.security.Principal;

--- a/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/MixedAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/MixedAuthenticatorTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/WaffleAuthenticatorBaseTest.java
+++ b/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/WaffleAuthenticatorBaseTest.java
@@ -1,3 +1,16 @@
+/**
+ * Waffle (https://github.com/dblock/waffle)
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Application Security, Inc.
+ */
 package waffle.apache;
 
 import org.apache.catalina.connector.Request;

--- a/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/WindowsAccountTests.java
+++ b/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/WindowsAccountTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/WindowsRealmTests.java
+++ b/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/WindowsRealmTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleContext.java
+++ b/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleContext.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache.catalina;
 
 import java.beans.PropertyChangeListener;

--- a/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleFilterChain.java
+++ b/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleFilterChain.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache.catalina;
 
 import java.io.IOException;

--- a/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleHttpRequest.java
+++ b/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleHttpRequest.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache.catalina;
 
 import java.security.Principal;

--- a/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleHttpResponse.java
+++ b/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleHttpResponse.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache.catalina;
 
 import java.util.ArrayList;

--- a/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleHttpSession.java
+++ b/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleHttpSession.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache.catalina;
 
 import java.util.Enumeration;

--- a/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleRealm.java
+++ b/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleRealm.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache.catalina;
 
 import java.security.Principal;

--- a/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleRequestDispatcher.java
+++ b/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleRequestDispatcher.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache.catalina;
 
 import java.io.IOException;

--- a/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleServletContext.java
+++ b/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/catalina/SimpleServletContext.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache.catalina;
 
 import java.io.InputStream;

--- a/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/GenericWindowsPrincipal.java
+++ b/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/GenericWindowsPrincipal.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache;
 
 import java.util.ArrayList;

--- a/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/MixedAuthenticator.java
+++ b/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/MixedAuthenticator.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache;
 
 import java.io.IOException;

--- a/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/NegotiateAuthenticator.java
+++ b/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/NegotiateAuthenticator.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache;
 
 import java.io.IOException;

--- a/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
+++ b/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache;
 
 import java.io.IOException;

--- a/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/WindowsRealm.java
+++ b/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/WindowsRealm.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache;
 
 import java.security.Principal;

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/MixedAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/MixedAuthenticatorTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/WaffleAuthenticatorBaseTest.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/WaffleAuthenticatorBaseTest.java
@@ -1,3 +1,16 @@
+/**
+ * Waffle (https://github.com/dblock/waffle)
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Application Security, Inc.
+ */
 package waffle.apache;
 
 import org.apache.catalina.connector.Request;

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/WindowsAccountTests.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/WindowsAccountTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/WindowsRealmTests.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/WindowsRealmTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleContext.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleContext.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache.catalina;
 
 import java.beans.PropertyChangeListener;

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleEngine.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleEngine.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache.catalina;
 
 import java.beans.PropertyChangeListener;

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleFilterChain.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleFilterChain.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache.catalina;
 
 import java.io.IOException;

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleHttpRequest.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleHttpRequest.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache.catalina;
 
 import java.security.Principal;

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleHttpResponse.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleHttpResponse.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache.catalina;
 
 import java.util.ArrayList;

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleHttpSession.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleHttpSession.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache.catalina;
 
 import java.util.Enumeration;

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimplePipeline.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimplePipeline.java
@@ -1,3 +1,16 @@
+/**
+ * Waffle (https://github.com/dblock/waffle)
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Application Security, Inc.
+ */
 package waffle.apache.catalina;
 
 import org.apache.catalina.Container;

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleRealm.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleRealm.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache.catalina;
 
 import java.security.Principal;

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleRequestDispatcher.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleRequestDispatcher.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache.catalina;
 
 import java.io.IOException;

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleServletContext.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleServletContext.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache.catalina;
 
 import java.io.InputStream;

--- a/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/GenericWindowsPrincipal.java
+++ b/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/GenericWindowsPrincipal.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache;
 
 import java.util.ArrayList;

--- a/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/MixedAuthenticator.java
+++ b/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/MixedAuthenticator.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache;
 
 import java.io.IOException;

--- a/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/NegotiateAuthenticator.java
+++ b/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/NegotiateAuthenticator.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache;
 
 import java.io.IOException;

--- a/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
+++ b/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache;
 
 import java.io.IOException;

--- a/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/WindowsRealm.java
+++ b/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/WindowsRealm.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache;
 
 import java.security.Principal;

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/MixedAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/MixedAuthenticatorTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/WaffleAuthenticatorBaseTest.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/WaffleAuthenticatorBaseTest.java
@@ -1,3 +1,16 @@
+/**
+ * Waffle (https://github.com/dblock/waffle)
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Application Security, Inc.
+ */
 package waffle.apache;
 
 import org.apache.catalina.connector.Request;

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/WindowsAccountTests.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/WindowsAccountTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/WindowsRealmTests.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/WindowsRealmTests.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleContext.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleContext.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache.catalina;
 
 import java.beans.PropertyChangeListener;

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleEngine.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleEngine.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache.catalina;
 
 import java.beans.PropertyChangeListener;

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleFilterChain.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleFilterChain.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache.catalina;
 
 import java.io.IOException;

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleHttpRequest.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleHttpRequest.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache.catalina;
 
 import java.security.Principal;

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleHttpResponse.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleHttpResponse.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache.catalina;
 
 import java.util.ArrayList;

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleHttpSession.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleHttpSession.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache.catalina;
 
 import java.util.Enumeration;

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimplePipeline.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimplePipeline.java
@@ -1,3 +1,16 @@
+/**
+ * Waffle (https://github.com/dblock/waffle)
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Application Security, Inc.
+ */
 package waffle.apache.catalina;
 
 import org.apache.catalina.Container;

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleRealm.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleRealm.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache.catalina;
 
 import java.security.Principal;

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleRequestDispatcher.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleRequestDispatcher.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache.catalina;
 
 import java.io.IOException;

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleServletContext.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleServletContext.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+/**
  * Waffle (https://github.com/dblock/waffle)
- * 
- * Copyright (c) 2010 Application Security, Inc.
- * 
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Application Security, Inc.
- *******************************************************************************/
+ */
 package waffle.apache.catalina;
 
 import java.io.InputStream;


### PR DESCRIPTION
- Put master license in waffle-parent as text file.
- Using license maven plugin to ensure license exists on all java files
- Replaced shiro license notes (code donated to this project)
- Any license changes now should be made to waffle-parent text and all
  java files will pick up on next build.
- Retained base64 license and added waffle license as well.
- Minor cleanup for sonar related issues
