### PR TITLE
This Qualification / Proper Naming

### DIFF
--- a/Source/JNA/waffle-demo/waffle-mixed/src/main/webapp/index.jsp
+++ b/Source/JNA/waffle-demo/waffle-mixed/src/main/webapp/index.jsp
@@ -25,7 +25,7 @@
  <head>
   <title>Protected Page for Examples</title>
  </head>
- <body style="background-color:white;>
+ <body style="background-color:white;">
   You are logged in as remote user <b><%= request.getRemoteUser() %></b> in session <b><%= session.getId() %></b>.
   <br><br>
   <%

--- a/Source/JNA/waffle-jna/src/main/java/waffle/jaas/RolePrincipal.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/jaas/RolePrincipal.java
@@ -41,7 +41,7 @@ public class RolePrincipal implements Principal, Serializable {
      */
     @Override
     public String getName() {
-        return fqn;
+        return this.fqn;
     }
 
     /**

--- a/Source/JNA/waffle-jna/src/main/java/waffle/jaas/UserPrincipal.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/jaas/UserPrincipal.java
@@ -41,7 +41,7 @@ public class UserPrincipal implements Principal, Serializable {
      */
     @Override
     public String getName() {
-        return fqn;
+        return this.fqn;
     }
 
     @Override

--- a/Source/JNA/waffle-jna/src/main/java/waffle/jaas/WindowsLoginModule.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/jaas/WindowsLoginModule.java
@@ -94,12 +94,12 @@ public class WindowsLoginModule implements LoginModule {
         callbacks[0] = usernameCallback;
         callbacks[1] = passwordCallback;
 
-        String username;
+        String userName;
         String password;
 
         try {
             this.callbackHandler.handle(callbacks);
-            username = usernameCallback.getName();
+            userName = usernameCallback.getName();
             password = passwordCallback.getPassword() == null ? "" : new String(passwordCallback.getPassword());
             passwordCallback.clearPassword();
         } catch (IOException e) {
@@ -114,7 +114,7 @@ public class WindowsLoginModule implements LoginModule {
 
         IWindowsIdentity windowsIdentity = null;
         try {
-            windowsIdentity = this.auth.logonUser(username, password);
+            windowsIdentity = this.auth.logonUser(userName, password);
         } catch (Exception e) {
             LOGGER.trace("{}", e);
             throw new LoginException(e.getMessage());
@@ -165,12 +165,12 @@ public class WindowsLoginModule implements LoginModule {
             throw new LoginException("Subject cannot be read-only.");
         }
 
-        Set<Principal> principals = this.subject.getPrincipals();
-        principals.addAll(this.principals);
+        Set<Principal> principalsSet = this.subject.getPrincipals();
+        principalsSet.addAll(this.principals);
 
         LOGGER.debug("committing {} principals", Integer.valueOf(this.subject.getPrincipals().size()));
         if (this.debug) {
-            for (Principal principal : principals) {
+            for (Principal principal : principalsSet) {
                 LOGGER.debug(" principal: {}", principal.getName());
             }
         }
@@ -235,17 +235,17 @@ public class WindowsLoginModule implements LoginModule {
      */
     private static List<Principal> getUserPrincipals(IWindowsIdentity windowsIdentity, PrincipalFormat principalFormat) {
 
-        List<Principal> principals = new ArrayList<Principal>();
+        List<Principal> principalsList = new ArrayList<Principal>();
         switch (principalFormat) {
             case fqn:
-                principals.add(new UserPrincipal(windowsIdentity.getFqn()));
+                principalsList.add(new UserPrincipal(windowsIdentity.getFqn()));
                 break;
             case sid:
-                principals.add(new UserPrincipal(windowsIdentity.getSidString()));
+                principalsList.add(new UserPrincipal(windowsIdentity.getSidString()));
                 break;
             case both:
-                principals.add(new UserPrincipal(windowsIdentity.getFqn()));
-                principals.add(new UserPrincipal(windowsIdentity.getSidString()));
+                principalsList.add(new UserPrincipal(windowsIdentity.getFqn()));
+                principalsList.add(new UserPrincipal(windowsIdentity.getSidString()));
                 break;
             case none:
                 break;
@@ -253,7 +253,7 @@ public class WindowsLoginModule implements LoginModule {
                 break;
         }
 
-        return principals;
+        return principalsList;
     }
 
     /**
@@ -267,17 +267,17 @@ public class WindowsLoginModule implements LoginModule {
      */
     private static List<Principal> getRolePrincipals(IWindowsAccount group, PrincipalFormat principalFormat) {
 
-        List<Principal> principals = new ArrayList<Principal>();
+        List<Principal> principalsList = new ArrayList<Principal>();
         switch (principalFormat) {
             case fqn:
-                principals.add(new RolePrincipal(group.getFqn()));
+                principalsList.add(new RolePrincipal(group.getFqn()));
                 break;
             case sid:
-                principals.add(new RolePrincipal(group.getSidString()));
+                principalsList.add(new RolePrincipal(group.getSidString()));
                 break;
             case both:
-                principals.add(new RolePrincipal(group.getFqn()));
-                principals.add(new RolePrincipal(group.getSidString()));
+                principalsList.add(new RolePrincipal(group.getFqn()));
+                principalsList.add(new RolePrincipal(group.getSidString()));
                 break;
             case none:
                 break;
@@ -285,7 +285,7 @@ public class WindowsLoginModule implements LoginModule {
                 break;
         }
 
-        return principals;
+        return principalsList;
     }
 
     /**

--- a/Source/JNA/waffle-jna/src/main/java/waffle/servlet/NegotiateRequestWrapper.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/servlet/NegotiateRequestWrapper.java
@@ -37,7 +37,7 @@ public class NegotiateRequestWrapper extends HttpServletRequestWrapper {
      */
     @Override
     public Principal getUserPrincipal() {
-        return principal;
+        return this.principal;
     }
 
     /**
@@ -53,7 +53,7 @@ public class NegotiateRequestWrapper extends HttpServletRequestWrapper {
      */
     @Override
     public String getRemoteUser() {
-        return principal.getName();
+        return this.principal.getName();
     }
 
     /**
@@ -61,6 +61,6 @@ public class NegotiateRequestWrapper extends HttpServletRequestWrapper {
      */
     @Override
     public boolean isUserInRole(String role) {
-        return principal.hasRole(role);
+        return this.principal.hasRole(role);
     }
 }

--- a/Source/JNA/waffle-jna/src/main/java/waffle/servlet/WindowsPrincipal.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/servlet/WindowsPrincipal.java
@@ -62,12 +62,12 @@ public class WindowsPrincipal implements Principal, Serializable {
      */
     public WindowsPrincipal(IWindowsIdentity windowsIdentity, PrincipalFormat principalFormat,
             PrincipalFormat roleFormat) {
-        identity = windowsIdentity;
-        fqn = windowsIdentity.getFqn();
-        sid = windowsIdentity.getSid();
-        sidString = windowsIdentity.getSidString();
-        groups = getGroups(windowsIdentity.getGroups());
-        roles = getRoles(windowsIdentity, principalFormat, roleFormat);
+        this.identity = windowsIdentity;
+        this.fqn = windowsIdentity.getFqn();
+        this.sid = windowsIdentity.getSid();
+        this.sidString = windowsIdentity.getSidString();
+        this.groups = getGroups(windowsIdentity.getGroups());
+        this.roles = getRoles(windowsIdentity, principalFormat, roleFormat);
     }
 
     private static List<String> getRoles(IWindowsIdentity windowsIdentity, PrincipalFormat principalFormat,
@@ -94,7 +94,7 @@ public class WindowsPrincipal implements Principal, Serializable {
      * @return Array of bytes.
      */
     public byte[] getSid() {
-        return sid.clone();
+        return this.sid.clone();
     }
 
     /**
@@ -103,7 +103,7 @@ public class WindowsPrincipal implements Principal, Serializable {
      * @return String.
      */
     public String getSidString() {
-        return sidString;
+        return this.sidString;
     }
 
     /**
@@ -112,7 +112,7 @@ public class WindowsPrincipal implements Principal, Serializable {
      * @return A map of group names to groups.
      */
     public Map<String, WindowsAccount> getGroups() {
-        return groups;
+        return this.groups;
     }
 
     /**
@@ -186,7 +186,7 @@ public class WindowsPrincipal implements Principal, Serializable {
      */
     public String getRolesString() {
         StringBuilder sb = new StringBuilder();
-        for (String role : roles) {
+        for (String role : this.roles) {
             if (sb.length() > 0) {
                 sb.append(", ");
             }
@@ -203,7 +203,7 @@ public class WindowsPrincipal implements Principal, Serializable {
      * @return True if the principal has a role, false otherwise.
      */
     public boolean hasRole(String role) {
-        return roles.contains(role);
+        return this.roles.contains(role);
     }
 
     /**
@@ -211,11 +211,11 @@ public class WindowsPrincipal implements Principal, Serializable {
      */
     @Override
     public String getName() {
-        return fqn;
+        return this.fqn;
     }
 
     /** Underlying identity */
     public IWindowsIdentity getIdentity() {
-        return identity;
+        return this.identity;
     }
 }

--- a/Source/JNA/waffle-jna/src/main/java/waffle/servlet/spi/BasicSecurityFilterProvider.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/servlet/spi/BasicSecurityFilterProvider.java
@@ -51,7 +51,7 @@ public class BasicSecurityFilterProvider implements SecurityFilterProvider {
             throw new RuntimeException("Invalid username:password in Authorization header.");
         }
         LOGGER.debug("logging in user: {}", usernamePasswordArray[0]);
-        return auth.logonUser(usernamePasswordArray[0], usernamePasswordArray[1]);
+        return this.auth.logonUser(usernamePasswordArray[0], usernamePasswordArray[1]);
     }
 
     @Override
@@ -66,7 +66,7 @@ public class BasicSecurityFilterProvider implements SecurityFilterProvider {
 
     @Override
     public void sendUnauthorized(HttpServletResponse response) {
-        response.addHeader("WWW-Authenticate", "Basic realm=\"" + realm + "\"");
+        response.addHeader("WWW-Authenticate", "Basic realm=\"" + this.realm + "\"");
     }
 
     /**
@@ -75,17 +75,17 @@ public class BasicSecurityFilterProvider implements SecurityFilterProvider {
      * @return Name of the protection space.
      */
     public String getRealm() {
-        return realm;
+        return this.realm;
     }
 
     /**
      * Set the protection space.
      * 
-     * @param realm
+     * @param value
      *            Protection space name.
      */
-    public void setRealm(String realm) {
-        this.realm = realm;
+    public void setRealm(String value) {
+        this.realm = value;
     }
 
     /**

--- a/Source/JNA/waffle-jna/src/main/java/waffle/servlet/spi/NegotiateSecurityFilterProvider.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/servlet/spi/NegotiateSecurityFilterProvider.java
@@ -46,21 +46,21 @@ public class NegotiateSecurityFilterProvider implements SecurityFilterProvider {
 
     public NegotiateSecurityFilterProvider(IWindowsAuthProvider auth) {
         this.auth = auth;
-        protocols.add("Negotiate");
-        protocols.add("NTLM");
+        this.protocols.add("Negotiate");
+        this.protocols.add("NTLM");
     }
 
     public List<String> getProtocols() {
-        return protocols;
+        return this.protocols;
     }
 
-    public void setProtocols(List<String> protocols) {
-        this.protocols = protocols;
+    public void setProtocols(List<String> values) {
+        this.protocols = values;
     }
 
     @Override
     public void sendUnauthorized(HttpServletResponse response) {
-        Iterator<String> protocolsIterator = protocols.iterator();
+        Iterator<String> protocolsIterator = this.protocols.iterator();
         while (protocolsIterator.hasNext()) {
             response.addHeader("WWW-Authenticate", protocolsIterator.next());
         }
@@ -87,12 +87,13 @@ public class NegotiateSecurityFilterProvider implements SecurityFilterProvider {
 
         if (ntlmPost) {
             // type 2 NTLM authentication message received
-            auth.resetSecurityToken(connectionId);
+            this.auth.resetSecurityToken(connectionId);
         }
 
         byte[] tokenBuffer = authorizationHeader.getTokenBytes();
         LOGGER.debug("token buffer: {} byte(s)", Integer.valueOf(tokenBuffer.length));
-        IWindowsSecurityContext securityContext = auth.acceptSecurityToken(connectionId, tokenBuffer, securityPackage);
+        IWindowsSecurityContext securityContext = this.auth.acceptSecurityToken(connectionId, tokenBuffer,
+                securityPackage);
 
         byte[] continueTokenBytes = securityContext.getToken();
         if (continueTokenBytes != null && continueTokenBytes.length > 0) {
@@ -116,7 +117,7 @@ public class NegotiateSecurityFilterProvider implements SecurityFilterProvider {
 
     @Override
     public boolean isSecurityPackageSupported(String securityPackage) {
-        for (String protocol : protocols) {
+        for (String protocol : this.protocols) {
             if (protocol.equalsIgnoreCase(securityPackage)) {
                 return true;
             }
@@ -127,14 +128,14 @@ public class NegotiateSecurityFilterProvider implements SecurityFilterProvider {
     @Override
     public void initParameter(String parameterName, String parameterValue) {
         if (parameterName.equals("protocols")) {
-            protocols = new ArrayList<String>();
+            this.protocols = new ArrayList<String>();
             String[] protocolNames = parameterValue.split("\\s+");
             for (String protocolName : protocolNames) {
                 protocolName = protocolName.trim();
                 if (protocolName.length() > 0) {
                     LOGGER.debug("init protocol: {}", protocolName);
                     if (protocolName.equals("Negotiate") || protocolName.equals("NTLM")) {
-                        protocols.add(protocolName);
+                        this.protocols.add(protocolName);
                     } else {
                         LOGGER.error("unsupported protocol: {}", protocolName);
                         throw new RuntimeException("Unsupported protocol: " + protocolName);

--- a/Source/JNA/waffle-jna/src/main/java/waffle/servlet/spi/SecurityFilterProviderCollection.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/servlet/spi/SecurityFilterProviderCollection.java
@@ -56,7 +56,7 @@ public class SecurityFilterProviderCollection {
                         .forName(providerName);
                 Constructor<SecurityFilterProvider> c = providerClass.getConstructor(IWindowsAuthProvider.class);
                 SecurityFilterProvider provider = c.newInstance(auth);
-                providers.add(provider);
+                this.providers.add(provider);
             } catch (ClassNotFoundException e) {
                 LOGGER.error("error loading '{}': {}", providerName, e.getMessage());
                 LOGGER.trace("{}", e);
@@ -84,8 +84,8 @@ public class SecurityFilterProviderCollection {
     }
 
     public SecurityFilterProviderCollection(IWindowsAuthProvider auth) {
-        providers.add(new NegotiateSecurityFilterProvider(auth));
-        providers.add(new BasicSecurityFilterProvider(auth));
+        this.providers.add(new NegotiateSecurityFilterProvider(auth));
+        this.providers.add(new BasicSecurityFilterProvider(auth));
     }
 
     /**
@@ -100,7 +100,7 @@ public class SecurityFilterProviderCollection {
     }
 
     private SecurityFilterProvider get(String securityPackage) {
-        for (SecurityFilterProvider provider : providers) {
+        for (SecurityFilterProvider provider : this.providers) {
             if (provider.isSecurityPackageSupported(securityPackage)) {
                 return provider;
             }
@@ -137,7 +137,7 @@ public class SecurityFilterProviderCollection {
      */
     public boolean isPrincipalException(HttpServletRequest request) {
 
-        for (SecurityFilterProvider provider : providers) {
+        for (SecurityFilterProvider provider : this.providers) {
             if (provider.isPrincipalException(request)) {
                 return true;
             }
@@ -153,7 +153,7 @@ public class SecurityFilterProviderCollection {
      *            Http Response
      */
     public void sendUnauthorized(HttpServletResponse response) {
-        for (SecurityFilterProvider provider : providers) {
+        for (SecurityFilterProvider provider : this.providers) {
             provider.sendUnauthorized(response);
         }
     }
@@ -164,7 +164,7 @@ public class SecurityFilterProviderCollection {
      * @return Number of providers.
      */
     public int size() {
-        return providers.size();
+        return this.providers.size();
     }
 
     /**
@@ -176,7 +176,7 @@ public class SecurityFilterProviderCollection {
      * @throws ClassNotFoundException
      */
     public SecurityFilterProvider getByClassName(String name) throws ClassNotFoundException {
-        for (SecurityFilterProvider provider : providers) {
+        for (SecurityFilterProvider provider : this.providers) {
             if (provider.getClass().getName().equals(name)) {
                 return provider;
             }

--- a/Source/JNA/waffle-jna/src/main/java/waffle/util/AuthorizationHeader.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/util/AuthorizationHeader.java
@@ -26,12 +26,12 @@ public class AuthorizationHeader {
 
     private HttpServletRequest request;
 
-    public AuthorizationHeader(HttpServletRequest request) {
-        this.request = request;
+    public AuthorizationHeader(HttpServletRequest httpServletRequest) {
+        this.request = httpServletRequest;
     }
 
     public String getHeader() {
-        return request.getHeader("Authorization");
+        return this.request.getHeader("Authorization");
     }
 
     public boolean isNull() {
@@ -107,11 +107,11 @@ public class AuthorizationHeader {
      * @return True if request is an NTLM POST or PUT with an Authorization header and no data.
      */
     public boolean isNtlmType1PostAuthorizationHeader() {
-        if (!request.getMethod().equals("POST") && !request.getMethod().equals("PUT")) {
+        if (!this.request.getMethod().equals("POST") && !this.request.getMethod().equals("PUT")) {
             return false;
         }
 
-        if (request.getContentLength() != 0) {
+        if (this.request.getContentLength() != 0) {
             return false;
         }
 

--- a/Source/JNA/waffle-jna/src/main/java/waffle/util/WaffleInfo.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/util/WaffleInfo.java
@@ -72,7 +72,7 @@ import waffle.windows.auth.impl.WindowsAuthProviderImpl;
  */
 public class WaffleInfo {
 
-    private static final Logger _log = LoggerFactory.getLogger(WaffleInfo.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(WaffleInfo.class);
 
     /**
      * Get a Document with basic system information
@@ -250,7 +250,7 @@ public class WaffleInfo {
                 } else if (arg.equals("-lookup")) {
                     lookup.add(args[++i]);
                 } else {
-                    _log.error("Unknown Argument: {}", arg);
+                    LOGGER.error("Unknown Argument: {}", arg);
                     System.exit(1);
                 }
             }
@@ -269,17 +269,17 @@ public class WaffleInfo {
                 Files.write(xml, f, Charsets.UTF_8);
                 Desktop.getDesktop().open(f);
             } else {
-                _log.info(xml);
+                LOGGER.info(xml);
             }
         } catch (IOException e) {
-            _log.error(e.getMessage());
-            _log.trace("{}", e);
+            LOGGER.error(e.getMessage());
+            LOGGER.trace("{}", e);
         } catch (TransformerException e) {
-            _log.error(e.getMessage());
-            _log.trace("{}", e);
+            LOGGER.error(e.getMessage());
+            LOGGER.trace("{}", e);
         } catch (ParserConfigurationException e) {
-            _log.error(e.getMessage());
-            _log.trace("{}", e);
+            LOGGER.error(e.getMessage());
+            LOGGER.trace("{}", e);
         }
     }
 }

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/WindowsAccount.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/WindowsAccount.java
@@ -23,32 +23,32 @@ import java.io.Serializable;
 public class WindowsAccount implements Serializable {
 
     private static final long serialVersionUID = 1L;
-    private String            _sidString;
-    private String            _fqn;
-    private String            _name;
-    private String            _domain;
+    private String            sidString;
+    private String            fqn;
+    private String            name;
+    private String            domain;
 
     public WindowsAccount(IWindowsAccount account) {
-        _sidString = account.getSidString();
-        _fqn = account.getFqn();
-        _name = account.getName();
-        _domain = account.getDomain();
+        this.sidString = account.getSidString();
+        this.fqn = account.getFqn();
+        this.name = account.getName();
+        this.domain = account.getDomain();
     }
 
     public String getSidString() {
-        return _sidString;
+        return this.sidString;
     }
 
     public String getFqn() {
-        return _fqn;
+        return this.fqn;
     }
 
     public String getName() {
-        return _name;
+        return this.name;
     }
 
     public String getDomain() {
-        return _domain;
+        return this.domain;
     }
 
     @Override

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsAccountImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsAccountImpl.java
@@ -27,16 +27,16 @@ import com.sun.jna.platform.win32.Secur32.EXTENDED_NAME_FORMAT;
  */
 public class WindowsAccountImpl implements IWindowsAccount {
 
-    private Account _account;
+    private Account account;
 
     @Override
     public String getFqn() {
-        return _account.fqn;
+        return this.account.fqn;
     }
 
     @Override
     public String getSidString() {
-        return _account.sidString;
+        return this.account.sidString;
     }
 
     /**
@@ -44,7 +44,7 @@ public class WindowsAccountImpl implements IWindowsAccount {
      */
     @Override
     public String getName() {
-        return _account.name;
+        return this.account.name;
     }
 
     /**
@@ -52,7 +52,7 @@ public class WindowsAccountImpl implements IWindowsAccount {
      */
     @Override
     public String getDomain() {
-        return _account.domain;
+        return this.account.domain;
     }
 
     /**
@@ -93,6 +93,6 @@ public class WindowsAccountImpl implements IWindowsAccount {
      *            Account.
      */
     public WindowsAccountImpl(Account account) {
-        _account = account;
+        this.account = account;
     }
 }

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsComputerImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsComputerImpl.java
@@ -34,13 +34,13 @@ public class WindowsComputerImpl implements IWindowsComputer {
 
     @Override
     public String getComputerName() {
-        return computerName;
+        return this.computerName;
     }
 
     @Override
     public String[] getGroups() {
         List<String> groupNames = new ArrayList<String>();
-        LocalGroup[] groups = Netapi32Util.getLocalGroups(computerName);
+        LocalGroup[] groups = Netapi32Util.getLocalGroups(this.computerName);
         for (LocalGroup group : groups) {
             groupNames.add(group.name);
         }
@@ -49,7 +49,7 @@ public class WindowsComputerImpl implements IWindowsComputer {
 
     @Override
     public String getJoinStatus() {
-        int joinStatus = Netapi32Util.getJoinStatus(computerName);
+        int joinStatus = Netapi32Util.getJoinStatus(this.computerName);
         switch (joinStatus) {
             case LMJoin.NETSETUP_JOIN_STATUS.NetSetupDomainName:
                 return "NetSetupDomainName";
@@ -66,7 +66,7 @@ public class WindowsComputerImpl implements IWindowsComputer {
 
     @Override
     public String getMemberOf() {
-        return domainName;
+        return this.domainName;
     }
 
     public WindowsComputerImpl(String computerName) {

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsCredentialsHandleImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsCredentialsHandleImpl.java
@@ -30,11 +30,11 @@ import com.sun.jna.platform.win32.WinError;
  */
 public class WindowsCredentialsHandleImpl implements IWindowsCredentialsHandle {
 
-    private String     _principalName;
-    private int        _credentialsType;
-    private String     _securityPackage;
-    private CredHandle _handle;
-    private TimeStamp  _clientLifetime;
+    private String     principalName;
+    private int        credentialsType;
+    private String     securityPackage;
+    private CredHandle handle;
+    private TimeStamp  clientLifetime;
 
     /**
      * Returns the current credentials handle.
@@ -61,9 +61,9 @@ public class WindowsCredentialsHandleImpl implements IWindowsCredentialsHandle {
      *            Security package.
      */
     public WindowsCredentialsHandleImpl(String principalName, int credentialsType, String securityPackage) {
-        _principalName = principalName;
-        _credentialsType = credentialsType;
-        _securityPackage = securityPackage;
+        this.principalName = principalName;
+        this.credentialsType = credentialsType;
+        this.securityPackage = securityPackage;
     }
 
     /**
@@ -71,10 +71,10 @@ public class WindowsCredentialsHandleImpl implements IWindowsCredentialsHandle {
      */
     @Override
     public void initialize() {
-        _handle = new CredHandle();
-        _clientLifetime = new TimeStamp();
-        int rc = Secur32.INSTANCE.AcquireCredentialsHandle(_principalName, _securityPackage, _credentialsType, null,
-                null, null, null, _handle, _clientLifetime);
+        this.handle = new CredHandle();
+        this.clientLifetime = new TimeStamp();
+        int rc = Secur32.INSTANCE.AcquireCredentialsHandle(this.principalName, this.securityPackage,
+                this.credentialsType, null, null, null, null, this.handle, this.clientLifetime);
         if (WinError.SEC_E_OK != rc) {
             throw new Win32Exception(rc);
         }
@@ -85,8 +85,8 @@ public class WindowsCredentialsHandleImpl implements IWindowsCredentialsHandle {
      */
     @Override
     public void dispose() {
-        if (_handle != null && !_handle.isNull()) {
-            int rc = Secur32.INSTANCE.FreeCredentialsHandle(_handle);
+        if (this.handle != null && !this.handle.isNull()) {
+            int rc = Secur32.INSTANCE.FreeCredentialsHandle(this.handle);
             if (WinError.SEC_E_OK != rc) {
                 throw new Win32Exception(rc);
             }
@@ -98,6 +98,6 @@ public class WindowsCredentialsHandleImpl implements IWindowsCredentialsHandle {
      */
     @Override
     public CredHandle getHandle() {
-        return _handle;
+        return this.handle;
     }
 }

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsDomainImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsDomainImpl.java
@@ -32,48 +32,48 @@ public class WindowsDomainImpl implements IWindowsDomain {
         TreeRoot, ParentChild, CrossLink, External, Forest, Kerberos, Unknown
     }
 
-    private String         _fqn;
-    private TrustDirection _trustDirection = TrustDirection.Bidirectional;
-    private TrustType      _trustType      = TrustType.Unknown;
+    private String         fqn;
+    private TrustDirection trustDirection = TrustDirection.Bidirectional;
+    private TrustType      trustType      = TrustType.Unknown;
 
     @Override
     public String getFqn() {
-        return _fqn;
+        return this.fqn;
     }
 
     @Override
     public String getTrustDirectionString() {
-        return _trustDirection.toString();
+        return this.trustDirection.toString();
     }
 
     @Override
     public String getTrustTypeString() {
-        return _trustType.toString();
+        return this.trustType.toString();
     }
 
     public WindowsDomainImpl(String fqn) {
-        _fqn = fqn;
+        this.fqn = fqn;
     }
 
     public WindowsDomainImpl(DomainTrust trust) {
         // fqn
-        _fqn = trust.DnsDomainName;
-        if (_fqn == null || _fqn.length() == 0) {
-            _fqn = trust.NetbiosDomainName;
+        this.fqn = trust.DnsDomainName;
+        if (this.fqn == null || this.fqn.length() == 0) {
+            this.fqn = trust.NetbiosDomainName;
         }
         // trust direction
         if (trust.isInbound() && trust.isOutbound()) {
-            _trustDirection = TrustDirection.Bidirectional;
+            this.trustDirection = TrustDirection.Bidirectional;
         } else if (trust.isOutbound()) {
-            _trustDirection = TrustDirection.Outbound;
+            this.trustDirection = TrustDirection.Outbound;
         } else if (trust.isInbound()) {
-            _trustDirection = TrustDirection.Inbound;
+            this.trustDirection = TrustDirection.Inbound;
         }
         // trust type
         if (trust.isInForest()) {
-            _trustType = TrustType.Forest;
+            this.trustType = TrustType.Forest;
         } else if (trust.isRoot()) {
-            _trustType = TrustType.TreeRoot;
+            this.trustType = TrustType.TreeRoot;
         }
     }
 }

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsIdentityImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsIdentityImpl.java
@@ -33,22 +33,22 @@ import com.sun.jna.platform.win32.WinNT.WELL_KNOWN_SID_TYPE;
  */
 public class WindowsIdentityImpl implements IWindowsIdentity {
 
-    private HANDLE    _windowsIdentity;
-    private Account[] _userGroups;
-    private Account   _windowsAccount;
+    private HANDLE    windowsIdentity;
+    private Account[] userGroups;
+    private Account   windowsAccount;
 
     private Account getWindowsAccount() {
-        if (_windowsAccount == null) {
-            _windowsAccount = Advapi32Util.getTokenAccount(_windowsIdentity);
+        if (this.windowsAccount == null) {
+            this.windowsAccount = Advapi32Util.getTokenAccount(this.windowsIdentity);
         }
-        return _windowsAccount;
+        return this.windowsAccount;
     }
 
     private Account[] getUserGroups() {
-        if (_userGroups == null) {
-            _userGroups = Advapi32Util.getTokenGroups(_windowsIdentity);
+        if (this.userGroups == null) {
+            this.userGroups = Advapi32Util.getTokenGroups(this.windowsIdentity);
         }
-        return _userGroups.clone();
+        return this.userGroups.clone();
     }
 
     @Override
@@ -82,18 +82,18 @@ public class WindowsIdentityImpl implements IWindowsIdentity {
 
     @Override
     public void dispose() {
-        if (_windowsIdentity != null) {
-            Kernel32.INSTANCE.CloseHandle(_windowsIdentity);
+        if (this.windowsIdentity != null) {
+            Kernel32.INSTANCE.CloseHandle(this.windowsIdentity);
         }
     }
 
     @Override
     public IWindowsImpersonationContext impersonate() {
-        return new WindowsIdentityImpersonationContextImpl(_windowsIdentity);
+        return new WindowsIdentityImpersonationContextImpl(this.windowsIdentity);
     }
 
     public WindowsIdentityImpl(HANDLE windowsIdentity) {
-        _windowsIdentity = windowsIdentity;
+        this.windowsIdentity = windowsIdentity;
     }
 
     @Override

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsSecurityContextImpersonationContextImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsSecurityContextImpersonationContextImpl.java
@@ -25,7 +25,7 @@ import waffle.windows.auth.IWindowsImpersonationContext;
  */
 public class WindowsSecurityContextImpersonationContextImpl implements IWindowsImpersonationContext {
 
-    private CtxtHandle _ctx;
+    private CtxtHandle ctx;
 
     public WindowsSecurityContextImpersonationContextImpl(CtxtHandle ctx) {
         int rc = Secur32.INSTANCE.ImpersonateSecurityContext(ctx);
@@ -33,12 +33,12 @@ public class WindowsSecurityContextImpersonationContextImpl implements IWindowsI
             throw new Win32Exception(rc);
         }
 
-        _ctx = ctx;
+        this.ctx = ctx;
     }
 
     @Override
     public void revertToSelf() {
-        int rc = Secur32.INSTANCE.RevertSecurityContext(_ctx);
+        int rc = Secur32.INSTANCE.RevertSecurityContext(this.ctx);
         if (rc != WinError.SEC_E_OK) {
             throw new Win32Exception(rc);
         }

--- a/Source/JNA/waffle-jna/src/test/java/waffle/jaas/RolePrincipalTests.java
+++ b/Source/JNA/waffle-jna/src/test/java/waffle/jaas/RolePrincipalTests.java
@@ -31,11 +31,11 @@ import org.junit.Test;
  */
 public class RolePrincipalTests {
 
-    private RolePrincipal _rolePrincipal;
+    private RolePrincipal rolePrincipal;
 
     @Before
     public void setUp() {
-        _rolePrincipal = new RolePrincipal("localhost\\Administrator");
+        this.rolePrincipal = new RolePrincipal("localhost\\Administrator");
     }
 
     @Test
@@ -43,7 +43,7 @@ public class RolePrincipalTests {
         // serialize
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(out);
-        oos.writeObject(_rolePrincipal);
+        oos.writeObject(this.rolePrincipal);
         oos.close();
         assertTrue(out.toByteArray().length > 0);
         // deserialize
@@ -52,7 +52,7 @@ public class RolePrincipalTests {
         Object o = ois.readObject();
         RolePrincipal copy = (RolePrincipal) o;
         // test
-        assertEquals(_rolePrincipal, copy);
-        assertEquals(_rolePrincipal.getName(), copy.getName());
+        assertEquals(this.rolePrincipal, copy);
+        assertEquals(this.rolePrincipal.getName(), copy.getName());
     }
 }

--- a/Source/JNA/waffle-jna/src/test/java/waffle/jaas/UserPrincipalTests.java
+++ b/Source/JNA/waffle-jna/src/test/java/waffle/jaas/UserPrincipalTests.java
@@ -31,11 +31,11 @@ import org.junit.Test;
  */
 public class UserPrincipalTests {
 
-    private UserPrincipal _userPrincipal;
+    private UserPrincipal userPrincipal;
 
     @Before
     public void setUp() {
-        _userPrincipal = new UserPrincipal("localhost\\Administrator");
+        this.userPrincipal = new UserPrincipal("localhost\\Administrator");
     }
 
     @Test
@@ -43,7 +43,7 @@ public class UserPrincipalTests {
         // serialize
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(out);
-        oos.writeObject(_userPrincipal);
+        oos.writeObject(this.userPrincipal);
         oos.close();
         assertTrue(out.toByteArray().length > 0);
         // deserialize
@@ -52,7 +52,7 @@ public class UserPrincipalTests {
         Object o = ois.readObject();
         UserPrincipal copy = (UserPrincipal) o;
         // test
-        assertEquals(_userPrincipal, copy);
-        assertEquals(_userPrincipal.getName(), copy.getName());
+        assertEquals(this.userPrincipal, copy);
+        assertEquals(this.userPrincipal.getName(), copy.getName());
     }
 }

--- a/Source/JNA/waffle-jna/src/test/java/waffle/util/Base64Tests.java
+++ b/Source/JNA/waffle-jna/src/test/java/waffle/util/Base64Tests.java
@@ -17,6 +17,8 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
+import com.google.common.io.BaseEncoding;
+
 /**
  * @author dblock[at]dblock[dot]org
  */
@@ -30,8 +32,8 @@ public class Base64Tests {
                 data[j] = j;
             }
 
-            String base64data = Base64.encode(data);
-            byte[] decodedData = Base64.decode(base64data);
+            String base64data = BaseEncoding.base64().encode(data);
+            byte[] decodedData = BaseEncoding.base64().decode(base64data);
 
             assertEquals(decodedData.length, data.length);
 
@@ -44,16 +46,16 @@ public class Base64Tests {
     @Test
     public void testBase64DecodeEncode() {
         String base64String = "YH8GBisGAQUFAqB1MHOgMDAuBgorBgEEAYI3AgIKBgkqhkiC9xIBAgIGCSqGSIb3EgECAgYKKwYBBAGCNwICHqI/BD1OVExNU1NQAAEAAACXsgjiCQAJADQAAAAMAAwAKAAAAAYBsB0AAAAPREJMT0NLLUdSRUVOV09SS0dST1VQ";
-        byte[] data = Base64.decode(base64String);
-        String encodedBase64String = Base64.encode(data);
+        byte[] data = BaseEncoding.base64().decode(base64String);
+        String encodedBase64String = BaseEncoding.base64().encode(data);
         assertEquals(encodedBase64String, base64String);
     }
 
     @Test
     public void testBase64DecodeEncode2() {
         String base64String = "oXcwdaADCgEBoloEWE5UTE1TU1AAAwAAAAAAAABYAAAAAAAAAFgAAAAAAAAAWAAAAAAAAABYAAAAAAAAAFgAAAAAAAAAWAAAABXCiOIGAbAdAAAAD0K5dZi6NldppxCrei9fHUGjEgQQAQAAAPUXp1AtIpqEAAAAAA==";
-        byte[] data = Base64.decode(base64String);
-        String encodedBase64String = Base64.encode(data);
+        byte[] data = BaseEncoding.base64().decode(base64String);
+        String encodedBase64String = BaseEncoding.base64().encode(data);
         assertEquals(encodedBase64String, base64String);
     }
 }


### PR DESCRIPTION
JNA package only -> Fully qualify with 'this'.  Remove remainder of
underscores from names.  Additional cleanup to make clear for local
variables that hid class instance variables.  Setters which is clear to
intent, just use 'value' rather than name that hides instance variable.

Added missing quote in waffle-mixed demo.
Found Base64 missed in prior switch to guava, switched it.
