### PR TITLE
More Quality Cleanup

### DIFF
--- a/Source/JNA/waffle-jetty/src/test/java/waffle/jetty/StartEmbeddedJettyValidateNTLMGroup.java
+++ b/Source/JNA/waffle-jetty/src/test/java/waffle/jetty/StartEmbeddedJettyValidateNTLMGroup.java
@@ -111,15 +111,14 @@ public class StartEmbeddedJettyValidateNTLMGroup {
             }
         }
 
-        private boolean isUserAuthorised(HttpServletRequest request, List<String> authorisedGroups) {
+        private boolean isUserAuthorised(HttpServletRequest request, List<String> authorizedGroups) {
             List<String> usersGroups = getUsersGroups(request);
 
-            boolean noOverlappingGroups = Collections.disjoint(authorisedGroups, usersGroups);
+            boolean noOverlappingGroups = Collections.disjoint(authorizedGroups, usersGroups);
             if (!noOverlappingGroups) {
                 return true;
-            } else {
-                return false;
             }
+            return false;
         }
 
         private List<String> getUsersGroups(HttpServletRequest request) {

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsAccountImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsAccountImpl.java
@@ -27,34 +27,6 @@ import com.sun.jna.platform.win32.Secur32.EXTENDED_NAME_FORMAT;
  */
 public class WindowsAccountImpl implements IWindowsAccount {
 
-    private Account account;
-
-    @Override
-    public String getFqn() {
-        return this.account.fqn;
-    }
-
-    @Override
-    public String getSidString() {
-        return this.account.sidString;
-    }
-
-    /**
-     * Account name.
-     */
-    @Override
-    public String getName() {
-        return this.account.name;
-    }
-
-    /**
-     * Account domain.
-     */
-    @Override
-    public String getDomain() {
-        return this.account.domain;
-    }
-
     /**
      * Get the SAM-compatible username of the currently logged-on user.
      * 
@@ -62,6 +34,18 @@ public class WindowsAccountImpl implements IWindowsAccount {
      */
     public static String getCurrentUsername() {
         return Secur32Util.getUserNameEx(EXTENDED_NAME_FORMAT.NameSamCompatible);
+    }
+
+    private Account account;
+
+    /**
+     * Windows Account.
+     * 
+     * @param account
+     *            Account.
+     */
+    public WindowsAccountImpl(Account account) {
+        this.account = account;
     }
 
     /**
@@ -87,12 +71,28 @@ public class WindowsAccountImpl implements IWindowsAccount {
     }
 
     /**
-     * Windows Account.
-     * 
-     * @param account
-     *            Account.
+     * Account domain.
      */
-    public WindowsAccountImpl(Account account) {
-        this.account = account;
+    @Override
+    public String getDomain() {
+        return this.account.domain;
+    }
+
+    @Override
+    public String getFqn() {
+        return this.account.fqn;
+    }
+
+    /**
+     * Account name.
+     */
+    @Override
+    public String getName() {
+        return this.account.name;
+    }
+
+    @Override
+    public String getSidString() {
+        return this.account.sidString;
     }
 }

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsDomainImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsDomainImpl.java
@@ -25,16 +25,16 @@ import com.sun.jna.platform.win32.Netapi32Util.DomainTrust;
 public class WindowsDomainImpl implements IWindowsDomain {
 
     private enum TrustDirection {
-        Inbound, Outbound, Bidirectional
+        INBOUND, OUTBOUND, BIDIRECTIONAL
     }
 
     private enum TrustType {
-        TreeRoot, ParentChild, CrossLink, External, Forest, Kerberos, Unknown
+        TREE_ROOT, PARENT_CHILD, CROSS_LINK, EXTERNAL, FOREST, KERBEROS, UNKNOWN
     }
 
     private String         fqn;
-    private TrustDirection trustDirection = TrustDirection.Bidirectional;
-    private TrustType      trustType      = TrustType.Unknown;
+    private TrustDirection trustDirection = TrustDirection.BIDIRECTIONAL;
+    private TrustType      trustType      = TrustType.UNKNOWN;
 
     @Override
     public String getFqn() {
@@ -63,17 +63,17 @@ public class WindowsDomainImpl implements IWindowsDomain {
         }
         // trust direction
         if (trust.isInbound() && trust.isOutbound()) {
-            this.trustDirection = TrustDirection.Bidirectional;
+            this.trustDirection = TrustDirection.BIDIRECTIONAL;
         } else if (trust.isOutbound()) {
-            this.trustDirection = TrustDirection.Outbound;
+            this.trustDirection = TrustDirection.OUTBOUND;
         } else if (trust.isInbound()) {
-            this.trustDirection = TrustDirection.Inbound;
+            this.trustDirection = TrustDirection.INBOUND;
         }
         // trust type
         if (trust.isInForest()) {
-            this.trustType = TrustType.Forest;
+            this.trustType = TrustType.FOREST;
         } else if (trust.isRoot()) {
-            this.trustType = TrustType.TreeRoot;
+            this.trustType = TrustType.TREE_ROOT;
         }
     }
 }

--- a/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/GroupMappingWaffleRealm.java
+++ b/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/GroupMappingWaffleRealm.java
@@ -34,10 +34,10 @@ public class GroupMappingWaffleRealm extends AbstractWaffleRealm {
      * Sets the translation from group names to role names. If not set, the map is empty, resulting in no users getting
      * roles.
      */
-    public void setGroupRolesMap(Map<String, String> groupRolesMap) {
+    public void setGroupRolesMap(Map<String, String> value) {
         this.groupRolesMap.clear();
-        if (groupRolesMap != null) {
-            this.groupRolesMap.putAll(groupRolesMap);
+        if (value != null) {
+            this.groupRolesMap.putAll(value);
         }
     }
 
@@ -53,7 +53,7 @@ public class GroupMappingWaffleRealm extends AbstractWaffleRealm {
     protected Collection<String> getRoleNamesForGroups(Collection<String> groupNames) {
         Set<String> roleNames = new HashSet<String>();
         for (String groupName : groupNames) {
-            String roleName = groupRolesMap.get(groupName);
+            String roleName = this.groupRolesMap.get(groupName);
             if (roleName != null) {
                 roleNames.add(roleName);
             }

--- a/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/WaffleFqnPrincipal.java
+++ b/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/WaffleFqnPrincipal.java
@@ -27,9 +27,9 @@ public class WaffleFqnPrincipal implements Serializable {
     private final Set<String> groupFqns        = new HashSet<String>();
 
     WaffleFqnPrincipal(IWindowsIdentity identity) {
-        fqn = identity.getFqn();
+        this.fqn = identity.getFqn();
         for (IWindowsAccount group : identity.getGroups()) {
-            groupFqns.add(group.getFqn());
+            this.groupFqns.add(group.getFqn());
         }
     }
 
@@ -37,27 +37,27 @@ public class WaffleFqnPrincipal implements Serializable {
      * Returns the fully qualified name of the user
      */
     public String getFqn() {
-        return fqn;
+        return this.fqn;
     }
 
     /**
      * Returns the fully qualified names of all groups that the use belongs to
      */
     public Set<String> getGroupFqns() {
-        return Collections.unmodifiableSet(groupFqns);
+        return Collections.unmodifiableSet(this.groupFqns);
     }
 
     @Override
     public boolean equals(Object obj) {
         if (obj instanceof WaffleFqnPrincipal) {
-            return fqn.equals(((WaffleFqnPrincipal) obj).fqn);
+            return this.fqn.equals(((WaffleFqnPrincipal) obj).fqn);
         }
         return false;
     }
 
     @Override
     public int hashCode() {
-        return fqn.hashCode();
+        return this.fqn.hashCode();
     }
 
     @Override
@@ -66,7 +66,7 @@ public class WaffleFqnPrincipal implements Serializable {
         stringBuilder.append("{");
         stringBuilder.append(getClass().getSimpleName());
         stringBuilder.append(":");
-        stringBuilder.append(fqn);
+        stringBuilder.append(this.fqn);
         stringBuilder.append("}");
         return stringBuilder.toString();
     }

--- a/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/dynamic/DynamicAuthenticationFilter.java
+++ b/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/dynamic/DynamicAuthenticationFilter.java
@@ -90,7 +90,7 @@ import javax.servlet.ServletResponse;
  */
 public class DynamicAuthenticationFilter extends FormAuthenticationFilter {
 
-    private static final Logger log                          = LoggerFactory
+    private static final Logger LOGGER                       = LoggerFactory
                                                                      .getLogger(DynamicAuthenticationFilter.class);
 
     public static final String  PARAM_NAME_AUTHTYPE          = "authType";
@@ -103,7 +103,7 @@ public class DynamicAuthenticationFilter extends FormAuthenticationFilter {
 
         private final DynamicAuthenticationFilter parent;
 
-        private WrapNegotiateAuthenticationFilter(final DynamicAuthenticationFilter parent) {
+        WrapNegotiateAuthenticationFilter(final DynamicAuthenticationFilter parent) {
             this.parent = parent;
         }
 
@@ -115,7 +115,7 @@ public class DynamicAuthenticationFilter extends FormAuthenticationFilter {
         @Override
         protected boolean onLoginSuccess(final AuthenticationToken token, final Subject subject,
                 final ServletRequest request, final ServletResponse response) throws Exception {
-            return parent.onLoginSuccess(token, subject, request, response);
+            return this.parent.onLoginSuccess(token, subject, request, response);
         }
     }
 
@@ -128,7 +128,7 @@ public class DynamicAuthenticationFilter extends FormAuthenticationFilter {
 
         private final DynamicAuthenticationFilter parent;
 
-        private WrapFormAuthenticationFilter(final DynamicAuthenticationFilter parent) {
+        WrapFormAuthenticationFilter(final DynamicAuthenticationFilter parent) {
             this.parent = parent;
         }
 
@@ -140,7 +140,7 @@ public class DynamicAuthenticationFilter extends FormAuthenticationFilter {
         @Override
         protected boolean onLoginSuccess(final AuthenticationToken token, final Subject subject,
                 final ServletRequest request, final ServletResponse response) throws Exception {
-            return parent.onLoginSuccess(token, subject, request, response);
+            return this.parent.onLoginSuccess(token, subject, request, response);
         }
     }
 
@@ -156,12 +156,11 @@ public class DynamicAuthenticationFilter extends FormAuthenticationFilter {
     @Override
     protected boolean executeLogin(final ServletRequest request, final ServletResponse response) throws Exception {
         if (isAuthTypeNegotiate(request)) {
-            log.debug("using filterNegotiate");
-            return filterNegotiate.onAccessDenied(request, response);
-        } else {
-            log.debug("using filterFormAuthc");
-            return filterFormAuthc.onAccessDenied(request, response);
+            LOGGER.debug("using filterNegotiate");
+            return this.filterNegotiate.onAccessDenied(request, response);
         }
+        LOGGER.debug("using filterFormAuthc");
+        return this.filterFormAuthc.onAccessDenied(request, response);
     }
 
     boolean isAuthTypeNegotiate(final ServletRequest request) {

--- a/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/negotiate/NegotiateAuthenticationRealm.java
+++ b/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/negotiate/NegotiateAuthenticationRealm.java
@@ -49,7 +49,7 @@ public class NegotiateAuthenticationRealm extends AuthenticatingRealm {
     private final IWindowsAuthProvider windowsAuthProvider;
 
     public NegotiateAuthenticationRealm() {
-        windowsAuthProvider = new WindowsAuthProviderImpl();
+        this.windowsAuthProvider = new WindowsAuthProviderImpl();
     }
 
     @Override
@@ -65,12 +65,12 @@ public class NegotiateAuthenticationRealm extends AuthenticatingRealm {
 
         if (token.isNtlmPost()) {
             // type 2 NTLM authentication message received
-            windowsAuthProvider.resetSecurityToken(token.getConnectionId());
+            this.windowsAuthProvider.resetSecurityToken(token.getConnectionId());
         }
 
         final IWindowsSecurityContext securityContext;
         try {
-            securityContext = windowsAuthProvider.acceptSecurityToken(token.getConnectionId(), inToken,
+            securityContext = this.windowsAuthProvider.acceptSecurityToken(token.getConnectionId(), inToken,
                     token.getSecurityPackage());
         } catch (Exception e) {
             log.warn("error logging in user: {}", e.getMessage());

--- a/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/negotiate/NegotiateInfo.java
+++ b/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/negotiate/NegotiateInfo.java
@@ -61,7 +61,7 @@ public class NegotiateInfo implements AuthenticationInfo {
      */
     @Override
     public PrincipalCollection getPrincipals() {
-        return new SimplePrincipalCollection(subject.getPrincipals(), realmName);
+        return new SimplePrincipalCollection(this.subject.getPrincipals(), this.realmName);
     }
 
     /**
@@ -71,6 +71,6 @@ public class NegotiateInfo implements AuthenticationInfo {
      */
     @Override
     public Object getCredentials() {
-        return subject;
+        return this.subject;
     }
 }

--- a/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/negotiate/NegotiateToken.java
+++ b/Source/JNA/waffle-shiro/src/main/java/waffle/shiro/negotiate/NegotiateToken.java
@@ -71,53 +71,53 @@ public class NegotiateToken implements HostAuthenticationToken, RememberMeAuthen
     }
 
     public String getConnectionId() {
-        return connectionId;
+        return this.connectionId;
     }
 
     public String getSecurityPackage() {
-        return securityPackage;
+        return this.securityPackage;
     }
 
     public boolean isNtlmPost() {
-        return ntlmPost;
+        return this.ntlmPost;
     }
 
     @Override
     public Object getCredentials() {
-        return subject;
+        return this.subject;
     }
 
     @Override
     public Object getPrincipal() {
-        return principal;
+        return this.principal;
     }
 
     byte[] getOut() {
-        return out;
+        return this.out;
     }
 
     public void setOut(final byte[] outToken) {
         this.out = (outToken != null ? outToken.clone() : null);
     }
 
-    public void setSubject(final Subject subject) {
-        this.subject = subject;
+    public void setSubject(final Subject value) {
+        this.subject = value;
     }
 
     public byte[] getIn() {
-        return in.clone();
+        return this.in.clone();
     }
 
     public Subject getSubject() {
-        return subject;
+        return this.subject;
     }
 
     public AuthenticationInfo createInfo() {
-        return new NegotiateInfo(subject, "NegotiateWaffleRealm");
+        return new NegotiateInfo(this.subject, "NegotiateWaffleRealm");
     }
 
-    public void setPrincipal(final Object principal) {
-        this.principal = principal;
+    public void setPrincipal(final Object value) {
+        this.principal = value;
     }
 
     /**
@@ -130,7 +130,7 @@ public class NegotiateToken implements HostAuthenticationToken, RememberMeAuthen
      */
     @Override
     public boolean isRememberMe() {
-        return rememberMe;
+        return this.rememberMe;
     }
 
     /**
@@ -148,6 +148,6 @@ public class NegotiateToken implements HostAuthenticationToken, RememberMeAuthen
      */
     @Override
     public String getHost() {
-        return host;
+        return this.host;
     }
 }

--- a/Source/JNA/waffle-shiro/src/test/java/waffle/shiro/GroupMappingWaffleRealmTests.java
+++ b/Source/JNA/waffle-shiro/src/test/java/waffle/shiro/GroupMappingWaffleRealmTests.java
@@ -42,16 +42,16 @@ public class GroupMappingWaffleRealmTests {
 
     @Before
     public void setUp() {
-        windowsAuthProvider = new MockWindowsAuthProvider();
-        realm = new GroupMappingWaffleRealm();
-        realm.setProvider(windowsAuthProvider);
-        realm.setGroupRolesMap(Collections.singletonMap("Users", ROLE_NAME));
+        this.windowsAuthProvider = new MockWindowsAuthProvider();
+        this.realm = new GroupMappingWaffleRealm();
+        this.realm.setProvider(this.windowsAuthProvider);
+        this.realm.setGroupRolesMap(Collections.singletonMap("Users", ROLE_NAME));
     }
 
     @Test
     public void testValidUsernamePassword() {
         AuthenticationToken token = new UsernamePasswordToken(getCurrentUserName(), "somePassword");
-        AuthenticationInfo authcInfo = realm.getAuthenticationInfo(token);
+        AuthenticationInfo authcInfo = this.realm.getAuthenticationInfo(token);
         PrincipalCollection principals = authcInfo.getPrincipals();
         assertFalse(principals.isEmpty());
         Object primaryPrincipal = principals.getPrimaryPrincipal();
@@ -62,19 +62,19 @@ public class GroupMappingWaffleRealmTests {
         Object credentials = authcInfo.getCredentials();
         assertThat(credentials, instanceOf(char[].class));
         assertThat((char[]) credentials, equalTo("somePassword".toCharArray()));
-        assertTrue(realm.hasRole(principals, ROLE_NAME));
+        assertTrue(this.realm.hasRole(principals, ROLE_NAME));
     }
 
     @Test(expected = AuthenticationException.class)
     public void testInvalidUsernamePassword() {
         AuthenticationToken token = new UsernamePasswordToken("InvalidUser", "somePassword");
-        realm.getAuthenticationInfo(token);
+        this.realm.getAuthenticationInfo(token);
     }
 
     @Test(expected = AuthenticationException.class)
     public void testGuestUsernamePassword() {
         AuthenticationToken token = new UsernamePasswordToken("Guest", "somePassword");
-        realm.getAuthenticationInfo(token);
+        this.realm.getAuthenticationInfo(token);
     }
 
     private String getCurrentUserName() {

--- a/Source/JNA/waffle-shiro/src/test/java/waffle/shiro/dynamic/DynamicAuthenticationFilterTest.java
+++ b/Source/JNA/waffle-shiro/src/test/java/waffle/shiro/dynamic/DynamicAuthenticationFilterTest.java
@@ -40,21 +40,21 @@ public class DynamicAuthenticationFilterTest {
 
     @Before
     public void setUp() {
-        dynamicAuthenticationFilter = new DynamicAuthenticationFilter();
+        this.dynamicAuthenticationFilter = new DynamicAuthenticationFilter();
 
-        request = new MockServletRequest();
+        this.request = new MockServletRequest();
     }
 
     @Test
     public void testIsAuthTypeNegotiate() {
-        Assert.assertFalse(dynamicAuthenticationFilter.isAuthTypeNegotiate(request));
+        Assert.assertFalse(this.dynamicAuthenticationFilter.isAuthTypeNegotiate(this.request));
 
-        request.parameters.put(DynamicAuthenticationFilter.PARAM_NAME_AUTHTYPE, "zzz");
-        Assert.assertFalse(dynamicAuthenticationFilter.isAuthTypeNegotiate(request));
+        this.request.parameters.put(DynamicAuthenticationFilter.PARAM_NAME_AUTHTYPE, "zzz");
+        Assert.assertFalse(this.dynamicAuthenticationFilter.isAuthTypeNegotiate(this.request));
 
-        request.parameters.put(DynamicAuthenticationFilter.PARAM_NAME_AUTHTYPE,
+        this.request.parameters.put(DynamicAuthenticationFilter.PARAM_NAME_AUTHTYPE,
                 DynamicAuthenticationFilter.PARAM_VAL_AUTHTYPE_NEGOTIATE);
-        Assert.assertTrue(dynamicAuthenticationFilter.isAuthTypeNegotiate(request));
+        Assert.assertTrue(this.dynamicAuthenticationFilter.isAuthTypeNegotiate(this.request));
     }
 
     private static class MockServletRequest implements ServletRequest {
@@ -107,7 +107,7 @@ public class DynamicAuthenticationFilterTest {
 
         @Override
         public String getParameter(String name) {
-            return parameters.get(name);
+            return this.parameters.get(name);
         }
 
         @Override
@@ -204,6 +204,7 @@ public class DynamicAuthenticationFilterTest {
             return null;
         }
 
+        @Deprecated
         @Override
         public String getRealPath(String path) {
             notImplemented();

--- a/Source/JNA/waffle-shiro/src/test/java/waffle/shiro/negotiate/NegotiateAuthenticationFilterTest.java
+++ b/Source/JNA/waffle-shiro/src/test/java/waffle/shiro/negotiate/NegotiateAuthenticationFilterTest.java
@@ -43,35 +43,35 @@ public final class NegotiateAuthenticationFilterTest {
 
     @Before
     public void setUp() {
-        negAuthFilter = new NegotiateAuthenticationFilter();
+        this.negAuthFilter = new NegotiateAuthenticationFilter();
 
-        response = new MockServletResponse();
+        this.response = new MockServletResponse();
     }
 
     @Test
     public void testIsLoginAttempt() {
-        Assert.assertFalse(negAuthFilter.isLoginAttempt(""));
-        Assert.assertTrue(negAuthFilter.isLoginAttempt("NEGOTIATe"));
-        Assert.assertTrue(negAuthFilter.isLoginAttempt("ntlm"));
+        Assert.assertFalse(this.negAuthFilter.isLoginAttempt(""));
+        Assert.assertTrue(this.negAuthFilter.isLoginAttempt("NEGOTIATe"));
+        Assert.assertTrue(this.negAuthFilter.isLoginAttempt("ntlm"));
     }
 
     @Test
     public void testSendChallengeInitiateNegotiate() {
 
-        out = new byte[1];
-        out[0] = -1;
+        this.out = new byte[1];
+        this.out[0] = -1;
 
-        negAuthFilter.sendChallengeInitiateNegotiate(response);
+        this.negAuthFilter.sendChallengeInitiateNegotiate(this.response);
 
-        Assert.assertEquals("Negotiate", response.headersAdded.get("WWW-Authenticate").get(0));
-        Assert.assertEquals("NTLM", response.headersAdded.get("WWW-Authenticate").get(1));
+        Assert.assertEquals("Negotiate", this.response.headersAdded.get("WWW-Authenticate").get(0));
+        Assert.assertEquals("NTLM", this.response.headersAdded.get("WWW-Authenticate").get(1));
 
-        Assert.assertEquals("keep-alive", response.headers.get("Connection"));
+        Assert.assertEquals("keep-alive", this.response.headers.get("Connection"));
 
-        Assert.assertEquals(HttpServletResponse.SC_UNAUTHORIZED, response.sc);
-        Assert.assertEquals(0, response.errorCode);
+        Assert.assertEquals(HttpServletResponse.SC_UNAUTHORIZED, this.response.sc);
+        Assert.assertEquals(0, this.response.errorCode);
 
-        Assert.assertFalse(response.isFlushed);
+        Assert.assertFalse(this.response.isFlushed);
     }
 
     @Test
@@ -79,36 +79,36 @@ public final class NegotiateAuthenticationFilterTest {
 
         final String myProtocol = "myProtocol";
 
-        out = new byte[1];
-        out[0] = -1;
+        this.out = new byte[1];
+        this.out[0] = -1;
 
-        negAuthFilter.sendChallengeDuringNegotiate(myProtocol, response, out);
+        this.negAuthFilter.sendChallengeDuringNegotiate(myProtocol, this.response, this.out);
 
-        Assert.assertEquals(myProtocol + " " + BaseEncoding.base64().encode(out),
-                response.headers.get("WWW-Authenticate"));
+        Assert.assertEquals(myProtocol + " " + BaseEncoding.base64().encode(this.out),
+                this.response.headers.get("WWW-Authenticate"));
 
-        Assert.assertEquals("keep-alive", response.headers.get("Connection"));
+        Assert.assertEquals("keep-alive", this.response.headers.get("Connection"));
 
-        Assert.assertEquals(HttpServletResponse.SC_UNAUTHORIZED, response.sc);
-        Assert.assertEquals(0, response.errorCode);
+        Assert.assertEquals(HttpServletResponse.SC_UNAUTHORIZED, this.response.sc);
+        Assert.assertEquals(0, this.response.errorCode);
 
-        Assert.assertFalse(response.isFlushed);
+        Assert.assertFalse(this.response.isFlushed);
     }
 
     @Test
     public void testSendChallengeOnFailure() {
 
-        negAuthFilter.sendChallengeOnFailure(response);
+        this.negAuthFilter.sendChallengeOnFailure(this.response);
 
-        Assert.assertEquals("Negotiate", response.headersAdded.get("WWW-Authenticate").get(0));
-        Assert.assertEquals("NTLM", response.headersAdded.get("WWW-Authenticate").get(1));
+        Assert.assertEquals("Negotiate", this.response.headersAdded.get("WWW-Authenticate").get(0));
+        Assert.assertEquals("NTLM", this.response.headersAdded.get("WWW-Authenticate").get(1));
 
-        Assert.assertEquals("close", response.headers.get("Connection"));
+        Assert.assertEquals("close", this.response.headers.get("Connection"));
 
-        Assert.assertEquals(0, response.sc);
-        Assert.assertEquals(HttpServletResponse.SC_UNAUTHORIZED, response.errorCode);
+        Assert.assertEquals(0, this.response.sc);
+        Assert.assertEquals(HttpServletResponse.SC_UNAUTHORIZED, this.response.errorCode);
 
-        Assert.assertTrue(response.isFlushed);
+        Assert.assertTrue(this.response.isFlushed);
     }
 
     private static class MockServletResponse implements HttpServletResponse {
@@ -170,7 +170,7 @@ public final class NegotiateAuthenticationFilterTest {
 
         @Override
         public void flushBuffer() throws IOException {
-            isFlushed = true;
+            this.isFlushed = true;
         }
 
         @Override
@@ -244,7 +244,7 @@ public final class NegotiateAuthenticationFilterTest {
 
         @Override
         public void sendError(int sc) throws IOException {
-            errorCode = sc;
+            this.errorCode = sc;
         }
 
         @Override
@@ -266,21 +266,21 @@ public final class NegotiateAuthenticationFilterTest {
 
         @Override
         public void setHeader(String name, String value) {
-            headers.put(name, value);
+            this.headers.put(name, value);
         }
 
         final Map<String, List<String>> headersAdded = new HashMap<String, List<String>>();
 
         @Override
         public void addHeader(String name, String value) {
-            if (headersAdded.containsKey(name)) {
-                headersAdded.get(name).add(value);
+            if (this.headersAdded.containsKey(name)) {
+                this.headersAdded.get(name).add(value);
                 return;
             }
 
             List<String> values = new ArrayList<String>();
             values.add(value);
-            headersAdded.put(name, values);
+            this.headersAdded.put(name, values);
         }
 
         @Override

--- a/Source/JNA/waffle-shiro/src/test/java/waffle/shiro/negotiate/NegotiateAuthenticationRealmTest.java
+++ b/Source/JNA/waffle-shiro/src/test/java/waffle/shiro/negotiate/NegotiateAuthenticationRealmTest.java
@@ -25,24 +25,25 @@ public final class NegotiateAuthenticationRealmTest extends TestCase {
 
     @Override
     protected void setUp() throws Exception {
-        negAuthRealm = new NegotiateAuthenticationRealm();
+        this.negAuthRealm = new NegotiateAuthenticationRealm();
     }
 
     public void testSupports() {
-        assertFalse("Non-NegotiateToken should not be supported.", negAuthRealm.supports(new AuthenticationToken() {
-            private static final long serialVersionUID = 334672725950031145L;
+        assertFalse("Non-NegotiateToken should not be supported.",
+                this.negAuthRealm.supports(new AuthenticationToken() {
+                    private static final long serialVersionUID = 334672725950031145L;
 
-            @Override
-            public Object getPrincipal() {
-                return null;
-            }
+                    @Override
+                    public Object getPrincipal() {
+                        return null;
+                    }
 
-            @Override
-            public Object getCredentials() {
-                return null;
-            }
-        }));
+                    @Override
+                    public Object getCredentials() {
+                        return null;
+                    }
+                }));
 
-        assertTrue(negAuthRealm.supports(new NegotiateToken(null, null, null, null, false, false, null)));
+        assertTrue(this.negAuthRealm.supports(new NegotiateToken(null, null, null, null, false, false, null)));
     }
 }

--- a/Source/JNA/waffle-shiro/src/test/java/waffle/shiro/negotiate/NegotiateAuthenticationStrategyTest.java
+++ b/Source/JNA/waffle-shiro/src/test/java/waffle/shiro/negotiate/NegotiateAuthenticationStrategyTest.java
@@ -28,7 +28,7 @@ public class NegotiateAuthenticationStrategyTest {
 
     @Before
     public void setUp() {
-        authStrategy = new NegotiateAuthenticationStrategy();
+        this.authStrategy = new NegotiateAuthenticationStrategy();
     }
 
     @Test(expected = AuthenticationInProgressException.class)
@@ -36,13 +36,13 @@ public class NegotiateAuthenticationStrategyTest {
 
         final Realm otherRealm = new IniRealm();
 
-        authStrategy.afterAttempt(otherRealm, null, null, null, new RuntimeException());
+        this.authStrategy.afterAttempt(otherRealm, null, null, null, new RuntimeException());
 
         final AuthenticationInProgressException authInProgressException = new AuthenticationInProgressException();
 
-        authStrategy.afterAttempt(otherRealm, null, null, null, authInProgressException);
+        this.authStrategy.afterAttempt(otherRealm, null, null, null, authInProgressException);
 
-        authStrategy.afterAttempt(new NegotiateAuthenticationRealm(), null, null, null, authInProgressException);
+        this.authStrategy.afterAttempt(new NegotiateAuthenticationRealm(), null, null, null, authInProgressException);
         Assert.fail();
     }
 }

--- a/Source/JNA/waffle-spring-security2/src/main/java/waffle/spring/FqnGrantedAuthorityFactory.java
+++ b/Source/JNA/waffle-spring-security2/src/main/java/waffle/spring/FqnGrantedAuthorityFactory.java
@@ -28,12 +28,12 @@ import waffle.windows.auth.WindowsAccount;
  */
 public class FqnGrantedAuthorityFactory implements GrantedAuthorityFactory {
 
-    private final String  _prefix;
-    private final boolean _convertToUpperCase;
+    private final String  prefix;
+    private final boolean convertToUpperCase;
 
     public FqnGrantedAuthorityFactory(String prefix, boolean convertToUpperCase) {
-        _prefix = prefix;
-        _convertToUpperCase = convertToUpperCase;
+        this.prefix = prefix;
+        this.convertToUpperCase = convertToUpperCase;
     }
 
     @Override
@@ -41,11 +41,11 @@ public class FqnGrantedAuthorityFactory implements GrantedAuthorityFactory {
 
         String grantedAuthorityString = windowsAccount.getFqn();
 
-        if (_prefix != null) {
-            grantedAuthorityString = _prefix + grantedAuthorityString;
+        if (this.prefix != null) {
+            grantedAuthorityString = this.prefix + grantedAuthorityString;
         }
 
-        if (_convertToUpperCase) {
+        if (this.convertToUpperCase) {
             grantedAuthorityString = grantedAuthorityString.toUpperCase();
         }
 

--- a/Source/JNA/waffle-spring-security2/src/main/java/waffle/spring/NegotiateSecurityFilterEntryPoint.java
+++ b/Source/JNA/waffle-spring-security2/src/main/java/waffle/spring/NegotiateSecurityFilterEntryPoint.java
@@ -34,12 +34,12 @@ import waffle.servlet.spi.SecurityFilterProviderCollection;
  */
 public class NegotiateSecurityFilterEntryPoint implements AuthenticationEntryPoint {
 
-    private static final Logger              _log      = LoggerFactory
-                                                               .getLogger(NegotiateSecurityFilterEntryPoint.class);
-    private SecurityFilterProviderCollection _provider = null;
+    private static final Logger              LOGGER   = LoggerFactory
+                                                              .getLogger(NegotiateSecurityFilterEntryPoint.class);
+    private SecurityFilterProviderCollection provider = null;
 
     public NegotiateSecurityFilterEntryPoint() {
-        _log.debug("[waffle.spring.NegotiateEntryPoint] loaded");
+        LOGGER.debug("[waffle.spring.NegotiateEntryPoint] loaded");
     }
 
     @Override
@@ -48,23 +48,23 @@ public class NegotiateSecurityFilterEntryPoint implements AuthenticationEntryPoi
 
         HttpServletResponse response = (HttpServletResponse) srep;
 
-        _log.debug("[waffle.spring.NegotiateEntryPoint] commence");
+        LOGGER.debug("[waffle.spring.NegotiateEntryPoint] commence");
 
-        if (_provider == null) {
+        if (this.provider == null) {
             throw new ServletException("Missing NegotiateEntryPoint.Provider");
         }
 
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setHeader("Connection", "keep-alive");
-        _provider.sendUnauthorized(response);
+        this.provider.sendUnauthorized(response);
         response.flushBuffer();
     }
 
     public SecurityFilterProviderCollection getProvider() {
-        return _provider;
+        return this.provider;
     }
 
     public void setProvider(SecurityFilterProviderCollection provider) {
-        _provider = provider;
+        this.provider = provider;
     }
 }

--- a/Source/JNA/waffle-spring-security2/src/main/java/waffle/spring/WindowsAuthenticationProvider.java
+++ b/Source/JNA/waffle-spring-security2/src/main/java/waffle/spring/WindowsAuthenticationProvider.java
@@ -34,37 +34,38 @@ import waffle.windows.auth.PrincipalFormat;
  */
 public class WindowsAuthenticationProvider implements AuthenticationProvider {
 
-    private static final Logger     _log                     = LoggerFactory
-                                                                     .getLogger(WindowsAuthenticationProvider.class);
-    private PrincipalFormat         _principalFormat         = PrincipalFormat.fqn;
-    private PrincipalFormat         _roleFormat              = PrincipalFormat.fqn;
-    private boolean                 _allowGuestLogin         = true;
-    private IWindowsAuthProvider    _authProvider;
-    private GrantedAuthorityFactory _grantedAuthorityFactory = WindowsAuthenticationToken.DEFAULT_GRANTED_AUTHORITY_FACTORY;
-    private GrantedAuthority        _defaultGrantedAuthority = WindowsAuthenticationToken.DEFAULT_GRANTED_AUTHORITY;
+    private static final Logger     LOGGER                  = LoggerFactory
+                                                                    .getLogger(WindowsAuthenticationProvider.class);
+    private PrincipalFormat         principalFormat         = PrincipalFormat.fqn;
+    private PrincipalFormat         roleFormat              = PrincipalFormat.fqn;
+    private boolean                 allowGuestLogin         = true;
+    private IWindowsAuthProvider    authProvider;
+    private GrantedAuthorityFactory grantedAuthorityFactory = WindowsAuthenticationToken.DEFAULT_GRANTED_AUTHORITY_FACTORY;
+    private GrantedAuthority        defaultGrantedAuthority = WindowsAuthenticationToken.DEFAULT_GRANTED_AUTHORITY;
 
     public WindowsAuthenticationProvider() {
-        _log.debug("[waffle.spring.WindowsAuthenticationProvider] loaded");
+        LOGGER.debug("[waffle.spring.WindowsAuthenticationProvider] loaded");
     }
 
     @Override
     public Authentication authenticate(Authentication authentication) {
         UsernamePasswordAuthenticationToken auth = (UsernamePasswordAuthenticationToken) authentication;
-        IWindowsIdentity windowsIdentity = _authProvider.logonUser(auth.getName(), auth.getCredentials().toString());
-        _log.debug("logged in user: {} ({})", windowsIdentity.getFqn(), windowsIdentity.getSidString());
+        IWindowsIdentity windowsIdentity = this.authProvider
+                .logonUser(auth.getName(), auth.getCredentials().toString());
+        LOGGER.debug("logged in user: {} ({})", windowsIdentity.getFqn(), windowsIdentity.getSidString());
 
-        if (!_allowGuestLogin && windowsIdentity.isGuest()) {
-            _log.warn("guest login disabled: {}", windowsIdentity.getFqn());
+        if (!this.allowGuestLogin && windowsIdentity.isGuest()) {
+            LOGGER.warn("guest login disabled: {}", windowsIdentity.getFqn());
             throw new GuestLoginDisabledAuthenticationException(windowsIdentity.getFqn());
         }
 
-        WindowsPrincipal windowsPrincipal = new WindowsPrincipal(windowsIdentity, _principalFormat, _roleFormat);
-        _log.debug("roles: {}", windowsPrincipal.getRolesString());
+        WindowsPrincipal windowsPrincipal = new WindowsPrincipal(windowsIdentity, this.principalFormat, this.roleFormat);
+        LOGGER.debug("roles: {}", windowsPrincipal.getRolesString());
 
-        WindowsAuthenticationToken token = new WindowsAuthenticationToken(windowsPrincipal, _grantedAuthorityFactory,
-                _defaultGrantedAuthority);
+        WindowsAuthenticationToken token = new WindowsAuthenticationToken(windowsPrincipal,
+                this.grantedAuthorityFactory, this.defaultGrantedAuthority);
 
-        _log.info("successfully logged in user: {}", windowsIdentity.getFqn());
+        LOGGER.info("successfully logged in user: {}", windowsIdentity.getFqn());
         return token;
     }
 
@@ -76,50 +77,50 @@ public class WindowsAuthenticationProvider implements AuthenticationProvider {
     }
 
     public PrincipalFormat getPrincipalFormat() {
-        return _principalFormat;
+        return this.principalFormat;
     }
 
-    public void setPrincipalFormat(PrincipalFormat principalFormat) {
-        _principalFormat = principalFormat;
+    public void setPrincipalFormat(PrincipalFormat value) {
+        this.principalFormat = value;
     }
 
     public PrincipalFormat getRoleFormat() {
-        return _roleFormat;
+        return this.roleFormat;
     }
 
-    public void setRoleFormat(PrincipalFormat principalFormat) {
-        _roleFormat = principalFormat;
+    public void setRoleFormat(PrincipalFormat value) {
+        this.roleFormat = value;
     }
 
     public boolean isAllowGuestLogin() {
-        return _allowGuestLogin;
+        return this.allowGuestLogin;
     }
 
-    public void setAllowGuestLogin(boolean allowGuestLogin) {
-        _allowGuestLogin = allowGuestLogin;
+    public void setAllowGuestLogin(boolean value) {
+        this.allowGuestLogin = value;
     }
 
     public IWindowsAuthProvider getAuthProvider() {
-        return _authProvider;
+        return this.authProvider;
     }
 
-    public void setAuthProvider(IWindowsAuthProvider authProvider) {
-        _authProvider = authProvider;
+    public void setAuthProvider(IWindowsAuthProvider value) {
+        this.authProvider = value;
     }
 
     public GrantedAuthorityFactory getGrantedAuthorityFactory() {
-        return _grantedAuthorityFactory;
+        return this.grantedAuthorityFactory;
     }
 
-    public void setGrantedAuthorityFactory(GrantedAuthorityFactory grantedAuthorityFactory) {
-        _grantedAuthorityFactory = grantedAuthorityFactory;
+    public void setGrantedAuthorityFactory(GrantedAuthorityFactory value) {
+        this.grantedAuthorityFactory = value;
     }
 
     public GrantedAuthority getDefaultGrantedAuthority() {
-        return _defaultGrantedAuthority;
+        return this.defaultGrantedAuthority;
     }
 
-    public void setDefaultGrantedAuthority(GrantedAuthority defaultGrantedAuthority) {
-        _defaultGrantedAuthority = defaultGrantedAuthority;
+    public void setDefaultGrantedAuthority(GrantedAuthority value) {
+        this.defaultGrantedAuthority = value;
     }
 }

--- a/Source/JNA/waffle-spring-security2/src/main/java/waffle/spring/WindowsAuthenticationToken.java
+++ b/Source/JNA/waffle-spring-security2/src/main/java/waffle/spring/WindowsAuthenticationToken.java
@@ -46,8 +46,8 @@ public class WindowsAuthenticationToken implements Authentication {
                                                                                           "ROLE_USER");
 
     private static final long                   serialVersionUID                  = 1L;
-    private WindowsPrincipal                    _principal;
-    private Collection<GrantedAuthority>        _authorities;
+    private WindowsPrincipal                    principal;
+    private Collection<GrantedAuthority>        authorities;
 
     /**
      * Convenience constructor that calls
@@ -74,20 +74,20 @@ public class WindowsAuthenticationToken implements Authentication {
     public WindowsAuthenticationToken(WindowsPrincipal identity, GrantedAuthorityFactory grantedAuthorityFactory,
             GrantedAuthority defaultGrantedAuthority) {
 
-        _principal = identity;
-        _authorities = new ArrayList<GrantedAuthority>();
+        this.principal = identity;
+        this.authorities = new ArrayList<GrantedAuthority>();
         if (defaultGrantedAuthority != null) {
-            _authorities.add(defaultGrantedAuthority);
+            this.authorities.add(defaultGrantedAuthority);
         }
-        for (WindowsAccount group : _principal.getGroups().values()) {
-            _authorities.add(grantedAuthorityFactory.createGrantedAuthority(group));
+        for (WindowsAccount group : this.principal.getGroups().values()) {
+            this.authorities.add(grantedAuthorityFactory.createGrantedAuthority(group));
         }
     }
 
     @Override
     public GrantedAuthority[] getAuthorities() {
-        GrantedAuthority[] grantedAuthorities = new GrantedAuthority[_authorities.size()];
-        _authorities.toArray(grantedAuthorities);
+        GrantedAuthority[] grantedAuthorities = new GrantedAuthority[this.authorities.size()];
+        this.authorities.toArray(grantedAuthorities);
         return grantedAuthorities;
     }
 
@@ -103,12 +103,12 @@ public class WindowsAuthenticationToken implements Authentication {
 
     @Override
     public Object getPrincipal() {
-        return _principal;
+        return this.principal;
     }
 
     @Override
     public boolean isAuthenticated() {
-        return _principal != null;
+        return this.principal != null;
     }
 
     @Override
@@ -118,6 +118,6 @@ public class WindowsAuthenticationToken implements Authentication {
 
     @Override
     public String getName() {
-        return _principal.getName();
+        return this.principal.getName();
     }
 }

--- a/Source/JNA/waffle-spring-security2/src/test/java/waffle/spring/FqnGrantedAuthorityFactoryTests.java
+++ b/Source/JNA/waffle-spring-security2/src/test/java/waffle/spring/FqnGrantedAuthorityFactoryTests.java
@@ -24,35 +24,35 @@ import waffle.windows.auth.WindowsAccount;
 
 public class FqnGrantedAuthorityFactoryTests {
 
-    private WindowsAccount _group;
+    private WindowsAccount group;
 
     @Before
     public void setUp() {
-        _group = new WindowsAccount(new MockWindowsAccount("group"));
+        this.group = new WindowsAccount(new MockWindowsAccount("group"));
     }
 
     @Test
     public void testPrefixAndUppercase() {
         FqnGrantedAuthorityFactory factory = new FqnGrantedAuthorityFactory("prefix_", true);
-        assertEquals(new GrantedAuthorityImpl("PREFIX_GROUP"), factory.createGrantedAuthority(_group));
+        assertEquals(new GrantedAuthorityImpl("PREFIX_GROUP"), factory.createGrantedAuthority(this.group));
     }
 
     @Test
     public void testPrefixAndLowercase() {
         FqnGrantedAuthorityFactory factory = new FqnGrantedAuthorityFactory("prefix_", false);
-        assertEquals(new GrantedAuthorityImpl("prefix_group"), factory.createGrantedAuthority(_group));
+        assertEquals(new GrantedAuthorityImpl("prefix_group"), factory.createGrantedAuthority(this.group));
     }
 
     @Test
     public void testNoPrefixAndUppercase() {
         FqnGrantedAuthorityFactory factory = new FqnGrantedAuthorityFactory(null, true);
-        assertEquals(new GrantedAuthorityImpl("GROUP"), factory.createGrantedAuthority(_group));
+        assertEquals(new GrantedAuthorityImpl("GROUP"), factory.createGrantedAuthority(this.group));
     }
 
     @Test
     public void testNoPrefixAndLowercase() {
         FqnGrantedAuthorityFactory factory = new FqnGrantedAuthorityFactory(null, false);
-        assertEquals(new GrantedAuthorityImpl("group"), factory.createGrantedAuthority(_group));
+        assertEquals(new GrantedAuthorityImpl("group"), factory.createGrantedAuthority(this.group));
     }
 
 }

--- a/Source/JNA/waffle-spring-security2/src/test/java/waffle/spring/NegotiateSecurityFilterEntryPointTests.java
+++ b/Source/JNA/waffle-spring-security2/src/test/java/waffle/spring/NegotiateSecurityFilterEntryPointTests.java
@@ -37,19 +37,19 @@ import waffle.mock.http.SimpleHttpResponse;
  */
 public class NegotiateSecurityFilterEntryPointTests {
 
-    private NegotiateSecurityFilterEntryPoint _entryPoint;
+    private NegotiateSecurityFilterEntryPoint entryPoint;
     private ApplicationContext                ctx;
 
     @Before
     public void setUp() {
         String[] configFiles = new String[] { "springTestFilterBeans.xml" };
-        ctx = new ClassPathXmlApplicationContext(configFiles);
-        _entryPoint = (NegotiateSecurityFilterEntryPoint) ctx.getBean("negotiateSecurityFilterEntryPoint");
+        this.ctx = new ClassPathXmlApplicationContext(configFiles);
+        this.entryPoint = (NegotiateSecurityFilterEntryPoint) this.ctx.getBean("negotiateSecurityFilterEntryPoint");
     }
 
     @After
     public void shutDown() {
-        ((AbstractApplicationContext) ctx).close();
+        ((AbstractApplicationContext) this.ctx).close();
     }
 
     @Test
@@ -57,7 +57,7 @@ public class NegotiateSecurityFilterEntryPointTests {
         SimpleHttpRequest request = new SimpleHttpRequest();
         request.setMethod("GET");
         SimpleHttpResponse response = new SimpleHttpResponse();
-        _entryPoint.commence(request, response, null);
+        this.entryPoint.commence(request, response, null);
         String[] wwwAuthenticates = response.getHeaderValues("WWW-Authenticate");
         assertEquals(3, wwwAuthenticates.length);
         assertEquals("NTLM", wwwAuthenticates[0]);
@@ -70,12 +70,12 @@ public class NegotiateSecurityFilterEntryPointTests {
 
     @Test(expected = ServletException.class)
     public void testGetSetProvider() throws IOException, ServletException {
-        assertNotNull(_entryPoint.getProvider());
-        _entryPoint.setProvider(null);
+        assertNotNull(this.entryPoint.getProvider());
+        this.entryPoint.setProvider(null);
         SimpleHttpRequest request = new SimpleHttpRequest();
         request.setMethod("GET");
         SimpleHttpResponse response = new SimpleHttpResponse();
-        _entryPoint.commence(request, response, null);
+        this.entryPoint.commence(request, response, null);
         fail("expected ServletException");
     }
 }

--- a/Source/JNA/waffle-spring-security2/src/test/java/waffle/spring/NegotiateSecurityFilterTests.java
+++ b/Source/JNA/waffle-spring-security2/src/test/java/waffle/spring/NegotiateSecurityFilterTests.java
@@ -49,34 +49,34 @@ import waffle.windows.auth.impl.WindowsAccountImpl;
  */
 public class NegotiateSecurityFilterTests {
 
-    private NegotiateSecurityFilter _filter;
+    private NegotiateSecurityFilter filter;
     private ApplicationContext      ctx;
 
     @Before
     public void setUp() {
         String[] configFiles = new String[] { "springTestFilterBeans.xml" };
-        ctx = new ClassPathXmlApplicationContext(configFiles);
+        this.ctx = new ClassPathXmlApplicationContext(configFiles);
         SecurityContextHolder.getContext().setAuthentication(null);
-        _filter = (NegotiateSecurityFilter) ctx.getBean("waffleNegotiateSecurityFilter");
+        this.filter = (NegotiateSecurityFilter) this.ctx.getBean("waffleNegotiateSecurityFilter");
     }
 
     @After
     public void shutDown() {
-        ((AbstractApplicationContext) ctx).close();
+        ((AbstractApplicationContext) this.ctx).close();
     }
 
     @Test
     public void testFilter() {
-        assertFalse(_filter.isAllowGuestLogin());
-        assertEquals(PrincipalFormat.fqn, _filter.getPrincipalFormat());
-        assertEquals(PrincipalFormat.both, _filter.getRoleFormat());
-        assertNull(_filter.getFilterConfig());
-        assertNotNull(_filter.getProvider());
+        assertFalse(this.filter.isAllowGuestLogin());
+        assertEquals(PrincipalFormat.fqn, this.filter.getPrincipalFormat());
+        assertEquals(PrincipalFormat.both, this.filter.getRoleFormat());
+        assertNull(this.filter.getFilterConfig());
+        assertNotNull(this.filter.getProvider());
     }
 
     @Test
     public void testProvider() throws ClassNotFoundException {
-        SecurityFilterProviderCollection provider = _filter.getProvider();
+        SecurityFilterProviderCollection provider = this.filter.getProvider();
         assertEquals(2, provider.size());
         assertTrue(provider.getByClassName("waffle.servlet.spi.BasicSecurityFilterProvider") instanceof BasicSecurityFilterProvider);
         assertTrue(provider.getByClassName("waffle.servlet.spi.NegotiateSecurityFilterProvider") instanceof NegotiateSecurityFilterProvider);
@@ -88,7 +88,7 @@ public class NegotiateSecurityFilterTests {
         request.setMethod("GET");
         SimpleHttpResponse response = new SimpleHttpResponse();
         SimpleFilterChain chain = new SimpleFilterChain();
-        _filter.doFilter(request, response, chain);
+        this.filter.doFilter(request, response, chain);
         // unlike servlet filters, it's a passthrough
         assertEquals(500, response.getStatus());
     }
@@ -103,7 +103,7 @@ public class NegotiateSecurityFilterTests {
         request.addHeader("Authorization", securityPackage + " " + clientToken);
 
         SimpleHttpResponse response = new SimpleHttpResponse();
-        _filter.doFilter(request, response, filterChain);
+        this.filter.doFilter(request, response, filterChain);
 
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         assertNotNull(auth);
@@ -122,7 +122,7 @@ public class NegotiateSecurityFilterTests {
         SimpleHttpRequest request = new SimpleHttpRequest();
         request.addHeader("Authorization", "Unsupported challenge");
         SimpleHttpResponse response = new SimpleHttpResponse();
-        _filter.doFilter(request, response, filterChain);
+        this.filter.doFilter(request, response, filterChain);
         // the filter should ignore authorization for an unsupported security package, ie. not return a 401
         assertEquals(500, response.getStatus());
     }
@@ -137,7 +137,7 @@ public class NegotiateSecurityFilterTests {
         request.addHeader("Authorization", securityPackage + " " + clientToken);
 
         SimpleHttpResponse response = new SimpleHttpResponse();
-        _filter.doFilter(request, response, filterChain);
+        this.filter.doFilter(request, response, filterChain);
 
         assertEquals(401, response.getStatus());
         assertNull(SecurityContextHolder.getContext().getAuthentication());
@@ -145,7 +145,7 @@ public class NegotiateSecurityFilterTests {
 
     @Test(expected = ServletException.class)
     public void testAfterPropertiesSet() throws ServletException {
-        _filter.setProvider(null);
-        _filter.afterPropertiesSet();
+        this.filter.setProvider(null);
+        this.filter.afterPropertiesSet();
     }
 }

--- a/Source/JNA/waffle-spring-security2/src/test/java/waffle/spring/WindowsAuthenticationProviderTests.java
+++ b/Source/JNA/waffle-spring-security2/src/test/java/waffle/spring/WindowsAuthenticationProviderTests.java
@@ -42,33 +42,33 @@ import waffle.windows.auth.impl.WindowsAccountImpl;
  */
 public class WindowsAuthenticationProviderTests {
 
-    private WindowsAuthenticationProvider _provider;
+    private WindowsAuthenticationProvider provider;
     private ApplicationContext            ctx;
 
     @Before
     public void setUp() {
         String[] configFiles = new String[] { "springTestAuthBeans.xml" };
-        ctx = new ClassPathXmlApplicationContext(configFiles);
-        _provider = (WindowsAuthenticationProvider) ctx.getBean("waffleSpringAuthenticationProvider");
+        this.ctx = new ClassPathXmlApplicationContext(configFiles);
+        this.provider = (WindowsAuthenticationProvider) this.ctx.getBean("waffleSpringAuthenticationProvider");
     }
 
     @After
     public void shutDown() {
-        ((AbstractApplicationContext) ctx).close();
+        ((AbstractApplicationContext) this.ctx).close();
     }
 
     @Test
     public void testWindowsAuthenticationProvider() {
-        assertTrue(_provider.isAllowGuestLogin());
-        assertTrue(_provider.getAuthProvider() instanceof MockWindowsAuthProvider);
-        assertEquals(PrincipalFormat.sid, _provider.getPrincipalFormat());
-        assertEquals(PrincipalFormat.both, _provider.getRoleFormat());
+        assertTrue(this.provider.isAllowGuestLogin());
+        assertTrue(this.provider.getAuthProvider() instanceof MockWindowsAuthProvider);
+        assertEquals(PrincipalFormat.sid, this.provider.getPrincipalFormat());
+        assertEquals(PrincipalFormat.both, this.provider.getRoleFormat());
     }
 
     @Test
     public void testSupports() {
-        assertFalse(_provider.supports(this.getClass()));
-        assertTrue(_provider.supports(UsernamePasswordAuthenticationToken.class));
+        assertFalse(this.provider.supports(this.getClass()));
+        assertTrue(this.provider.supports(UsernamePasswordAuthenticationToken.class));
     }
 
     @Test
@@ -78,7 +78,7 @@ public class WindowsAuthenticationProviderTests {
         WindowsPrincipal principal = new WindowsPrincipal(mockIdentity);
         UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(principal,
                 "password");
-        Authentication authenticated = _provider.authenticate(authentication);
+        Authentication authenticated = this.provider.authenticate(authentication);
         assertNotNull(authenticated);
         assertTrue(authenticated.isAuthenticated());
         GrantedAuthority[] authorities = authenticated.getAuthorities();
@@ -91,8 +91,8 @@ public class WindowsAuthenticationProviderTests {
 
     @Test
     public void testAuthenticateWithCustomGrantedAuthorityFactory() {
-        _provider.setDefaultGrantedAuthority(null);
-        _provider.setGrantedAuthorityFactory(new FqnGrantedAuthorityFactory(null, false));
+        this.provider.setDefaultGrantedAuthority(null);
+        this.provider.setGrantedAuthorityFactory(new FqnGrantedAuthorityFactory(null, false));
 
         MockWindowsIdentity mockIdentity = new MockWindowsIdentity(WindowsAccountImpl.getCurrentUsername(),
                 new ArrayList<String>());
@@ -100,7 +100,7 @@ public class WindowsAuthenticationProviderTests {
         UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(principal,
                 "password");
 
-        Authentication authenticated = _provider.authenticate(authentication);
+        Authentication authenticated = this.provider.authenticate(authentication);
         assertNotNull(authenticated);
         assertTrue(authenticated.isAuthenticated());
         GrantedAuthority[] authorities = authenticated.getAuthorities();
@@ -113,11 +113,11 @@ public class WindowsAuthenticationProviderTests {
     @Test(expected = GuestLoginDisabledAuthenticationException.class)
     public void testGuestIsDisabled() {
         MockWindowsIdentity mockIdentity = new MockWindowsIdentity("Guest", new ArrayList<String>());
-        _provider.setAllowGuestLogin(false);
+        this.provider.setAllowGuestLogin(false);
         WindowsPrincipal principal = new WindowsPrincipal(mockIdentity);
         UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(principal,
                 "password");
-        _provider.authenticate(authentication);
+        this.provider.authenticate(authentication);
         fail("expected AuthenticationServiceException");
     }
 }

--- a/Source/JNA/waffle-spring-security2/src/test/java/waffle/spring/WindowsAuthenticationTokenTests.java
+++ b/Source/JNA/waffle-spring-security2/src/test/java/waffle/spring/WindowsAuthenticationTokenTests.java
@@ -32,8 +32,8 @@ import waffle.servlet.WindowsPrincipal;
  */
 public class WindowsAuthenticationTokenTests {
 
-    private WindowsPrincipal           _principal = null;
-    private WindowsAuthenticationToken _token     = null;
+    private WindowsPrincipal           principal = null;
+    private WindowsAuthenticationToken token     = null;
 
     @Before
     public void setUp() {
@@ -41,29 +41,29 @@ public class WindowsAuthenticationTokenTests {
         mockGroups.add("group1");
         mockGroups.add("group2");
         MockWindowsIdentity mockIdentity = new MockWindowsIdentity("localhost\\user1", mockGroups);
-        _principal = new WindowsPrincipal(mockIdentity);
-        _token = new WindowsAuthenticationToken(_principal);
+        this.principal = new WindowsPrincipal(mockIdentity);
+        this.token = new WindowsAuthenticationToken(this.principal);
     }
 
     @Test
     public void testWindowsAuthenticationToken() {
-        assertNull(_token.getCredentials());
-        assertNull(_token.getDetails());
-        assertTrue(_token.isAuthenticated());
-        assertEquals("localhost\\user1", _token.getName());
-        GrantedAuthority[] authorities = _token.getAuthorities();
+        assertNull(this.token.getCredentials());
+        assertNull(this.token.getDetails());
+        assertTrue(this.token.isAuthenticated());
+        assertEquals("localhost\\user1", this.token.getName());
+        GrantedAuthority[] authorities = this.token.getAuthorities();
         assertEquals(3, authorities.length);
         assertEquals("ROLE_USER", authorities[0].getAuthority());
         assertEquals("ROLE_GROUP1", authorities[1].getAuthority());
         assertEquals("ROLE_GROUP2", authorities[2].getAuthority());
-        assertEquals(_principal, _token.getPrincipal());
+        assertEquals(this.principal, this.token.getPrincipal());
     }
 
     @Test
     public void testCustomGrantedAuthorityFactory() {
 
-        WindowsAuthenticationToken token = new WindowsAuthenticationToken(_principal, new FqnGrantedAuthorityFactory(
-                null, false), null);
+        WindowsAuthenticationToken token = new WindowsAuthenticationToken(this.principal,
+                new FqnGrantedAuthorityFactory(null, false), null);
 
         assertNull(token.getCredentials());
         assertNull(token.getDetails());
@@ -73,12 +73,12 @@ public class WindowsAuthenticationTokenTests {
         assertEquals(2, authorities.length);
         assertEquals("group1", authorities[0].getAuthority());
         assertEquals("group2", authorities[1].getAuthority());
-        assertEquals(_principal, token.getPrincipal());
+        assertEquals(this.principal, token.getPrincipal());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testAuthenticated() {
-        assertTrue(_token.isAuthenticated());
-        _token.setAuthenticated(true);
+        assertTrue(this.token.isAuthenticated());
+        this.token.setAuthenticated(true);
     }
 }

--- a/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/FqnGrantedAuthorityFactory.java
+++ b/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/FqnGrantedAuthorityFactory.java
@@ -28,12 +28,12 @@ import waffle.windows.auth.WindowsAccount;
  */
 public class FqnGrantedAuthorityFactory implements GrantedAuthorityFactory {
 
-    private final String  _prefix;
-    private final boolean _convertToUpperCase;
+    private final String  prefix;
+    private final boolean convertToUpperCase;
 
     public FqnGrantedAuthorityFactory(String prefix, boolean convertToUpperCase) {
-        _prefix = prefix;
-        _convertToUpperCase = convertToUpperCase;
+        this.prefix = prefix;
+        this.convertToUpperCase = convertToUpperCase;
     }
 
     @Override
@@ -41,11 +41,11 @@ public class FqnGrantedAuthorityFactory implements GrantedAuthorityFactory {
 
         String grantedAuthorityString = windowsAccount.getFqn();
 
-        if (_prefix != null) {
-            grantedAuthorityString = _prefix + grantedAuthorityString;
+        if (this.prefix != null) {
+            grantedAuthorityString = this.prefix + grantedAuthorityString;
         }
 
-        if (_convertToUpperCase) {
+        if (this.convertToUpperCase) {
             grantedAuthorityString = grantedAuthorityString.toUpperCase();
         }
 

--- a/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/NegotiateSecurityFilter.java
+++ b/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/NegotiateSecurityFilter.java
@@ -42,19 +42,19 @@ import waffle.windows.auth.PrincipalFormat;
  */
 public class NegotiateSecurityFilter extends GenericFilterBean {
 
-    private static final Logger              _log                     = LoggerFactory
-                                                                              .getLogger(NegotiateSecurityFilter.class);
-    private SecurityFilterProviderCollection _provider;
-    private PrincipalFormat                  _principalFormat         = PrincipalFormat.fqn;
-    private PrincipalFormat                  _roleFormat              = PrincipalFormat.fqn;
-    private boolean                          _allowGuestLogin         = true;
+    private static final Logger              LOGGER                  = LoggerFactory
+                                                                             .getLogger(NegotiateSecurityFilter.class);
+    private SecurityFilterProviderCollection provider;
+    private PrincipalFormat                  principalFormat         = PrincipalFormat.fqn;
+    private PrincipalFormat                  roleFormat              = PrincipalFormat.fqn;
+    private boolean                          allowGuestLogin         = true;
 
-    private GrantedAuthorityFactory          _grantedAuthorityFactory = WindowsAuthenticationToken.DEFAULT_GRANTED_AUTHORITY_FACTORY;
-    private GrantedAuthority                 _defaultGrantedAuthority = WindowsAuthenticationToken.DEFAULT_GRANTED_AUTHORITY;
+    private GrantedAuthorityFactory          grantedAuthorityFactory = WindowsAuthenticationToken.DEFAULT_GRANTED_AUTHORITY_FACTORY;
+    private GrantedAuthority                 defaultGrantedAuthority = WindowsAuthenticationToken.DEFAULT_GRANTED_AUTHORITY;
 
     public NegotiateSecurityFilter() {
         super();
-        _log.debug("[waffle.spring.NegotiateSecurityFilter] loaded");
+        LOGGER.debug("[waffle.spring.NegotiateSecurityFilter] loaded");
     }
 
     @Override
@@ -64,49 +64,50 @@ public class NegotiateSecurityFilter extends GenericFilterBean {
         HttpServletRequest request = (HttpServletRequest) req;
         HttpServletResponse response = (HttpServletResponse) res;
 
-        _log.debug("{} {}, contentlength: {}", request.getMethod(), request.getRequestURI(),
+        LOGGER.debug("{} {}, contentlength: {}", request.getMethod(), request.getRequestURI(),
                 Integer.valueOf(request.getContentLength()));
 
         AuthorizationHeader authorizationHeader = new AuthorizationHeader(request);
 
         // authenticate user
         if (!authorizationHeader.isNull()
-                && _provider.isSecurityPackageSupported(authorizationHeader.getSecurityPackage())) {
+                && this.provider.isSecurityPackageSupported(authorizationHeader.getSecurityPackage())) {
 
             // log the user in using the token
             IWindowsIdentity windowsIdentity = null;
 
             try {
-                windowsIdentity = _provider.doFilter(request, response);
+                windowsIdentity = this.provider.doFilter(request, response);
                 if (windowsIdentity == null) {
                     return;
                 }
             } catch (IOException e) {
-                _log.warn("error logging in user: {}", e.getMessage());
-                _log.trace("{}", e);
+                LOGGER.warn("error logging in user: {}", e.getMessage());
+                LOGGER.trace("{}", e);
                 sendUnauthorized(response, true);
                 return;
             }
 
-            if (!_allowGuestLogin && windowsIdentity.isGuest()) {
-                _log.warn("guest login disabled: {}", windowsIdentity.getFqn());
+            if (!this.allowGuestLogin && windowsIdentity.isGuest()) {
+                LOGGER.warn("guest login disabled: {}", windowsIdentity.getFqn());
                 sendUnauthorized(response, true);
                 return;
             }
 
             try {
-                _log.debug("logged in user: {} ({})", windowsIdentity.getFqn(), windowsIdentity.getSidString());
+                LOGGER.debug("logged in user: {} ({})", windowsIdentity.getFqn(), windowsIdentity.getSidString());
 
-                WindowsPrincipal principal = new WindowsPrincipal(windowsIdentity, _principalFormat, _roleFormat);
+                WindowsPrincipal principal = new WindowsPrincipal(windowsIdentity, this.principalFormat,
+                        this.roleFormat);
 
-                _log.debug("roles: {}", principal.getRolesString());
+                LOGGER.debug("roles: {}", principal.getRolesString());
 
-                Authentication authentication = new WindowsAuthenticationToken(principal, _grantedAuthorityFactory,
-                        _defaultGrantedAuthority);
+                Authentication authentication = new WindowsAuthenticationToken(principal, this.grantedAuthorityFactory,
+                        this.defaultGrantedAuthority);
 
                 SecurityContextHolder.getContext().setAuthentication(authentication);
 
-                _log.info("successfully logged in user: {}", windowsIdentity.getFqn());
+                LOGGER.info("successfully logged in user: {}", windowsIdentity.getFqn());
 
             } finally {
                 windowsIdentity.dispose();
@@ -120,7 +121,7 @@ public class NegotiateSecurityFilter extends GenericFilterBean {
     public void afterPropertiesSet() throws ServletException {
         super.afterPropertiesSet();
 
-        if (_provider == null) {
+        if (this.provider == null) {
             throw new ServletException("Missing NegotiateSecurityFilter.Provider");
         }
     }
@@ -135,7 +136,7 @@ public class NegotiateSecurityFilter extends GenericFilterBean {
      */
     private void sendUnauthorized(HttpServletResponse response, boolean close) {
         try {
-            _provider.sendUnauthorized(response);
+            this.provider.sendUnauthorized(response);
             if (close) {
                 response.setHeader("Connection", "close");
             } else {
@@ -149,50 +150,50 @@ public class NegotiateSecurityFilter extends GenericFilterBean {
     }
 
     public PrincipalFormat getPrincipalFormat() {
-        return _principalFormat;
+        return this.principalFormat;
     }
 
     public void setPrincipalFormat(PrincipalFormat principalFormat) {
-        _principalFormat = principalFormat;
+        this.principalFormat = principalFormat;
     }
 
     public PrincipalFormat getRoleFormat() {
-        return _roleFormat;
+        return this.roleFormat;
     }
 
     public void setRoleFormat(PrincipalFormat principalFormat) {
-        _roleFormat = principalFormat;
+        this.roleFormat = principalFormat;
     }
 
     public boolean isAllowGuestLogin() {
-        return _allowGuestLogin;
+        return this.allowGuestLogin;
     }
 
     public void setAllowGuestLogin(boolean allowGuestLogin) {
-        _allowGuestLogin = allowGuestLogin;
+        this.allowGuestLogin = allowGuestLogin;
     }
 
     public SecurityFilterProviderCollection getProvider() {
-        return _provider;
+        return this.provider;
     }
 
     public void setProvider(SecurityFilterProviderCollection provider) {
-        _provider = provider;
+        this.provider = provider;
     }
 
     public GrantedAuthorityFactory getGrantedAuthorityFactory() {
-        return _grantedAuthorityFactory;
+        return this.grantedAuthorityFactory;
     }
 
     public void setGrantedAuthorityFactory(GrantedAuthorityFactory grantedAuthorityFactory) {
-        _grantedAuthorityFactory = grantedAuthorityFactory;
+        this.grantedAuthorityFactory = grantedAuthorityFactory;
     }
 
     public GrantedAuthority getDefaultGrantedAuthority() {
-        return _defaultGrantedAuthority;
+        return this.defaultGrantedAuthority;
     }
 
     public void setDefaultGrantedAuthority(GrantedAuthority defaultGrantedAuthority) {
-        _defaultGrantedAuthority = defaultGrantedAuthority;
+        this.defaultGrantedAuthority = defaultGrantedAuthority;
     }
 }

--- a/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/NegotiateSecurityFilterEntryPoint.java
+++ b/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/NegotiateSecurityFilterEntryPoint.java
@@ -33,34 +33,34 @@ import waffle.servlet.spi.SecurityFilterProviderCollection;
  */
 public class NegotiateSecurityFilterEntryPoint implements AuthenticationEntryPoint {
 
-    private static final Logger              _log = LoggerFactory.getLogger(NegotiateSecurityFilterEntryPoint.class);
-    private SecurityFilterProviderCollection _provider;
+    private static final Logger              LOGGER = LoggerFactory.getLogger(NegotiateSecurityFilterEntryPoint.class);
+    private SecurityFilterProviderCollection provider;
 
     public NegotiateSecurityFilterEntryPoint() {
-        _log.debug("[waffle.spring.NegotiateEntryPoint] loaded");
+        LOGGER.debug("[waffle.spring.NegotiateEntryPoint] loaded");
     }
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException ex)
             throws IOException, ServletException {
 
-        _log.debug("[waffle.spring.NegotiateEntryPoint] commence");
+        LOGGER.debug("[waffle.spring.NegotiateEntryPoint] commence");
 
-        if (_provider == null) {
+        if (this.provider == null) {
             throw new ServletException("Missing NegotiateEntryPoint.Provider");
         }
 
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setHeader("Connection", "keep-alive");
-        _provider.sendUnauthorized(response);
+        this.provider.sendUnauthorized(response);
         response.flushBuffer();
     }
 
     public SecurityFilterProviderCollection getProvider() {
-        return _provider;
+        return this.provider;
     }
 
     public void setProvider(SecurityFilterProviderCollection provider) {
-        _provider = provider;
+        this.provider = provider;
     }
 }

--- a/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/WindowsAuthenticationProvider.java
+++ b/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/WindowsAuthenticationProvider.java
@@ -32,37 +32,38 @@ import waffle.windows.auth.PrincipalFormat;
  */
 public class WindowsAuthenticationProvider implements AuthenticationProvider {
 
-    private static final Logger     _log                     = LoggerFactory
-                                                                     .getLogger(WindowsAuthenticationProvider.class);
-    private PrincipalFormat         _principalFormat         = PrincipalFormat.fqn;
-    private PrincipalFormat         _roleFormat              = PrincipalFormat.fqn;
-    private boolean                 _allowGuestLogin         = true;
-    private IWindowsAuthProvider    _authProvider;
-    private GrantedAuthorityFactory _grantedAuthorityFactory = WindowsAuthenticationToken.DEFAULT_GRANTED_AUTHORITY_FACTORY;
-    private GrantedAuthority        _defaultGrantedAuthority = WindowsAuthenticationToken.DEFAULT_GRANTED_AUTHORITY;
+    private static final Logger     LOGGER                  = LoggerFactory
+                                                                    .getLogger(WindowsAuthenticationProvider.class);
+    private PrincipalFormat         principalFormat         = PrincipalFormat.fqn;
+    private PrincipalFormat         roleFormat              = PrincipalFormat.fqn;
+    private boolean                 allowGuestLogin         = true;
+    private IWindowsAuthProvider    authProvider;
+    private GrantedAuthorityFactory grantedAuthorityFactory = WindowsAuthenticationToken.DEFAULT_GRANTED_AUTHORITY_FACTORY;
+    private GrantedAuthority        defaultGrantedAuthority = WindowsAuthenticationToken.DEFAULT_GRANTED_AUTHORITY;
 
     public WindowsAuthenticationProvider() {
-        _log.debug("[waffle.spring.WindowsAuthenticationProvider] loaded");
+        LOGGER.debug("[waffle.spring.WindowsAuthenticationProvider] loaded");
     }
 
     @Override
     public Authentication authenticate(Authentication authentication) {
         UsernamePasswordAuthenticationToken auth = (UsernamePasswordAuthenticationToken) authentication;
-        IWindowsIdentity windowsIdentity = _authProvider.logonUser(auth.getName(), auth.getCredentials().toString());
-        _log.debug("logged in user: {} ({})", windowsIdentity.getFqn(), windowsIdentity.getSidString());
+        IWindowsIdentity windowsIdentity = this.authProvider
+                .logonUser(auth.getName(), auth.getCredentials().toString());
+        LOGGER.debug("logged in user: {} ({})", windowsIdentity.getFqn(), windowsIdentity.getSidString());
 
-        if (!_allowGuestLogin && windowsIdentity.isGuest()) {
-            _log.warn("guest login disabled: {}", windowsIdentity.getFqn());
+        if (!this.allowGuestLogin && windowsIdentity.isGuest()) {
+            LOGGER.warn("guest login disabled: {}", windowsIdentity.getFqn());
             throw new GuestLoginDisabledAuthenticationException(windowsIdentity.getFqn());
         }
 
-        WindowsPrincipal windowsPrincipal = new WindowsPrincipal(windowsIdentity, _principalFormat, _roleFormat);
-        _log.debug("roles: {}", windowsPrincipal.getRolesString());
+        WindowsPrincipal windowsPrincipal = new WindowsPrincipal(windowsIdentity, this.principalFormat, this.roleFormat);
+        LOGGER.debug("roles: {}", windowsPrincipal.getRolesString());
 
-        WindowsAuthenticationToken token = new WindowsAuthenticationToken(windowsPrincipal, _grantedAuthorityFactory,
-                _defaultGrantedAuthority);
+        WindowsAuthenticationToken token = new WindowsAuthenticationToken(windowsPrincipal,
+                this.grantedAuthorityFactory, this.defaultGrantedAuthority);
 
-        _log.info("successfully logged in user: {}", windowsIdentity.getFqn());
+        LOGGER.info("successfully logged in user: {}", windowsIdentity.getFqn());
         return token;
     }
 
@@ -72,50 +73,50 @@ public class WindowsAuthenticationProvider implements AuthenticationProvider {
     }
 
     public PrincipalFormat getPrincipalFormat() {
-        return _principalFormat;
+        return this.principalFormat;
     }
 
     public void setPrincipalFormat(PrincipalFormat principalFormat) {
-        _principalFormat = principalFormat;
+        this.principalFormat = principalFormat;
     }
 
     public PrincipalFormat getRoleFormat() {
-        return _roleFormat;
+        return this.roleFormat;
     }
 
     public void setRoleFormat(PrincipalFormat principalFormat) {
-        _roleFormat = principalFormat;
+        this.roleFormat = principalFormat;
     }
 
     public boolean isAllowGuestLogin() {
-        return _allowGuestLogin;
+        return this.allowGuestLogin;
     }
 
     public void setAllowGuestLogin(boolean allowGuestLogin) {
-        _allowGuestLogin = allowGuestLogin;
+        this.allowGuestLogin = allowGuestLogin;
     }
 
     public IWindowsAuthProvider getAuthProvider() {
-        return _authProvider;
+        return this.authProvider;
     }
 
     public void setAuthProvider(IWindowsAuthProvider authProvider) {
-        _authProvider = authProvider;
+        this.authProvider = authProvider;
     }
 
     public GrantedAuthorityFactory getGrantedAuthorityFactory() {
-        return _grantedAuthorityFactory;
+        return this.grantedAuthorityFactory;
     }
 
     public void setGrantedAuthorityFactory(GrantedAuthorityFactory grantedAuthorityFactory) {
-        _grantedAuthorityFactory = grantedAuthorityFactory;
+        this.grantedAuthorityFactory = grantedAuthorityFactory;
     }
 
     public GrantedAuthority getDefaultGrantedAuthority() {
-        return _defaultGrantedAuthority;
+        return this.defaultGrantedAuthority;
     }
 
     public void setDefaultGrantedAuthority(GrantedAuthority defaultGrantedAuthority) {
-        _defaultGrantedAuthority = defaultGrantedAuthority;
+        this.defaultGrantedAuthority = defaultGrantedAuthority;
     }
 }

--- a/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/WindowsAuthenticationToken.java
+++ b/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/WindowsAuthenticationToken.java
@@ -46,8 +46,8 @@ public class WindowsAuthenticationToken implements Authentication {
                                                                                           "ROLE_USER");
 
     private static final long                   serialVersionUID                  = 1L;
-    private WindowsPrincipal                    _principal                        = null;
-    private Collection<GrantedAuthority>        _authorities                      = null;
+    private WindowsPrincipal                    principal                         = null;
+    private Collection<GrantedAuthority>        authorities                       = null;
 
     /**
      * Convenience constructor that calls
@@ -74,19 +74,19 @@ public class WindowsAuthenticationToken implements Authentication {
     public WindowsAuthenticationToken(WindowsPrincipal identity, GrantedAuthorityFactory grantedAuthorityFactory,
             GrantedAuthority defaultGrantedAuthority) {
 
-        _principal = identity;
-        _authorities = new ArrayList<GrantedAuthority>();
+        this.principal = identity;
+        this.authorities = new ArrayList<GrantedAuthority>();
         if (defaultGrantedAuthority != null) {
-            _authorities.add(defaultGrantedAuthority);
+            this.authorities.add(defaultGrantedAuthority);
         }
-        for (WindowsAccount group : _principal.getGroups().values()) {
-            _authorities.add(grantedAuthorityFactory.createGrantedAuthority(group));
+        for (WindowsAccount group : this.principal.getGroups().values()) {
+            this.authorities.add(grantedAuthorityFactory.createGrantedAuthority(group));
         }
     }
 
     @Override
     public Collection<GrantedAuthority> getAuthorities() {
-        return _authorities;
+        return this.authorities;
     }
 
     @Override
@@ -101,12 +101,12 @@ public class WindowsAuthenticationToken implements Authentication {
 
     @Override
     public Object getPrincipal() {
-        return _principal;
+        return this.principal;
     }
 
     @Override
     public boolean isAuthenticated() {
-        return _principal != null;
+        return this.principal != null;
     }
 
     @Override
@@ -116,6 +116,6 @@ public class WindowsAuthenticationToken implements Authentication {
 
     @Override
     public String getName() {
-        return _principal.getName();
+        return this.principal.getName();
     }
 }

--- a/Source/JNA/waffle-spring-security3/src/test/java/waffle/spring/FqnGrantedAuthorityFactoryTests.java
+++ b/Source/JNA/waffle-spring-security3/src/test/java/waffle/spring/FqnGrantedAuthorityFactoryTests.java
@@ -24,35 +24,35 @@ import waffle.windows.auth.WindowsAccount;
 
 public class FqnGrantedAuthorityFactoryTests {
 
-    private WindowsAccount _group;
+    private WindowsAccount group;
 
     @Before
     public void setUp() {
-        _group = new WindowsAccount(new MockWindowsAccount("group"));
+        this.group = new WindowsAccount(new MockWindowsAccount("group"));
     }
 
     @Test
     public void testPrefixAndUppercase() {
         FqnGrantedAuthorityFactory factory = new FqnGrantedAuthorityFactory("prefix_", true);
-        assertEquals(new SimpleGrantedAuthority("PREFIX_GROUP"), factory.createGrantedAuthority(_group));
+        assertEquals(new SimpleGrantedAuthority("PREFIX_GROUP"), factory.createGrantedAuthority(this.group));
     }
 
     @Test
     public void testPrefixAndLowercase() {
         FqnGrantedAuthorityFactory factory = new FqnGrantedAuthorityFactory("prefix_", false);
-        assertEquals(new SimpleGrantedAuthority("prefix_group"), factory.createGrantedAuthority(_group));
+        assertEquals(new SimpleGrantedAuthority("prefix_group"), factory.createGrantedAuthority(this.group));
     }
 
     @Test
     public void testNoPrefixAndUppercase() {
         FqnGrantedAuthorityFactory factory = new FqnGrantedAuthorityFactory(null, true);
-        assertEquals(new SimpleGrantedAuthority("GROUP"), factory.createGrantedAuthority(_group));
+        assertEquals(new SimpleGrantedAuthority("GROUP"), factory.createGrantedAuthority(this.group));
     }
 
     @Test
     public void testNoPrefixAndLowercase() {
         FqnGrantedAuthorityFactory factory = new FqnGrantedAuthorityFactory(null, false);
-        assertEquals(new SimpleGrantedAuthority("group"), factory.createGrantedAuthority(_group));
+        assertEquals(new SimpleGrantedAuthority("group"), factory.createGrantedAuthority(this.group));
     }
 
 }

--- a/Source/JNA/waffle-spring-security3/src/test/java/waffle/spring/NegotiateSecurityFilterEntryPointTests.java
+++ b/Source/JNA/waffle-spring-security3/src/test/java/waffle/spring/NegotiateSecurityFilterEntryPointTests.java
@@ -37,19 +37,19 @@ import waffle.mock.http.SimpleHttpResponse;
  */
 public class NegotiateSecurityFilterEntryPointTests {
 
-    private NegotiateSecurityFilterEntryPoint _entryPoint;
+    private NegotiateSecurityFilterEntryPoint entryPoint;
     private ApplicationContext                ctx;
 
     @Before
     public void setUp() {
         String[] configFiles = new String[] { "springTestFilterBeans.xml" };
-        ctx = new ClassPathXmlApplicationContext(configFiles);
-        _entryPoint = (NegotiateSecurityFilterEntryPoint) ctx.getBean("negotiateSecurityFilterEntryPoint");
+        this.ctx = new ClassPathXmlApplicationContext(configFiles);
+        this.entryPoint = (NegotiateSecurityFilterEntryPoint) this.ctx.getBean("negotiateSecurityFilterEntryPoint");
     }
 
     @After
     public void shutDown() {
-        ((AbstractApplicationContext) ctx).close();
+        ((AbstractApplicationContext) this.ctx).close();
     }
 
     @Test
@@ -57,7 +57,7 @@ public class NegotiateSecurityFilterEntryPointTests {
         SimpleHttpRequest request = new SimpleHttpRequest();
         request.setMethod("GET");
         SimpleHttpResponse response = new SimpleHttpResponse();
-        _entryPoint.commence(request, response, null);
+        this.entryPoint.commence(request, response, null);
         String[] wwwAuthenticates = response.getHeaderValues("WWW-Authenticate");
         assertEquals(3, wwwAuthenticates.length);
         assertEquals("NTLM", wwwAuthenticates[0]);
@@ -70,12 +70,12 @@ public class NegotiateSecurityFilterEntryPointTests {
 
     @Test(expected = ServletException.class)
     public void testGetSetProvider() throws IOException, ServletException {
-        assertNotNull(_entryPoint.getProvider());
-        _entryPoint.setProvider(null);
+        assertNotNull(this.entryPoint.getProvider());
+        this.entryPoint.setProvider(null);
         SimpleHttpRequest request = new SimpleHttpRequest();
         request.setMethod("GET");
         SimpleHttpResponse response = new SimpleHttpResponse();
-        _entryPoint.commence(request, response, null);
+        this.entryPoint.commence(request, response, null);
         fail("expected ServletException");
     }
 }

--- a/Source/JNA/waffle-spring-security3/src/test/java/waffle/spring/NegotiateSecurityFilterTests.java
+++ b/Source/JNA/waffle-spring-security3/src/test/java/waffle/spring/NegotiateSecurityFilterTests.java
@@ -51,34 +51,34 @@ import waffle.windows.auth.impl.WindowsAccountImpl;
  */
 public class NegotiateSecurityFilterTests {
 
-    private NegotiateSecurityFilter _filter;
+    private NegotiateSecurityFilter filter;
     private ApplicationContext      ctx;
 
     @Before
     public void setUp() {
         String[] configFiles = new String[] { "springTestFilterBeans.xml" };
-        ctx = new ClassPathXmlApplicationContext(configFiles);
+        this.ctx = new ClassPathXmlApplicationContext(configFiles);
         SecurityContextHolder.getContext().setAuthentication(null);
-        _filter = (NegotiateSecurityFilter) ctx.getBean("waffleNegotiateSecurityFilter");
+        this.filter = (NegotiateSecurityFilter) this.ctx.getBean("waffleNegotiateSecurityFilter");
     }
 
     @After
     public void shutDown() {
-        ((AbstractApplicationContext) ctx).close();
+        ((AbstractApplicationContext) this.ctx).close();
     }
 
     @Test
     public void testFilter() {
-        assertFalse(_filter.isAllowGuestLogin());
-        assertEquals(PrincipalFormat.fqn, _filter.getPrincipalFormat());
-        assertEquals(PrincipalFormat.both, _filter.getRoleFormat());
-        assertNull(_filter.getFilterConfig());
-        assertNotNull(_filter.getProvider());
+        assertFalse(this.filter.isAllowGuestLogin());
+        assertEquals(PrincipalFormat.fqn, this.filter.getPrincipalFormat());
+        assertEquals(PrincipalFormat.both, this.filter.getRoleFormat());
+        assertNull(this.filter.getFilterConfig());
+        assertNotNull(this.filter.getProvider());
     }
 
     @Test
     public void testProvider() throws ClassNotFoundException {
-        SecurityFilterProviderCollection provider = _filter.getProvider();
+        SecurityFilterProviderCollection provider = this.filter.getProvider();
         assertEquals(2, provider.size());
         assertTrue(provider.getByClassName("waffle.servlet.spi.BasicSecurityFilterProvider") instanceof BasicSecurityFilterProvider);
         assertTrue(provider.getByClassName("waffle.servlet.spi.NegotiateSecurityFilterProvider") instanceof NegotiateSecurityFilterProvider);
@@ -90,7 +90,7 @@ public class NegotiateSecurityFilterTests {
         request.setMethod("GET");
         SimpleHttpResponse response = new SimpleHttpResponse();
         SimpleFilterChain chain = new SimpleFilterChain();
-        _filter.doFilter(request, response, chain);
+        this.filter.doFilter(request, response, chain);
         // unlike servlet filters, it's a passthrough
         assertEquals(500, response.getStatus());
     }
@@ -105,7 +105,7 @@ public class NegotiateSecurityFilterTests {
         request.addHeader("Authorization", securityPackage + " " + clientToken);
 
         SimpleHttpResponse response = new SimpleHttpResponse();
-        _filter.doFilter(request, response, filterChain);
+        this.filter.doFilter(request, response, filterChain);
 
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         assertNotNull(auth);
@@ -125,7 +125,7 @@ public class NegotiateSecurityFilterTests {
         SimpleHttpRequest request = new SimpleHttpRequest();
         request.addHeader("Authorization", "Unsupported challenge");
         SimpleHttpResponse response = new SimpleHttpResponse();
-        _filter.doFilter(request, response, filterChain);
+        this.filter.doFilter(request, response, filterChain);
         // the filter should ignore authorization for an unsupported security package, ie. not return a 401
         assertEquals(500, response.getStatus());
     }
@@ -140,7 +140,7 @@ public class NegotiateSecurityFilterTests {
         request.addHeader("Authorization", securityPackage + " " + clientToken);
 
         SimpleHttpResponse response = new SimpleHttpResponse();
-        _filter.doFilter(request, response, filterChain);
+        this.filter.doFilter(request, response, filterChain);
 
         assertEquals(401, response.getStatus());
         assertNull(SecurityContextHolder.getContext().getAuthentication());
@@ -148,7 +148,7 @@ public class NegotiateSecurityFilterTests {
 
     @Test(expected = ServletException.class)
     public void testAfterPropertiesSet() throws ServletException {
-        _filter.setProvider(null);
-        _filter.afterPropertiesSet();
+        this.filter.setProvider(null);
+        this.filter.afterPropertiesSet();
     }
 }

--- a/Source/JNA/waffle-spring-security3/src/test/java/waffle/spring/WindowsAuthenticationProviderTests.java
+++ b/Source/JNA/waffle-spring-security3/src/test/java/waffle/spring/WindowsAuthenticationProviderTests.java
@@ -44,33 +44,33 @@ import waffle.windows.auth.impl.WindowsAccountImpl;
  */
 public class WindowsAuthenticationProviderTests {
 
-    private WindowsAuthenticationProvider _provider;
+    private WindowsAuthenticationProvider provider;
     private ApplicationContext            ctx;
 
     @Before
     public void setUp() {
         String[] configFiles = new String[] { "springTestAuthBeans.xml" };
-        ctx = new ClassPathXmlApplicationContext(configFiles);
-        _provider = (WindowsAuthenticationProvider) ctx.getBean("waffleSpringAuthenticationProvider");
+        this.ctx = new ClassPathXmlApplicationContext(configFiles);
+        this.provider = (WindowsAuthenticationProvider) this.ctx.getBean("waffleSpringAuthenticationProvider");
     }
 
     @After
     public void shutDown() {
-        ((AbstractApplicationContext) ctx).close();
+        ((AbstractApplicationContext) this.ctx).close();
     }
 
     @Test
     public void testWindowsAuthenticationProvider() {
-        assertTrue(_provider.isAllowGuestLogin());
-        assertTrue(_provider.getAuthProvider() instanceof MockWindowsAuthProvider);
-        assertEquals(PrincipalFormat.sid, _provider.getPrincipalFormat());
-        assertEquals(PrincipalFormat.both, _provider.getRoleFormat());
+        assertTrue(this.provider.isAllowGuestLogin());
+        assertTrue(this.provider.getAuthProvider() instanceof MockWindowsAuthProvider);
+        assertEquals(PrincipalFormat.sid, this.provider.getPrincipalFormat());
+        assertEquals(PrincipalFormat.both, this.provider.getRoleFormat());
     }
 
     @Test
     public void testSupports() {
-        assertFalse(_provider.supports(this.getClass()));
-        assertTrue(_provider.supports(UsernamePasswordAuthenticationToken.class));
+        assertFalse(this.provider.supports(this.getClass()));
+        assertTrue(this.provider.supports(UsernamePasswordAuthenticationToken.class));
     }
 
     @Test
@@ -80,7 +80,7 @@ public class WindowsAuthenticationProviderTests {
         WindowsPrincipal principal = new WindowsPrincipal(mockIdentity);
         UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(principal,
                 "password");
-        Authentication authenticated = _provider.authenticate(authentication);
+        Authentication authenticated = this.provider.authenticate(authentication);
         assertNotNull(authenticated);
         assertTrue(authenticated.isAuthenticated());
         Collection<? extends GrantedAuthority> authorities = authenticated.getAuthorities();
@@ -94,8 +94,8 @@ public class WindowsAuthenticationProviderTests {
 
     @Test
     public void testAuthenticateWithCustomGrantedAuthorityFactory() {
-        _provider.setDefaultGrantedAuthority(null);
-        _provider.setGrantedAuthorityFactory(new FqnGrantedAuthorityFactory(null, false));
+        this.provider.setDefaultGrantedAuthority(null);
+        this.provider.setGrantedAuthorityFactory(new FqnGrantedAuthorityFactory(null, false));
 
         MockWindowsIdentity mockIdentity = new MockWindowsIdentity(WindowsAccountImpl.getCurrentUsername(),
                 new ArrayList<String>());
@@ -103,7 +103,7 @@ public class WindowsAuthenticationProviderTests {
         UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(principal,
                 "password");
 
-        Authentication authenticated = _provider.authenticate(authentication);
+        Authentication authenticated = this.provider.authenticate(authentication);
         assertNotNull(authenticated);
         assertTrue(authenticated.isAuthenticated());
         Collection<? extends GrantedAuthority> authorities = authenticated.getAuthorities();
@@ -117,11 +117,11 @@ public class WindowsAuthenticationProviderTests {
     @Test(expected = GuestLoginDisabledAuthenticationException.class)
     public void testGuestIsDisabled() {
         MockWindowsIdentity mockIdentity = new MockWindowsIdentity("Guest", new ArrayList<String>());
-        _provider.setAllowGuestLogin(false);
+        this.provider.setAllowGuestLogin(false);
         WindowsPrincipal principal = new WindowsPrincipal(mockIdentity);
         UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(principal,
                 "password");
-        _provider.authenticate(authentication);
+        this.provider.authenticate(authentication);
         fail("expected AuthenticationServiceException");
     }
 }

--- a/Source/JNA/waffle-spring-security3/src/test/java/waffle/spring/WindowsAuthenticationTokenTests.java
+++ b/Source/JNA/waffle-spring-security3/src/test/java/waffle/spring/WindowsAuthenticationTokenTests.java
@@ -34,8 +34,8 @@ import waffle.servlet.WindowsPrincipal;
  */
 public class WindowsAuthenticationTokenTests {
 
-    private WindowsPrincipal           _principal;
-    private WindowsAuthenticationToken _token;
+    private WindowsPrincipal           principal;
+    private WindowsAuthenticationToken token;
 
     @Before
     public void setUp() {
@@ -43,30 +43,30 @@ public class WindowsAuthenticationTokenTests {
         mockGroups.add("group1");
         mockGroups.add("group2");
         MockWindowsIdentity mockIdentity = new MockWindowsIdentity("localhost\\user1", mockGroups);
-        _principal = new WindowsPrincipal(mockIdentity);
-        _token = new WindowsAuthenticationToken(_principal);
+        this.principal = new WindowsPrincipal(mockIdentity);
+        this.token = new WindowsAuthenticationToken(this.principal);
     }
 
     @Test
     public void testWindowsAuthenticationToken() {
-        assertNull(_token.getCredentials());
-        assertNull(_token.getDetails());
-        assertTrue(_token.isAuthenticated());
-        assertEquals("localhost\\user1", _token.getName());
-        Collection<GrantedAuthority> authorities = _token.getAuthorities();
+        assertNull(this.token.getCredentials());
+        assertNull(this.token.getDetails());
+        assertTrue(this.token.isAuthenticated());
+        assertEquals("localhost\\user1", this.token.getName());
+        Collection<GrantedAuthority> authorities = this.token.getAuthorities();
         Iterator<GrantedAuthority> authoritiesIterator = authorities.iterator();
         assertEquals(3, authorities.size());
         assertEquals("ROLE_USER", authoritiesIterator.next().getAuthority());
         assertEquals("ROLE_GROUP1", authoritiesIterator.next().getAuthority());
         assertEquals("ROLE_GROUP2", authoritiesIterator.next().getAuthority());
-        assertEquals(_principal, _token.getPrincipal());
+        assertEquals(this.principal, this.token.getPrincipal());
     }
 
     @Test
     public void testCustomGrantedAuthorityFactory() {
 
-        WindowsAuthenticationToken token = new WindowsAuthenticationToken(_principal, new FqnGrantedAuthorityFactory(
-                null, false), null);
+        WindowsAuthenticationToken token = new WindowsAuthenticationToken(this.principal,
+                new FqnGrantedAuthorityFactory(null, false), null);
 
         assertNull(token.getCredentials());
         assertNull(token.getDetails());
@@ -77,12 +77,12 @@ public class WindowsAuthenticationTokenTests {
         assertEquals(2, authorities.size());
         assertEquals("group1", authoritiesIterator.next().getAuthority());
         assertEquals("group2", authoritiesIterator.next().getAuthority());
-        assertEquals(_principal, token.getPrincipal());
+        assertEquals(this.principal, token.getPrincipal());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testAuthenticated() {
-        assertTrue(_token.isAuthenticated());
-        _token.setAuthenticated(true);
+        assertTrue(this.token.isAuthenticated());
+        this.token.setAuthenticated(true);
     }
 }

--- a/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/FqnGrantedAuthorityFactory.java
+++ b/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/FqnGrantedAuthorityFactory.java
@@ -28,12 +28,12 @@ import waffle.windows.auth.WindowsAccount;
  */
 public class FqnGrantedAuthorityFactory implements GrantedAuthorityFactory {
 
-    private final String  _prefix;
-    private final boolean _convertToUpperCase;
+    private final String  prefix;
+    private final boolean convertToUpperCase;
 
     public FqnGrantedAuthorityFactory(String prefix, boolean convertToUpperCase) {
-        _prefix = prefix;
-        _convertToUpperCase = convertToUpperCase;
+        this.prefix = prefix;
+        this.convertToUpperCase = convertToUpperCase;
     }
 
     @Override
@@ -41,11 +41,11 @@ public class FqnGrantedAuthorityFactory implements GrantedAuthorityFactory {
 
         String grantedAuthorityString = windowsAccount.getFqn();
 
-        if (_prefix != null) {
-            grantedAuthorityString = _prefix + grantedAuthorityString;
+        if (this.prefix != null) {
+            grantedAuthorityString = this.prefix + grantedAuthorityString;
         }
 
-        if (_convertToUpperCase) {
+        if (this.convertToUpperCase) {
             grantedAuthorityString = grantedAuthorityString.toUpperCase();
         }
 

--- a/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/NegotiateSecurityFilterEntryPoint.java
+++ b/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/NegotiateSecurityFilterEntryPoint.java
@@ -33,34 +33,34 @@ import waffle.servlet.spi.SecurityFilterProviderCollection;
  */
 public class NegotiateSecurityFilterEntryPoint implements AuthenticationEntryPoint {
 
-    private static final Logger              _log = LoggerFactory.getLogger(NegotiateSecurityFilterEntryPoint.class);
-    private SecurityFilterProviderCollection _provider;
+    private static final Logger              LOGGER = LoggerFactory.getLogger(NegotiateSecurityFilterEntryPoint.class);
+    private SecurityFilterProviderCollection provider;
 
     public NegotiateSecurityFilterEntryPoint() {
-        _log.debug("[waffle.spring.NegotiateEntryPoint] loaded");
+        LOGGER.debug("[waffle.spring.NegotiateEntryPoint] loaded");
     }
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException ex)
             throws IOException, ServletException {
 
-        _log.debug("[waffle.spring.NegotiateEntryPoint] commence");
+        LOGGER.debug("[waffle.spring.NegotiateEntryPoint] commence");
 
-        if (_provider == null) {
+        if (this.provider == null) {
             throw new ServletException("Missing NegotiateEntryPoint.Provider");
         }
 
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setHeader("Connection", "keep-alive");
-        _provider.sendUnauthorized(response);
+        this.provider.sendUnauthorized(response);
         response.flushBuffer();
     }
 
     public SecurityFilterProviderCollection getProvider() {
-        return _provider;
+        return this.provider;
     }
 
-    public void setProvider(SecurityFilterProviderCollection provider) {
-        _provider = provider;
+    public void setProvider(SecurityFilterProviderCollection value) {
+        this.provider = value;
     }
 }

--- a/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/WindowsAuthenticationProvider.java
+++ b/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/WindowsAuthenticationProvider.java
@@ -32,37 +32,38 @@ import waffle.windows.auth.PrincipalFormat;
  */
 public class WindowsAuthenticationProvider implements AuthenticationProvider {
 
-    private static final Logger     _log                     = LoggerFactory
-                                                                     .getLogger(WindowsAuthenticationProvider.class);
-    private PrincipalFormat         _principalFormat         = PrincipalFormat.fqn;
-    private PrincipalFormat         _roleFormat              = PrincipalFormat.fqn;
-    private boolean                 _allowGuestLogin         = true;
-    private IWindowsAuthProvider    _authProvider;
-    private GrantedAuthorityFactory _grantedAuthorityFactory = WindowsAuthenticationToken.DEFAULT_GRANTED_AUTHORITY_FACTORY;
-    private GrantedAuthority        _defaultGrantedAuthority = WindowsAuthenticationToken.DEFAULT_GRANTED_AUTHORITY;
+    private static final Logger     LOGGER                  = LoggerFactory
+                                                                    .getLogger(WindowsAuthenticationProvider.class);
+    private PrincipalFormat         principalFormat         = PrincipalFormat.fqn;
+    private PrincipalFormat         roleFormat              = PrincipalFormat.fqn;
+    private boolean                 allowGuestLogin         = true;
+    private IWindowsAuthProvider    authProvider;
+    private GrantedAuthorityFactory grantedAuthorityFactory = WindowsAuthenticationToken.DEFAULT_GRANTED_AUTHORITY_FACTORY;
+    private GrantedAuthority        defaultGrantedAuthority = WindowsAuthenticationToken.DEFAULT_GRANTED_AUTHORITY;
 
     public WindowsAuthenticationProvider() {
-        _log.debug("[waffle.spring.WindowsAuthenticationProvider] loaded");
+        LOGGER.debug("[waffle.spring.WindowsAuthenticationProvider] loaded");
     }
 
     @Override
     public Authentication authenticate(Authentication authentication) {
         UsernamePasswordAuthenticationToken auth = (UsernamePasswordAuthenticationToken) authentication;
-        IWindowsIdentity windowsIdentity = _authProvider.logonUser(auth.getName(), auth.getCredentials().toString());
-        _log.debug("logged in user: {} ({})", windowsIdentity.getFqn(), windowsIdentity.getSidString());
+        IWindowsIdentity windowsIdentity = this.authProvider
+                .logonUser(auth.getName(), auth.getCredentials().toString());
+        LOGGER.debug("logged in user: {} ({})", windowsIdentity.getFqn(), windowsIdentity.getSidString());
 
-        if (!_allowGuestLogin && windowsIdentity.isGuest()) {
-            _log.warn("guest login disabled: {}", windowsIdentity.getFqn());
+        if (!this.allowGuestLogin && windowsIdentity.isGuest()) {
+            LOGGER.warn("guest login disabled: {}", windowsIdentity.getFqn());
             throw new GuestLoginDisabledAuthenticationException(windowsIdentity.getFqn());
         }
 
-        WindowsPrincipal windowsPrincipal = new WindowsPrincipal(windowsIdentity, _principalFormat, _roleFormat);
-        _log.debug("roles: {}", windowsPrincipal.getRolesString());
+        WindowsPrincipal windowsPrincipal = new WindowsPrincipal(windowsIdentity, this.principalFormat, this.roleFormat);
+        LOGGER.debug("roles: {}", windowsPrincipal.getRolesString());
 
-        WindowsAuthenticationToken token = new WindowsAuthenticationToken(windowsPrincipal, _grantedAuthorityFactory,
-                _defaultGrantedAuthority);
+        WindowsAuthenticationToken token = new WindowsAuthenticationToken(windowsPrincipal,
+                this.grantedAuthorityFactory, this.defaultGrantedAuthority);
 
-        _log.info("successfully logged in user: {}", windowsIdentity.getFqn());
+        LOGGER.info("successfully logged in user: {}", windowsIdentity.getFqn());
         return token;
     }
 
@@ -72,50 +73,50 @@ public class WindowsAuthenticationProvider implements AuthenticationProvider {
     }
 
     public PrincipalFormat getPrincipalFormat() {
-        return _principalFormat;
+        return this.principalFormat;
     }
 
-    public void setPrincipalFormat(PrincipalFormat principalFormat) {
-        _principalFormat = principalFormat;
+    public void setPrincipalFormat(PrincipalFormat value) {
+        this.principalFormat = value;
     }
 
     public PrincipalFormat getRoleFormat() {
-        return _roleFormat;
+        return this.roleFormat;
     }
 
-    public void setRoleFormat(PrincipalFormat principalFormat) {
-        _roleFormat = principalFormat;
+    public void setRoleFormat(PrincipalFormat value) {
+        this.roleFormat = value;
     }
 
     public boolean isAllowGuestLogin() {
-        return _allowGuestLogin;
+        return this.allowGuestLogin;
     }
 
-    public void setAllowGuestLogin(boolean allowGuestLogin) {
-        _allowGuestLogin = allowGuestLogin;
+    public void setAllowGuestLogin(boolean value) {
+        this.allowGuestLogin = value;
     }
 
     public IWindowsAuthProvider getAuthProvider() {
-        return _authProvider;
+        return this.authProvider;
     }
 
-    public void setAuthProvider(IWindowsAuthProvider authProvider) {
-        _authProvider = authProvider;
+    public void setAuthProvider(IWindowsAuthProvider value) {
+        this.authProvider = value;
     }
 
     public GrantedAuthorityFactory getGrantedAuthorityFactory() {
-        return _grantedAuthorityFactory;
+        return this.grantedAuthorityFactory;
     }
 
-    public void setGrantedAuthorityFactory(GrantedAuthorityFactory grantedAuthorityFactory) {
-        _grantedAuthorityFactory = grantedAuthorityFactory;
+    public void setGrantedAuthorityFactory(GrantedAuthorityFactory value) {
+        this.grantedAuthorityFactory = value;
     }
 
     public GrantedAuthority getDefaultGrantedAuthority() {
-        return _defaultGrantedAuthority;
+        return this.defaultGrantedAuthority;
     }
 
-    public void setDefaultGrantedAuthority(GrantedAuthority defaultGrantedAuthority) {
-        _defaultGrantedAuthority = defaultGrantedAuthority;
+    public void setDefaultGrantedAuthority(GrantedAuthority value) {
+        this.defaultGrantedAuthority = value;
     }
 }

--- a/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/WindowsAuthenticationToken.java
+++ b/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/WindowsAuthenticationToken.java
@@ -30,6 +30,8 @@ import waffle.windows.auth.WindowsAccount;
  */
 public class WindowsAuthenticationToken implements Authentication {
 
+    private static final long                   serialVersionUID                  = 1L;
+
     /**
      * The {@link GrantedAuthorityFactory} that is used by default if a custom one is not specified. This default
      * {@link GrantedAuthorityFactory} is a {@link FqnGrantedAuthorityFactory} with prefix {@code "ROLE_"} and will
@@ -45,9 +47,8 @@ public class WindowsAuthenticationToken implements Authentication {
     public static final GrantedAuthority        DEFAULT_GRANTED_AUTHORITY         = new SimpleGrantedAuthority(
                                                                                           "ROLE_USER");
 
-    private static final long                   serialVersionUID                  = 1L;
-    private WindowsPrincipal                    _principal;
-    private Collection<GrantedAuthority>        _authorities;
+    private WindowsPrincipal                    principal;
+    private Collection<GrantedAuthority>        authorities;
 
     /**
      * Convenience constructor that calls
@@ -74,19 +75,19 @@ public class WindowsAuthenticationToken implements Authentication {
     public WindowsAuthenticationToken(WindowsPrincipal identity, GrantedAuthorityFactory grantedAuthorityFactory,
             GrantedAuthority defaultGrantedAuthority) {
 
-        _principal = identity;
-        _authorities = new ArrayList<GrantedAuthority>();
+        this.principal = identity;
+        this.authorities = new ArrayList<GrantedAuthority>();
         if (defaultGrantedAuthority != null) {
-            _authorities.add(defaultGrantedAuthority);
+            this.authorities.add(defaultGrantedAuthority);
         }
-        for (WindowsAccount group : _principal.getGroups().values()) {
-            _authorities.add(grantedAuthorityFactory.createGrantedAuthority(group));
+        for (WindowsAccount group : this.principal.getGroups().values()) {
+            this.authorities.add(grantedAuthorityFactory.createGrantedAuthority(group));
         }
     }
 
     @Override
     public Collection<GrantedAuthority> getAuthorities() {
-        return _authorities;
+        return this.authorities;
     }
 
     @Override
@@ -101,12 +102,12 @@ public class WindowsAuthenticationToken implements Authentication {
 
     @Override
     public Object getPrincipal() {
-        return _principal;
+        return this.principal;
     }
 
     @Override
     public boolean isAuthenticated() {
-        return _principal != null;
+        return this.principal != null;
     }
 
     @Override
@@ -116,6 +117,6 @@ public class WindowsAuthenticationToken implements Authentication {
 
     @Override
     public String getName() {
-        return _principal.getName();
+        return this.principal.getName();
     }
 }

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsAccount.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsAccount.java
@@ -23,44 +23,44 @@ public class MockWindowsAccount implements IWindowsAccount {
     public static final String TEST_USER_NAME = "WaffleTestUser";
     public static final String TEST_PASSWORD  = "!WAFFLEP$$Wrd0";
 
-    private String             _fqn;
-    private String             _name;
-    private String             _domain;
-    private String             _sid;
+    private String             fqn;
+    private String             name;
+    private String             domain;
+    private String             sid;
 
     public MockWindowsAccount(String fqn) {
         this(fqn, "S-" + fqn.hashCode());
     }
 
     public MockWindowsAccount(String fqn, String sid) {
-        _fqn = fqn;
-        _sid = sid;
+        this.fqn = fqn;
+        this.sid = sid;
         String[] userNameDomain = fqn.split("\\\\", 2);
         if (userNameDomain.length == 2) {
-            _name = userNameDomain[1];
-            _domain = userNameDomain[0];
+            this.name = userNameDomain[1];
+            this.domain = userNameDomain[0];
         } else {
-            _name = fqn;
+            this.name = fqn;
         }
     }
 
     @Override
     public String getDomain() {
-        return _domain;
+        return this.domain;
     }
 
     @Override
     public String getFqn() {
-        return _fqn;
+        return this.fqn;
     }
 
     @Override
     public String getName() {
-        return _name;
+        return this.name;
     }
 
     @Override
     public String getSidString() {
-        return _sid;
+        return this.sid;
     }
 }

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsAuthProvider.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsAuthProvider.java
@@ -31,15 +31,15 @@ import waffle.windows.auth.IWindowsSecurityContext;
  */
 public class MockWindowsAuthProvider implements IWindowsAuthProvider {
 
-    private List<String> _groups = new ArrayList<String>();
+    private List<String> groups = new ArrayList<String>();
 
     public MockWindowsAuthProvider() {
-        _groups.add("Users");
-        _groups.add("Everyone");
+        this.groups.add("Users");
+        this.groups.add("Everyone");
     }
 
     public void addGroup(String name) {
-        _groups.add(name);
+        this.groups.add(name);
     }
 
     @Override
@@ -76,9 +76,9 @@ public class MockWindowsAuthProvider implements IWindowsAuthProvider {
     public IWindowsIdentity logonUser(String username, String password) {
         String currentUsername = Secur32Util.getUserNameEx(EXTENDED_NAME_FORMAT.NameSamCompatible);
         if (username.equals(currentUsername)) {
-            return new MockWindowsIdentity(currentUsername, _groups);
+            return new MockWindowsIdentity(currentUsername, this.groups);
         } else if (username.equals("Guest")) {
-            return new MockWindowsIdentity("Guest", _groups);
+            return new MockWindowsIdentity("Guest", this.groups);
         } else {
             throw new RuntimeException("Mock error: " + username);
         }

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsIdentity.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsIdentity.java
@@ -27,23 +27,23 @@ import waffle.windows.auth.IWindowsImpersonationContext;
  */
 public class MockWindowsIdentity implements IWindowsIdentity {
 
-    private String       _fqn;
-    private List<String> _groups;
+    private String       fqn;
+    private List<String> groups;
 
     public MockWindowsIdentity(String fqn, List<String> groups) {
-        _fqn = fqn;
-        _groups = groups;
+        this.fqn = fqn;
+        this.groups = groups;
     }
 
     @Override
     public String getFqn() {
-        return _fqn;
+        return this.fqn;
     }
 
     @Override
     public IWindowsAccount[] getGroups() {
         List<MockWindowsAccount> groups = new ArrayList<MockWindowsAccount>();
-        for (String group : _groups) {
+        for (String group : this.groups) {
             groups.add(new MockWindowsAccount(group));
         }
         return groups.toArray(new IWindowsAccount[0]);
@@ -56,7 +56,7 @@ public class MockWindowsIdentity implements IWindowsIdentity {
 
     @Override
     public String getSidString() {
-        return "S-" + _fqn.hashCode();
+        return "S-" + this.fqn.hashCode();
     }
 
     @Override
@@ -66,7 +66,7 @@ public class MockWindowsIdentity implements IWindowsIdentity {
 
     @Override
     public boolean isGuest() {
-        return _fqn.equals("Guest");
+        return this.fqn.equals("Guest");
     }
 
     @Override

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsSecurityContext.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsSecurityContext.java
@@ -28,13 +28,13 @@ import com.sun.jna.platform.win32.Sspi.SecBufferDesc;
  */
 public class MockWindowsSecurityContext implements IWindowsSecurityContext {
 
-    private IWindowsIdentity _identity;
+    private IWindowsIdentity identity;
 
     public MockWindowsSecurityContext(String username) {
         List<String> groups = new ArrayList<String>();
         groups.add("Users");
         groups.add("Everyone");
-        _identity = new MockWindowsIdentity(username, groups);
+        this.identity = new MockWindowsIdentity(username, groups);
     }
 
     @Override
@@ -54,12 +54,12 @@ public class MockWindowsSecurityContext implements IWindowsSecurityContext {
 
     @Override
     public IWindowsIdentity getIdentity() {
-        return _identity;
+        return this.identity;
     }
 
     @Override
     public String getPrincipalName() {
-        return _identity.getFqn();
+        return this.identity.getFqn();
     }
 
     @Override

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleFilterChain.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleFilterChain.java
@@ -27,21 +27,21 @@ import javax.servlet.ServletResponse;
  */
 public class SimpleFilterChain implements FilterChain {
 
-    private ServletRequest  _request;
-    private ServletResponse _response;
+    private ServletRequest  request;
+    private ServletResponse response;
 
     public ServletRequest getRequest() {
-        return _request;
+        return this.request;
     }
 
     public ServletResponse getResponse() {
-        return _response;
+        return this.response;
     }
 
     @Override
     public void doFilter(ServletRequest sreq, ServletResponse srep) throws IOException, ServletException {
 
-        _request = sreq;
-        _response = srep;
+        this.request = sreq;
+        this.response = srep;
     }
 }

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleFilterConfig.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleFilterConfig.java
@@ -28,27 +28,27 @@ import javax.servlet.ServletContext;
  */
 public class SimpleFilterConfig implements FilterConfig {
 
-    private String              _filterName = "Simple Filter";
-    private Map<String, String> _parameters = new TreeMap<String, String>();
+    private String              filterName = "Simple Filter";
+    private Map<String, String> parameters = new TreeMap<String, String>();
 
     @Override
     public String getFilterName() {
-        return _filterName;
+        return this.filterName;
     }
 
-    public void setFilterName(String filterName) {
-        _filterName = filterName;
+    public void setFilterName(String value) {
+        this.filterName = value;
     }
 
     @Override
     public String getInitParameter(String s) {
-        return _parameters.get(s);
+        return this.parameters.get(s);
     }
 
     @Override
     public Enumeration<String> getInitParameterNames() {
         List<String> keys = new ArrayList<String>();
-        keys.addAll(_parameters.keySet());
+        keys.addAll(this.parameters.keySet());
         return Collections.enumeration(keys);
     }
 
@@ -58,6 +58,6 @@ public class SimpleFilterConfig implements FilterConfig {
     }
 
     public void setParameter(String parameterName, String parameterValue) {
-        _parameters.put(parameterName, parameterValue);
+        this.parameters.put(parameterName, parameterValue);
     }
 }

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleHttpRequest.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleHttpRequest.java
@@ -31,102 +31,102 @@ import com.google.common.collect.Iterators;
  */
 public class SimpleHttpRequest extends HttpServletRequestWrapper {
 
-    private static int          _remotePort_s = 0;
+    private static int          remotePortS = 0;
 
-    private String              _requestURI;
-    private String              _queryString;
-    private String              _remoteUser;
-    private String              _method       = "GET";
-    private String              _remoteHost;
-    private String              _remoteAddr;
-    private int                 _remotePort   = -1;
-    private Map<String, String> _headers      = new HashMap<String, String>();
-    private Map<String, String> _parameters   = new HashMap<String, String>();
-    private byte[]              _content;
-    private HttpSession         _session      = new SimpleHttpSession();
-    private Principal           _principal;
+    private String              requestURI;
+    private String              queryString;
+    private String              remoteUser;
+    private String              method      = "GET";
+    private String              remoteHost;
+    private String              remoteAddr;
+    private int                 remotePort  = -1;
+    private Map<String, String> headers     = new HashMap<String, String>();
+    private Map<String, String> parameters  = new HashMap<String, String>();
+    private byte[]              content;
+    private HttpSession         session     = new SimpleHttpSession();
+    private Principal           principal;
 
     public SimpleHttpRequest() {
         super(Mockito.mock(HttpServletRequest.class));
-        _remotePort = nextRemotePort();
+        this.remotePort = nextRemotePort();
     }
 
     public static synchronized int nextRemotePort() {
-        return ++_remotePort_s;
+        return ++remotePortS;
     }
 
     public static synchronized void resetRemotePort() {
-        _remotePort_s = 0;
+        remotePortS = 0;
     }
 
     public void addHeader(String headerName, String headerValue) {
-        _headers.put(headerName, headerValue);
+        this.headers.put(headerName, headerValue);
     }
 
     @Override
     public String getHeader(String headerName) {
-        return _headers.get(headerName);
+        return this.headers.get(headerName);
     }
 
     @Override
     public Enumeration<String> getHeaderNames() {
-        return Iterators.asEnumeration(_headers.keySet().iterator());
+        return Iterators.asEnumeration(this.headers.keySet().iterator());
     }
 
     @Override
     public String getMethod() {
-        return _method;
+        return this.method;
     }
 
     @Override
     public int getContentLength() {
-        return _content == null ? -1 : _content.length;
+        return this.content == null ? -1 : this.content.length;
     }
 
     @Override
     public int getRemotePort() {
-        return _remotePort;
+        return this.remotePort;
     }
 
     public void setMethod(String methodName) {
-        _method = methodName;
+        this.method = methodName;
     }
 
     public void setContentLength(int length) {
-        _content = new byte[length];
+        this.content = new byte[length];
     }
 
     public void setRemoteUser(String username) {
-        _remoteUser = username;
+        this.remoteUser = username;
     }
 
     @Override
     public String getRemoteUser() {
-        return _remoteUser;
+        return this.remoteUser;
     }
 
     @Override
     public HttpSession getSession() {
-        return _session;
+        return this.session;
     }
 
     @Override
     public HttpSession getSession(boolean create) {
-        if (_session == null && create) {
-            _session = new SimpleHttpSession();
+        if (this.session == null && create) {
+            this.session = new SimpleHttpSession();
         }
-        return _session;
+        return this.session;
     }
 
     @Override
     public String getQueryString() {
-        return _queryString;
+        return this.queryString;
     }
 
-    public void setQueryString(String queryString) {
-        _queryString = queryString;
-        if (_queryString != null) {
-            for (String eachParameter : _queryString.split("[&]")) {
+    public void setQueryString(String query) {
+        this.queryString = query;
+        if (this.queryString != null) {
+            for (String eachParameter : this.queryString.split("[&]")) {
                 String[] pair = eachParameter.split("=");
                 String value = (pair.length == 2) ? pair[1] : "";
                 addParameter(pair[0], value);
@@ -135,47 +135,47 @@ public class SimpleHttpRequest extends HttpServletRequestWrapper {
     }
 
     public void setRequestURI(String uri) {
-        _requestURI = uri;
+        this.requestURI = uri;
     }
 
     @Override
     public String getRequestURI() {
-        return _requestURI;
+        return this.requestURI;
     }
 
     @Override
     public String getParameter(String parameterName) {
-        return _parameters.get(parameterName);
+        return this.parameters.get(parameterName);
     }
 
     public void addParameter(String parameterName, String parameterValue) {
-        _parameters.put(parameterName, parameterValue);
+        this.parameters.put(parameterName, parameterValue);
     }
 
     @Override
     public String getRemoteHost() {
-        return _remoteHost;
+        return this.remoteHost;
     }
 
-    public void setRemoteHost(String remoteHost) {
-        _remoteHost = remoteHost;
+    public void setRemoteHost(String value) {
+        this.remoteHost = value;
     }
 
     @Override
     public String getRemoteAddr() {
-        return _remoteAddr;
+        return this.remoteAddr;
     }
 
-    public void setRemoteAddr(String remoteAddr) {
-        _remoteAddr = remoteAddr;
+    public void setRemoteAddr(String value) {
+        this.remoteAddr = value;
     }
 
     @Override
     public Principal getUserPrincipal() {
-        return _principal;
+        return this.principal;
     }
 
-    public void setUserPrincipal(Principal principal) {
-        _principal = principal;
+    public void setUserPrincipal(Principal value) {
+        this.principal = value;
     }
 }

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleHttpResponse.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleHttpResponse.java
@@ -34,59 +34,59 @@ import org.slf4j.LoggerFactory;
  */
 public class SimpleHttpResponse extends HttpServletResponseWrapper {
 
-    private static final Logger         _log     = LoggerFactory.getLogger(SimpleHttpResponse.class);
+    private static final Logger       LOGGER  = LoggerFactory.getLogger(SimpleHttpResponse.class);
 
-    private int                         _status  = 500;
-    private Map<String, List<String>>   _headers = new HashMap<String, List<String>>();
+    private int                       status  = 500;
+    private Map<String, List<String>> headers = new HashMap<String, List<String>>();
 
-    private final ByteArrayOutputStream bytes    = new ByteArrayOutputStream();
+    final ByteArrayOutputStream       bytes   = new ByteArrayOutputStream();
 
-    private final ServletOutputStream   out      = new ServletOutputStream() {
-                                                     @Override
-                                                     public void write(int b) throws IOException {
-                                                         bytes.write(b);
-                                                     }
-                                                 };
+    private final ServletOutputStream out     = new ServletOutputStream() {
+                                                  @Override
+                                                  public void write(int b) throws IOException {
+                                                      SimpleHttpResponse.this.bytes.write(b);
+                                                  }
+                                              };
 
-    private final PrintWriter           writer   = new PrintWriter(bytes);
+    private final PrintWriter         writer  = new PrintWriter(this.bytes);
 
     public SimpleHttpResponse() {
         super(Mockito.mock(HttpServletResponse.class));
     }
 
     public int getStatus() {
-        return _status;
+        return this.status;
     }
 
     @Override
     public void addHeader(String headerName, String headerValue) {
-        List<String> current = _headers.get(headerName);
+        List<String> current = this.headers.get(headerName);
         if (current == null) {
             current = new ArrayList<String>();
         }
         current.add(headerValue);
-        _headers.put(headerName, current);
+        this.headers.put(headerName, current);
     }
 
     @Override
     public void setHeader(String headerName, String headerValue) {
-        List<String> current = _headers.get(headerName);
+        List<String> current = this.headers.get(headerName);
         if (current == null) {
             current = new ArrayList<String>();
         } else {
             current.clear();
         }
         current.add(headerValue);
-        _headers.put(headerName, current);
+        this.headers.put(headerName, current);
     }
 
     @Override
     public void setStatus(int value) {
-        _status = value;
+        this.status = value;
     }
 
     public String getStatusString() {
-        if (_status == 401) {
+        if (this.status == 401) {
             return "Unauthorized";
         }
         return "Unknown";
@@ -94,10 +94,10 @@ public class SimpleHttpResponse extends HttpServletResponseWrapper {
 
     @Override
     public void flushBuffer() {
-        _log.info("{}: {}", Integer.valueOf(_status), getStatusString());
-        for (String header : _headers.keySet()) {
-            for (String headerValue : _headers.get(header)) {
-                _log.info("{}: {}", header, headerValue);
+        LOGGER.info("{}: {}", Integer.valueOf(this.status), getStatusString());
+        for (String header : this.headers.keySet()) {
+            for (String headerValue : this.headers.get(header)) {
+                LOGGER.info("{}: {}", header, headerValue);
             }
         }
     }
@@ -106,16 +106,16 @@ public class SimpleHttpResponse extends HttpServletResponseWrapper {
      * Use this for testing the number of headers
      */
     public int getHeaderNamesSize() {
-        return _headers.size();
+        return this.headers.size();
     }
 
     public String[] getHeaderValues(String headerName) {
-        List<String> headerValues = _headers.get(headerName);
+        List<String> headerValues = this.headers.get(headerName);
         return headerValues == null ? null : headerValues.toArray(new String[0]);
     }
 
     public String getHeader(String headerName) {
-        List<String> headerValues = _headers.get(headerName);
+        List<String> headerValues = this.headers.get(headerName);
         if (headerValues == null) {
             return null;
         }
@@ -131,26 +131,26 @@ public class SimpleHttpResponse extends HttpServletResponseWrapper {
 
     @Override
     public void sendError(int rc, String message) {
-        _status = rc;
+        this.status = rc;
     }
 
     @Override
     public void sendError(int rc) {
-        _status = rc;
+        this.status = rc;
     }
 
     @Override
     public PrintWriter getWriter() {
-        return writer;
+        return this.writer;
     }
 
     @Override
     public ServletOutputStream getOutputStream() throws IOException {
-        return out;
+        return this.out;
     }
 
     public String getOutputText() {
-        writer.flush();
-        return bytes.toString();
+        this.writer.flush();
+        return this.bytes.toString();
     }
 }

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleHttpSession.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleHttpSession.java
@@ -29,11 +29,11 @@ import javax.servlet.http.HttpSessionContext;
 @SuppressWarnings("deprecation")
 public class SimpleHttpSession implements HttpSession {
 
-    private Map<String, Object> _attributes = new HashMap<String, Object>();
+    private Map<String, Object> attributes = new HashMap<String, Object>();
 
     @Override
     public Object getAttribute(String attributeName) {
-        return _attributes.get(attributeName);
+        return this.attributes.get(attributeName);
     }
 
     @Override
@@ -66,16 +66,19 @@ public class SimpleHttpSession implements HttpSession {
         return null;
     }
 
+    @Deprecated
     @Override
     public HttpSessionContext getSessionContext() {
         return null;
     }
 
+    @Deprecated
     @Override
     public Object getValue(String arg0) {
         return null;
     }
 
+    @Deprecated
     @Override
     public String[] getValueNames() {
         return new String[0];
@@ -91,6 +94,7 @@ public class SimpleHttpSession implements HttpSession {
         return false;
     }
 
+    @Deprecated
     @Override
     public void putValue(String arg0, Object arg1) {
         // Do Nothing
@@ -98,9 +102,10 @@ public class SimpleHttpSession implements HttpSession {
 
     @Override
     public void removeAttribute(String attributeName) {
-        _attributes.remove(attributeName);
+        this.attributes.remove(attributeName);
     }
 
+    @Deprecated
     @Override
     public void removeValue(String arg0) {
         // Do Nothing
@@ -108,7 +113,7 @@ public class SimpleHttpSession implements HttpSession {
 
     @Override
     public void setAttribute(String attributeName, Object attributeValue) {
-        _attributes.put(attributeName, attributeValue);
+        this.attributes.put(attributeName, attributeValue);
     }
 
     @Override

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleRequestDispatcher.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleRequestDispatcher.java
@@ -26,17 +26,17 @@ import javax.servlet.http.HttpServletResponse;
  */
 public class SimpleRequestDispatcher implements RequestDispatcher {
 
-    private String _url;
+    private String url;
 
     public SimpleRequestDispatcher(String url) {
-        _url = url;
+        this.url = url;
     }
 
     @Override
     public void forward(ServletRequest request, ServletResponse response) throws ServletException, IOException {
         HttpServletResponse httpResponse = (HttpServletResponse) response;
         httpResponse.setStatus(304);
-        httpResponse.addHeader("Location", _url);
+        httpResponse.addHeader("Location", this.url);
     }
 
     @Override

--- a/Source/JNA/waffle-tests/src/test/java/waffle/jaas/WindowsLoginModuleTests.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/jaas/WindowsLoginModuleTests.java
@@ -39,14 +39,14 @@ import waffle.windows.auth.impl.WindowsAccountImpl;
  * @author dblock[at]dblock[dot]org
  */
 public class WindowsLoginModuleTests {
-    WindowsLoginModule      _loginModule;
-    MockWindowsAuthProvider _provider;
+    WindowsLoginModule      loginModule;
+    MockWindowsAuthProvider provider;
 
     @Before
     public void setUp() {
-        _provider = new MockWindowsAuthProvider();
-        _loginModule = new WindowsLoginModule();
-        _loginModule.setAuth(_provider);
+        this.provider = new MockWindowsAuthProvider();
+        this.loginModule = new WindowsLoginModule();
+        this.loginModule.setAuth(this.provider);
     }
 
     @Test
@@ -55,15 +55,15 @@ public class WindowsLoginModuleTests {
         UsernamePasswordCallbackHandler callbackHandler = new UsernamePasswordCallbackHandler("", "");
         Map<String, String> options = new HashMap<String, String>();
         options.put("debug", "true");
-        _loginModule.initialize(subject, callbackHandler, null, options);
-        assertTrue(_loginModule.isDebug());
+        this.loginModule.initialize(subject, callbackHandler, null, options);
+        assertTrue(this.loginModule.isDebug());
     }
 
     @Test
     public void testGetSetAuth() {
-        assertNotNull(_loginModule.getAuth());
-        _loginModule.setAuth(null);
-        assertNull(_loginModule.getAuth());
+        assertNotNull(this.loginModule.getAuth());
+        this.loginModule.setAuth(null);
+        assertNull(this.loginModule.getAuth());
     }
 
     @Test
@@ -73,15 +73,15 @@ public class WindowsLoginModuleTests {
                 WindowsAccountImpl.getCurrentUsername(), "password");
         Map<String, String> options = new HashMap<String, String>();
         options.put("debug", "true");
-        _loginModule.initialize(subject, callbackHandler, null, options);
-        assertTrue(_loginModule.login());
+        this.loginModule.initialize(subject, callbackHandler, null, options);
+        assertTrue(this.loginModule.login());
         assertEquals(0, subject.getPrincipals().size());
-        assertTrue(_loginModule.commit());
+        assertTrue(this.loginModule.commit());
         assertEquals(3, subject.getPrincipals().size());
         assertTrue(subject.getPrincipals().contains(new RolePrincipal("Everyone")));
         assertTrue(subject.getPrincipals().contains(new RolePrincipal("Users")));
         assertTrue(subject.getPrincipals().contains(new UserPrincipal(WindowsAccountImpl.getCurrentUsername())));
-        assertTrue(_loginModule.logout());
+        assertTrue(this.loginModule.logout());
         assertSame(Integer.valueOf(subject.getPrincipals().size()), Integer.valueOf(0));
     }
 
@@ -89,8 +89,8 @@ public class WindowsLoginModuleTests {
     public void testNoCallbackHandler() throws LoginException {
         Subject subject = new Subject();
         Map<String, String> options = new HashMap<String, String>();
-        _loginModule.initialize(subject, null, null, options);
-        _loginModule.login();
+        this.loginModule.initialize(subject, null, null, options);
+        this.loginModule.login();
     }
 
     @Test(expected = LoginException.class)
@@ -99,8 +99,8 @@ public class WindowsLoginModuleTests {
         UsernamePasswordCallbackHandler callbackHandler = new UsernamePasswordCallbackHandler("", "");
         Map<String, String> options = new HashMap<String, String>();
         options.put("debug", "true");
-        _loginModule.initialize(subject, callbackHandler, null, options);
-        assertFalse(_loginModule.login());
+        this.loginModule.initialize(subject, callbackHandler, null, options);
+        assertFalse(this.loginModule.login());
         fail("Expected LoginException");
     }
 
@@ -112,9 +112,9 @@ public class WindowsLoginModuleTests {
         Map<String, String> options = new HashMap<String, String>();
         options.put("debug", "true");
         options.put("roleFormat", "none");
-        _loginModule.initialize(subject, callbackHandler, null, options);
-        assertTrue(_loginModule.login());
-        assertTrue(_loginModule.commit());
+        this.loginModule.initialize(subject, callbackHandler, null, options);
+        assertTrue(this.loginModule.login());
+        assertTrue(this.loginModule.commit());
         assertEquals(1, subject.getPrincipals().size());
     }
 
@@ -126,9 +126,9 @@ public class WindowsLoginModuleTests {
         Map<String, String> options = new HashMap<String, String>();
         options.put("debug", "true");
         options.put("roleFormat", "both");
-        _loginModule.initialize(subject, callbackHandler, null, options);
-        assertTrue(_loginModule.login());
-        assertTrue(_loginModule.commit());
+        this.loginModule.initialize(subject, callbackHandler, null, options);
+        assertTrue(this.loginModule.login());
+        assertTrue(this.loginModule.commit());
         assertEquals(5, subject.getPrincipals().size());
     }
 
@@ -141,9 +141,9 @@ public class WindowsLoginModuleTests {
         options.put("debug", "true");
         options.put("principalFormat", "both");
         options.put("roleFormat", "none");
-        _loginModule.initialize(subject, callbackHandler, null, options);
-        assertTrue(_loginModule.login());
-        assertTrue(_loginModule.commit());
+        this.loginModule.initialize(subject, callbackHandler, null, options);
+        assertTrue(this.loginModule.login());
+        assertTrue(this.loginModule.commit());
         assertEquals(2, subject.getPrincipals().size());
     }
 
@@ -155,9 +155,9 @@ public class WindowsLoginModuleTests {
         Map<String, String> options = new HashMap<String, String>();
         options.put("debug", "true");
         options.put("roleFormat", "sid");
-        _loginModule.initialize(subject, callbackHandler, null, options);
-        assertTrue(_loginModule.login());
-        assertTrue(_loginModule.commit());
+        this.loginModule.initialize(subject, callbackHandler, null, options);
+        assertTrue(this.loginModule.login());
+        assertTrue(this.loginModule.commit());
         assertEquals(3, subject.getPrincipals().size());
         Iterator<Principal> principals = subject.getPrincipals().iterator();
         assertTrue(principals.next().getName().equals(WindowsAccountImpl.getCurrentUsername()));
@@ -171,13 +171,13 @@ public class WindowsLoginModuleTests {
         // the mock has an "Everyone" group
         UsernamePasswordCallbackHandler callbackHandler = new UsernamePasswordCallbackHandler(
                 WindowsAccountImpl.getCurrentUsername(), "password");
-        _provider.addGroup("Group 1");
-        _provider.addGroup("Group 1");
+        this.provider.addGroup("Group 1");
+        this.provider.addGroup("Group 1");
         Map<String, String> options = new HashMap<String, String>();
         options.put("debug", "true");
-        _loginModule.initialize(subject, callbackHandler, null, options);
-        assertTrue(_loginModule.login());
-        assertTrue(_loginModule.commit());
+        this.loginModule.initialize(subject, callbackHandler, null, options);
+        assertTrue(this.loginModule.login());
+        assertTrue(this.loginModule.commit());
         assertEquals(4, subject.getPrincipals().size());
     }
 
@@ -187,16 +187,16 @@ public class WindowsLoginModuleTests {
         UsernamePasswordCallbackHandler callbackHandler = new UsernamePasswordCallbackHandler("Guest", "password");
         Map<String, String> options = new HashMap<String, String>();
         options.put("debug", "true");
-        _loginModule.initialize(subject, callbackHandler, null, options);
-        assertTrue(_loginModule.isAllowGuestLogin());
-        assertTrue(_loginModule.login());
+        this.loginModule.initialize(subject, callbackHandler, null, options);
+        assertTrue(this.loginModule.isAllowGuestLogin());
+        assertTrue(this.loginModule.login());
         assertEquals(0, subject.getPrincipals().size());
-        assertTrue(_loginModule.commit());
+        assertTrue(this.loginModule.commit());
         assertEquals(3, subject.getPrincipals().size());
         assertTrue(subject.getPrincipals().contains(new RolePrincipal("Everyone")));
         assertTrue(subject.getPrincipals().contains(new RolePrincipal("Users")));
-        _loginModule.setAllowGuestLogin(false);
-        assertTrue(_loginModule.login());
+        this.loginModule.setAllowGuestLogin(false);
+        assertTrue(this.loginModule.login());
         fail("expected LoginException");
     }
 
@@ -206,9 +206,9 @@ public class WindowsLoginModuleTests {
         UsernamePasswordCallbackHandler callbackHandler = new UsernamePasswordCallbackHandler("Guest", "password");
         Map<String, String> options = new HashMap<String, String>();
         options.put("debug", "true");
-        _loginModule.initialize(subject, callbackHandler, null, options);
-        assertTrue(_loginModule.login());
-        _loginModule.abort();
+        this.loginModule.initialize(subject, callbackHandler, null, options);
+        assertTrue(this.loginModule.login());
+        this.loginModule.abort();
         assertSame(Integer.valueOf(subject.getPrincipals().size()), Integer.valueOf(0));
     }
 }

--- a/Source/JNA/waffle-tests/src/test/java/waffle/servlet/BasicSecurityFilterTests.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/servlet/BasicSecurityFilterTests.java
@@ -44,10 +44,10 @@ public class BasicSecurityFilterTests {
 
     @Before
     public void setUp() {
-        filter = new NegotiateSecurityFilter();
-        filter.setAuth(new MockWindowsAuthProvider());
+        this.filter = new NegotiateSecurityFilter();
+        this.filter.setAuth(new MockWindowsAuthProvider());
         try {
-            filter.init(null);
+            this.filter.init(null);
         } catch (ServletException e) {
             fail(e.getMessage());
         }
@@ -55,7 +55,7 @@ public class BasicSecurityFilterTests {
 
     @After
     public void tearDown() {
-        filter.destroy();
+        this.filter.destroy();
     }
 
     @Test
@@ -69,7 +69,7 @@ public class BasicSecurityFilterTests {
 
         SimpleHttpResponse response = new SimpleHttpResponse();
         FilterChain filterChain = new SimpleFilterChain();
-        filter.doFilter(request, response, filterChain);
+        this.filter.doFilter(request, response, filterChain);
         Subject subject = (Subject) request.getSession().getAttribute("javax.security.auth.subject");
         boolean authenticated = (subject != null && subject.getPrincipals().size() > 0);
         assertTrue(authenticated);

--- a/Source/JNA/waffle-tests/src/test/java/waffle/servlet/ImpersonateTests.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/servlet/ImpersonateTests.java
@@ -46,36 +46,36 @@ import com.sun.jna.platform.win32.Netapi32;
 
 public class ImpersonateTests {
 
-    private NegotiateSecurityFilter _filter;
-    private LMAccess.USER_INFO_1    _userInfo;
+    private NegotiateSecurityFilter filter;
+    private LMAccess.USER_INFO_1    userInfo;
     private int                     resultOfNetAddUser;
 
     @Before
     public void setUp() {
-        _filter = new NegotiateSecurityFilter();
-        _filter.setAuth(new WindowsAuthProviderImpl());
+        this.filter = new NegotiateSecurityFilter();
+        this.filter.setAuth(new WindowsAuthProviderImpl());
         try {
-            _filter.init(null);
+            this.filter.init(null);
         } catch (ServletException e) {
             fail(e.getMessage());
         }
 
-        _userInfo = new LMAccess.USER_INFO_1();
-        _userInfo.usri1_name = new WString(MockWindowsAccount.TEST_USER_NAME);
-        _userInfo.usri1_password = new WString(MockWindowsAccount.TEST_PASSWORD);
-        _userInfo.usri1_priv = LMAccess.USER_PRIV_USER;
+        this.userInfo = new LMAccess.USER_INFO_1();
+        this.userInfo.usri1_name = new WString(MockWindowsAccount.TEST_USER_NAME);
+        this.userInfo.usri1_password = new WString(MockWindowsAccount.TEST_PASSWORD);
+        this.userInfo.usri1_priv = LMAccess.USER_PRIV_USER;
 
-        resultOfNetAddUser = Netapi32.INSTANCE.NetUserAdd(null, 1, _userInfo, null);
+        this.resultOfNetAddUser = Netapi32.INSTANCE.NetUserAdd(null, 1, this.userInfo, null);
         // ignore test if not able to add user (need to be administrator to do this).
-        assumeTrue(LMErr.NERR_Success == resultOfNetAddUser);
+        assumeTrue(LMErr.NERR_Success == this.resultOfNetAddUser);
     }
 
     @After
     public void tearDown() {
-        _filter.destroy();
+        this.filter.destroy();
 
-        if (LMErr.NERR_Success == resultOfNetAddUser) {
-            assertEquals(LMErr.NERR_Success, Netapi32.INSTANCE.NetUserDel(null, _userInfo.usri1_name.toString()));
+        if (LMErr.NERR_Success == this.resultOfNetAddUser) {
+            assertEquals(LMErr.NERR_Success, Netapi32.INSTANCE.NetUserDel(null, this.userInfo.usri1_name.toString()));
         }
     }
 
@@ -96,8 +96,8 @@ public class ImpersonateTests {
 
         AutoDisposableWindowsPrincipal windowsPrincipal = null;
         try {
-            _filter.setImpersonate(true);
-            _filter.doFilter(request, response, filterChain);
+            this.filter.setImpersonate(true);
+            this.filter.doFilter(request, response, filterChain);
 
             Subject subject = (Subject) request.getSession().getAttribute("javax.security.auth.subject");
             boolean authenticated = (subject != null && subject.getPrincipals().size() > 0);
@@ -136,8 +136,8 @@ public class ImpersonateTests {
 
         WindowsPrincipal windowsPrincipal = null;
         try {
-            _filter.setImpersonate(false);
-            _filter.doFilter(request, response, filterChain);
+            this.filter.setImpersonate(false);
+            this.filter.doFilter(request, response, filterChain);
 
             Subject subject = (Subject) request.getSession().getAttribute("javax.security.auth.subject");
             boolean authenticated = (subject != null && subject.getPrincipals().size() > 0);
@@ -169,11 +169,11 @@ public class ImpersonateTests {
 
         @Override
         public void doFilter(ServletRequest sreq, ServletResponse srep) throws IOException, ServletException {
-            userName = Advapi32Util.getUserName();
+            this.userName = Advapi32Util.getUserName();
         }
 
         public String getUserName() {
-            return userName;
+            return this.userName;
         }
     }
 

--- a/Source/JNA/waffle-tests/src/test/java/waffle/servlet/NegotiateSecurityFilterLoadTests.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/servlet/NegotiateSecurityFilterLoadTests.java
@@ -29,21 +29,21 @@ public class NegotiateSecurityFilterLoadTests {
     @Rule
     public ContiPerfRule                 contiPerfRule = new ContiPerfRule();
 
-    private NegotiateSecurityFilterTests _tests        = new NegotiateSecurityFilterTests();
+    private NegotiateSecurityFilterTests tests         = new NegotiateSecurityFilterTests();
 
     @Before
     public void setUp() {
-        _tests.setUp();
+        this.tests.setUp();
     }
 
     @After
     public void tearDown() {
-        _tests.tearDown();
+        this.tests.tearDown();
     }
 
     @Test
     @PerfTest(invocations = 10, threads = 10)
     public void testLoad() throws Throwable {
-        _tests.testNegotiate();
+        this.tests.testNegotiate();
     }
 }

--- a/Source/JNA/waffle-tests/src/test/java/waffle/servlet/NegotiateSecurityFilterTests.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/servlet/NegotiateSecurityFilterTests.java
@@ -54,14 +54,14 @@ import com.sun.jna.platform.win32.Sspi.SecBufferDesc;
  */
 public class NegotiateSecurityFilterTests {
 
-    private NegotiateSecurityFilter _filter;
+    private NegotiateSecurityFilter filter;
 
     @Before
     public void setUp() {
-        _filter = new NegotiateSecurityFilter();
-        _filter.setAuth(new WindowsAuthProviderImpl());
+        this.filter = new NegotiateSecurityFilter();
+        this.filter.setAuth(new WindowsAuthProviderImpl());
         try {
-            _filter.init(null);
+            this.filter.init(null);
         } catch (ServletException e) {
             fail(e.getMessage());
         }
@@ -69,7 +69,7 @@ public class NegotiateSecurityFilterTests {
 
     @After
     public void tearDown() {
-        _filter.destroy();
+        this.filter.destroy();
     }
 
     @Test
@@ -77,7 +77,7 @@ public class NegotiateSecurityFilterTests {
         SimpleHttpRequest request = new SimpleHttpRequest();
         request.setMethod("GET");
         SimpleHttpResponse response = new SimpleHttpResponse();
-        _filter.doFilter(request, response, null);
+        this.filter.doFilter(request, response, null);
         String[] wwwAuthenticates = response.getHeaderValues("WWW-Authenticate");
         assertEquals(3, wwwAuthenticates.length);
         assertEquals("Negotiate", wwwAuthenticates[0]);
@@ -109,7 +109,7 @@ public class NegotiateSecurityFilterTests {
             String clientToken = BaseEncoding.base64().encode(clientContext.getToken());
             request.addHeader("Authorization", securityPackage + " " + clientToken);
             SimpleHttpResponse response = new SimpleHttpResponse();
-            _filter.doFilter(request, response, null);
+            this.filter.doFilter(request, response, null);
             assertTrue(response.getHeader("WWW-Authenticate").startsWith(securityPackage + " "));
             assertEquals("keep-alive", response.getHeader("Connection"));
             assertEquals(2, response.getHeaderNamesSize());
@@ -131,7 +131,7 @@ public class NegotiateSecurityFilterTests {
         IWindowsCredentialsHandle clientCredentials = null;
         WindowsSecurityContextImpl clientContext = null;
         // role will contain both Everyone and SID
-        _filter.setRoleFormat("both");
+        this.filter.setRoleFormat("both");
         try {
             // client credentials handle
             clientCredentials = WindowsCredentialsHandleImpl.getCurrent(securityPackage);
@@ -152,7 +152,7 @@ public class NegotiateSecurityFilterTests {
                 request.addHeader("Authorization", securityPackage + " " + clientToken);
 
                 SimpleHttpResponse response = new SimpleHttpResponse();
-                _filter.doFilter(request, response, filterChain);
+                this.filter.doFilter(request, response, filterChain);
 
                 Subject subject = (Subject) request.getSession().getAttribute("javax.security.auth.subject");
                 authenticated = (subject != null && subject.getPrincipals().size() > 0);
@@ -201,7 +201,7 @@ public class NegotiateSecurityFilterTests {
         request.setUserPrincipal(windowsPrincipal);
         SimpleFilterChain filterChain = new SimpleFilterChain();
         SimpleHttpResponse response = new SimpleHttpResponse();
-        _filter.doFilter(request, response, filterChain);
+        this.filter.doFilter(request, response, filterChain);
         assertTrue(filterChain.getRequest() instanceof NegotiateRequestWrapper);
         NegotiateRequestWrapper wrappedRequest = (NegotiateRequestWrapper) filterChain.getRequest();
         assertTrue(wrappedRequest.getUserPrincipal() instanceof WindowsPrincipal);
@@ -219,7 +219,7 @@ public class NegotiateSecurityFilterTests {
         request.addHeader("Authorization", "NTLM TlRMTVNTUAABAAAABzIAAAYABgArAAAACwALACAAAABXT1JLU1RBVElPTkRPTUFJTg==");
         SimpleFilterChain filterChain = new SimpleFilterChain();
         SimpleHttpResponse response = new SimpleHttpResponse();
-        _filter.doFilter(request, response, filterChain);
+        this.filter.doFilter(request, response, filterChain);
         assertEquals(401, response.getStatus());
         String[] wwwAuthenticates = response.getHeaderValues("WWW-Authenticate");
         assertEquals(1, wwwAuthenticates.length);
@@ -240,7 +240,7 @@ public class NegotiateSecurityFilterTests {
         request.addHeader("Authorization", "NTLM TlRMTVNTUAABAAAABzIAAAYABgArAAAACwALACAAAABXT1JLU1RBVElPTkRPTUFJTg==");
         SimpleFilterChain filterChain = new SimpleFilterChain();
         SimpleHttpResponse response = new SimpleHttpResponse();
-        _filter.doFilter(request, response, filterChain);
+        this.filter.doFilter(request, response, filterChain);
         assertEquals(401, response.getStatus());
         String[] wwwAuthenticates = response.getHeaderValues("WWW-Authenticate");
         assertEquals(1, wwwAuthenticates.length);
@@ -259,12 +259,12 @@ public class NegotiateSecurityFilterTests {
         filterConfig.setParameter("securityFilterProviders", "waffle.servlet.spi.BasicSecurityFilterProvider\n");
         filterConfig.setParameter("waffle.servlet.spi.BasicSecurityFilterProvider/realm", "DemoRealm");
         filterConfig.setParameter("authProvider", MockWindowsAuthProvider.class.getName());
-        _filter.init(filterConfig);
-        assertEquals(_filter.getPrincipalFormat(), PrincipalFormat.sid);
-        assertEquals(_filter.getRoleFormat(), PrincipalFormat.none);
-        assertTrue(_filter.isAllowGuestLogin());
-        assertEquals(1, _filter.getProviders().size());
-        assertTrue(_filter.getAuth() instanceof MockWindowsAuthProvider);
+        this.filter.init(filterConfig);
+        assertEquals(this.filter.getPrincipalFormat(), PrincipalFormat.sid);
+        assertEquals(this.filter.getRoleFormat(), PrincipalFormat.none);
+        assertTrue(this.filter.isAllowGuestLogin());
+        assertEquals(1, this.filter.getProviders().size());
+        assertTrue(this.filter.getAuth() instanceof MockWindowsAuthProvider);
     }
 
     @Test
@@ -273,8 +273,8 @@ public class NegotiateSecurityFilterTests {
         SimpleFilterConfig filterConfig = new SimpleFilterConfig();
         filterConfig.setParameter("securityFilterProviders", "waffle.servlet.spi.BasicSecurityFilterProvider\n"
                 + "waffle.servlet.spi.NegotiateSecurityFilterProvider waffle.servlet.spi.BasicSecurityFilterProvider");
-        _filter.init(filterConfig);
-        assertEquals(3, _filter.getProviders().size());
+        this.filter.init(filterConfig);
+        assertEquals(3, this.filter.getProviders().size());
     }
 
     @Test
@@ -283,11 +283,11 @@ public class NegotiateSecurityFilterTests {
         filterConfig.setParameter("securityFilterProviders", "waffle.servlet.spi.NegotiateSecurityFilterProvider\n");
         filterConfig.setParameter("waffle.servlet.spi.NegotiateSecurityFilterProvider/protocols",
                 "NTLM\nNegotiate NTLM");
-        _filter.init(filterConfig);
-        assertEquals(_filter.getPrincipalFormat(), PrincipalFormat.fqn);
-        assertEquals(_filter.getRoleFormat(), PrincipalFormat.fqn);
-        assertTrue(_filter.isAllowGuestLogin());
-        assertEquals(1, _filter.getProviders().size());
+        this.filter.init(filterConfig);
+        assertEquals(this.filter.getPrincipalFormat(), PrincipalFormat.fqn);
+        assertEquals(this.filter.getRoleFormat(), PrincipalFormat.fqn);
+        assertTrue(this.filter.isAllowGuestLogin());
+        assertEquals(1, this.filter.getProviders().size());
     }
 
     @Test
@@ -296,7 +296,7 @@ public class NegotiateSecurityFilterTests {
         filterConfig.setParameter("securityFilterProviders", "waffle.servlet.spi.NegotiateSecurityFilterProvider\n");
         filterConfig.setParameter("waffle.servlet.spi.NegotiateSecurityFilterProvider/protocols", "INVALID");
         try {
-            _filter.init(filterConfig);
+            this.filter.init(filterConfig);
             fail("expected ServletException");
         } catch (ServletException e) {
             assertEquals("java.lang.RuntimeException: Unsupported protocol: INVALID", e.getMessage());
@@ -308,7 +308,7 @@ public class NegotiateSecurityFilterTests {
         try {
             SimpleFilterConfig filterConfig = new SimpleFilterConfig();
             filterConfig.setParameter("invalidParameter", "random");
-            _filter.init(filterConfig);
+            this.filter.init(filterConfig);
             fail("expected ServletException");
         } catch (ServletException e) {
             assertEquals("Invalid parameter: invalidParameter", e.getMessage());
@@ -320,7 +320,7 @@ public class NegotiateSecurityFilterTests {
         try {
             SimpleFilterConfig filterConfig = new SimpleFilterConfig();
             filterConfig.setParameter("invalidClass/invalidParameter", "random");
-            _filter.init(filterConfig);
+            this.filter.init(filterConfig);
             fail("expected ServletException");
         } catch (ServletException e) {
             assertEquals("java.lang.ClassNotFoundException: invalidClass", e.getMessage());

--- a/Source/JNA/waffle-tests/src/test/java/waffle/servlet/WaffleInfoServletTests.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/servlet/WaffleInfoServletTests.java
@@ -40,7 +40,7 @@ import waffle.mock.http.SimpleHttpResponse;
  */
 public class WaffleInfoServletTests {
 
-    private static final Logger logger = LoggerFactory.getLogger(WaffleInfoServletTests.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(WaffleInfoServletTests.class);
 
     @Test
     public void testGetInfo() throws Exception {
@@ -55,7 +55,7 @@ public class WaffleInfoServletTests {
         String xml = response.getOutputText();
         Document doc = loadXMLFromString(xml);
 
-        this.logger.info("GOT: {}", xml);
+        WaffleInfoServletTests.LOGGER.info("GOT: {}", xml);
 
         // Make sure JNA Version is properly noted
         assertEquals(Platform.class.getPackage().getImplementationVersion(),

--- a/Source/JNA/waffle-tests/src/test/java/waffle/servlet/WindowsPrincipalTests.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/servlet/WindowsPrincipalTests.java
@@ -35,12 +35,12 @@ import waffle.mock.MockWindowsSecurityContext;
  */
 public class WindowsPrincipalTests {
 
-    private WindowsPrincipal _windowsPrincipal;
+    private WindowsPrincipal windowsPrincipal;
 
     @Before
     public void setUp() {
         MockWindowsSecurityContext ctx = new MockWindowsSecurityContext("Administrator");
-        _windowsPrincipal = new WindowsPrincipal(ctx.getIdentity());
+        this.windowsPrincipal = new WindowsPrincipal(ctx.getIdentity());
     }
 
     @Test
@@ -48,7 +48,7 @@ public class WindowsPrincipalTests {
         // serialize
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(out);
-        oos.writeObject(_windowsPrincipal);
+        oos.writeObject(this.windowsPrincipal);
         oos.close();
         assertTrue(out.toByteArray().length > 0);
         // deserialize
@@ -57,17 +57,17 @@ public class WindowsPrincipalTests {
         Object o = ois.readObject();
         WindowsPrincipal copy = (WindowsPrincipal) o;
         // test
-        assertEquals(_windowsPrincipal.getName(), copy.getName());
-        assertEquals(_windowsPrincipal.getRolesString(), copy.getRolesString());
-        assertEquals(_windowsPrincipal.getSidString(), copy.getSidString());
-        assertEquals(Boolean.valueOf(Arrays.equals(_windowsPrincipal.getSid(), copy.getSid())), Boolean.TRUE);
+        assertEquals(this.windowsPrincipal.getName(), copy.getName());
+        assertEquals(this.windowsPrincipal.getRolesString(), copy.getRolesString());
+        assertEquals(this.windowsPrincipal.getSidString(), copy.getSidString());
+        assertEquals(Boolean.valueOf(Arrays.equals(this.windowsPrincipal.getSid(), copy.getSid())), Boolean.TRUE);
     }
 
     @Test
     public void testHasRole() {
-        assertTrue(_windowsPrincipal.hasRole("Administrator"));
-        assertTrue(_windowsPrincipal.hasRole("Users"));
-        assertTrue(_windowsPrincipal.hasRole("Everyone"));
-        assertFalse(_windowsPrincipal.hasRole("RoleDoesNotExist"));
+        assertTrue(this.windowsPrincipal.hasRole("Administrator"));
+        assertTrue(this.windowsPrincipal.hasRole("Users"));
+        assertTrue(this.windowsPrincipal.hasRole("Everyone"));
+        assertFalse(this.windowsPrincipal.hasRole("RoleDoesNotExist"));
     }
 }

--- a/Source/JNA/waffle-tests/src/test/java/waffle/windows/auth/WindowsAuthProviderLoadTests.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/windows/auth/WindowsAuthProviderLoadTests.java
@@ -27,11 +27,11 @@ public class WindowsAuthProviderLoadTests {
     @Rule
     public ContiPerfRule             contiPerfRule = new ContiPerfRule();
 
-    private WindowsAuthProviderTests _tests        = new WindowsAuthProviderTests();
+    private WindowsAuthProviderTests tests         = new WindowsAuthProviderTests();
 
     @Test
     @PerfTest(invocations = 10, threads = 10)
     public void testLoad() throws Throwable {
-        _tests.testAcceptSecurityToken();
+        this.tests.testAcceptSecurityToken();
     }
 }

--- a/Source/JNA/waffle-tests/src/test/java/waffle/windows/auth/WindowsAuthProviderTests.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/windows/auth/WindowsAuthProviderTests.java
@@ -46,7 +46,7 @@ import com.sun.jna.platform.win32.Sspi.SecBufferDesc;
  */
 public class WindowsAuthProviderTests {
 
-    private static final Logger _log = LoggerFactory.getLogger(WindowsAuthProviderTests.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(WindowsAuthProviderTests.class);
 
     // TODO This was commented out, uncommented and ignore until I can determine if this is valid
     @Ignore
@@ -54,8 +54,8 @@ public class WindowsAuthProviderTests {
     public void testLogonGuestUser() {
         IWindowsAuthProvider prov = new WindowsAuthProviderImpl();
         IWindowsIdentity identity = prov.logonUser("garbage", "garbage");
-        _log.debug("Fqn: {}", identity.getFqn());
-        _log.debug("Guest: {}", Boolean.valueOf(identity.isGuest()));
+        LOGGER.debug("Fqn: {}", identity.getFqn());
+        LOGGER.debug("Guest: {}", Boolean.valueOf(identity.isGuest()));
         assertTrue(identity.getFqn().endsWith("\\Guest"));
         assertTrue(identity.isGuest());
         identity.dispose();
@@ -107,15 +107,15 @@ public class WindowsAuthProviderTests {
     public void testGetCurrentComputer() {
         IWindowsAuthProvider prov = new WindowsAuthProviderImpl();
         IWindowsComputer computer = prov.getCurrentComputer();
-        _log.debug(computer.getComputerName());
+        LOGGER.debug(computer.getComputerName());
         assertTrue(computer.getComputerName().length() > 0);
-        _log.debug(computer.getJoinStatus());
-        _log.debug(computer.getMemberOf());
+        LOGGER.debug(computer.getJoinStatus());
+        LOGGER.debug(computer.getMemberOf());
         String[] localGroups = computer.getGroups();
         assertNotNull(localGroups);
         assertTrue(localGroups.length > 0);
         for (String localGroup : localGroups) {
-            _log.debug(" {}", localGroup);
+            LOGGER.debug(" {}", localGroup);
         }
     }
 
@@ -129,7 +129,7 @@ public class WindowsAuthProviderTests {
         IWindowsDomain[] domains = prov.getDomains();
         assertNotNull(domains);
         for (IWindowsDomain domain : domains) {
-            _log.debug("{}: {}", domain.getFqn(), domain.getTrustDirectionString());
+            LOGGER.debug("{}: {}", domain.getFqn(), domain.getTrustDirectionString());
         }
     }
 
@@ -159,7 +159,7 @@ public class WindowsAuthProviderTests {
                     serverContext = provider.acceptSecurityToken(connectionId, clientContext.getToken(),
                             securityPackage);
                 } catch (Exception e) {
-                    _log.error("{}", e);
+                    LOGGER.error("{}", e);
                     break;
                 }
 
@@ -167,7 +167,7 @@ public class WindowsAuthProviderTests {
                     // initialize on the client
                     SecBufferDesc continueToken = new SecBufferDesc(Sspi.SECBUFFER_TOKEN, serverContext.getToken());
                     clientContext.initialize(clientContext.getHandle(), continueToken, targetName);
-                    _log.debug("Token: {}", BaseEncoding.base64().encode(serverContext.getToken()));
+                    LOGGER.debug("Token: {}", BaseEncoding.base64().encode(serverContext.getToken()));
                 }
 
             } while (clientContext.isContinue() || serverContext != null && serverContext.isContinue());
@@ -175,9 +175,9 @@ public class WindowsAuthProviderTests {
             if (serverContext != null) {
                 assertTrue(serverContext.getIdentity().getFqn().length() > 0);
 
-                _log.debug(serverContext.getIdentity().getFqn());
+                LOGGER.debug(serverContext.getIdentity().getFqn());
                 for (IWindowsAccount group : serverContext.getIdentity().getGroups()) {
-                    _log.debug(" {}", group.getFqn());
+                    LOGGER.debug(" {}", group.getFqn());
                 }
             }
         } finally {
@@ -218,7 +218,7 @@ public class WindowsAuthProviderTests {
                 serverContext = provider.acceptSecurityToken(connectionId, clientContext.getToken(), securityPackage);
                 assertTrue(provider.getContinueContextsSize() > 0);
             }
-            _log.debug("Cached security contexts: {}", Integer.valueOf(provider.getContinueContextsSize()));
+            LOGGER.debug("Cached security contexts: {}", Integer.valueOf(provider.getContinueContextsSize()));
             assertFalse(max == provider.getContinueContextsSize());
         } finally {
             if (serverContext != null) {
@@ -259,7 +259,7 @@ public class WindowsAuthProviderTests {
                     serverContext = provider.acceptSecurityToken(connectionId, clientContext.getToken(),
                             securityPackage);
                 } catch (Exception e) {
-                    _log.error("{}", e);
+                    LOGGER.error("{}", e);
                     break;
                 }
 
@@ -277,9 +277,9 @@ public class WindowsAuthProviderTests {
                 IWindowsImpersonationContext impersonationCtx = serverContext.impersonate();
                 impersonationCtx.revertToSelf();
 
-                _log.debug(serverContext.getIdentity().getFqn());
+                LOGGER.debug(serverContext.getIdentity().getFqn());
                 for (IWindowsAccount group : serverContext.getIdentity().getGroups()) {
-                    _log.debug(" {}", group.getFqn());
+                    LOGGER.debug(" {}", group.getFqn());
                 }
             }
         } finally {

--- a/Source/JNA/waffle-tomcat5/src/main/java/waffle/apache/GenericWindowsPrincipal.java
+++ b/Source/JNA/waffle-tomcat5/src/main/java/waffle/apache/GenericWindowsPrincipal.java
@@ -33,9 +33,9 @@ import waffle.windows.auth.WindowsAccount;
  */
 public class GenericWindowsPrincipal extends GenericPrincipal {
 
-    private byte[]                      _sid;
-    private String                      _sidString;
-    private Map<String, WindowsAccount> _groups;
+    private byte[]                      sid;
+    private String                      sidString;
+    private Map<String, WindowsAccount> groups;
 
     /**
      * A windows principal.
@@ -52,9 +52,9 @@ public class GenericWindowsPrincipal extends GenericPrincipal {
     public GenericWindowsPrincipal(IWindowsIdentity windowsIdentity, Realm realm, PrincipalFormat principalFormat,
             PrincipalFormat roleFormat) {
         super(realm, windowsIdentity.getFqn(), "", getRoles(windowsIdentity, principalFormat, roleFormat));
-        _sid = windowsIdentity.getSid();
-        _sidString = windowsIdentity.getSidString();
-        _groups = getGroups(windowsIdentity.getGroups());
+        this.sid = windowsIdentity.getSid();
+        this.sidString = windowsIdentity.getSidString();
+        this.groups = getGroups(windowsIdentity.getGroups());
     }
 
     private static List<String> getRoles(IWindowsIdentity windowsIdentity, PrincipalFormat principalFormat,
@@ -81,7 +81,7 @@ public class GenericWindowsPrincipal extends GenericPrincipal {
      * @return Array of bytes.
      */
     public byte[] getSid() {
-        return _sid.clone();
+        return this.sid.clone();
     }
 
     /**
@@ -90,7 +90,7 @@ public class GenericWindowsPrincipal extends GenericPrincipal {
      * @return String.
      */
     public String getSidString() {
-        return _sidString;
+        return this.sidString;
     }
 
     /**
@@ -99,7 +99,7 @@ public class GenericWindowsPrincipal extends GenericPrincipal {
      * @return A map of group names to groups.
      */
     public Map<String, WindowsAccount> getGroups() {
-        return _groups;
+        return this.groups;
     }
 
     /**

--- a/Source/JNA/waffle-tomcat5/src/main/java/waffle/apache/MixedAuthenticator.java
+++ b/Source/JNA/waffle-tomcat5/src/main/java/waffle/apache/MixedAuthenticator.java
@@ -43,53 +43,53 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
 
     public MixedAuthenticator() {
         super();
-        _log = LoggerFactory.getLogger(MixedAuthenticator.class);
-        _info = "waffle.apache.MixedAuthenticator/1.0";
-        _log.debug("[waffle.apache.MixedAuthenticator] loaded");
+        this.log = LoggerFactory.getLogger(MixedAuthenticator.class);
+        this.info = "waffle.apache.MixedAuthenticator/1.0";
+        this.log.debug("[waffle.apache.MixedAuthenticator] loaded");
     }
 
     @Override
     public void start() {
-        _log.info("[waffle.apache.MixedAuthenticator] started");
+        this.log.info("[waffle.apache.MixedAuthenticator] started");
     }
 
     @Override
     public void stop() {
-        _log.info("[waffle.apache.MixedAuthenticator] stopped");
+        this.log.info("[waffle.apache.MixedAuthenticator] stopped");
     }
 
     @Override
     public boolean authenticate(Request request, Response response, LoginConfig loginConfig) {
 
         // realm: fail if no realm is configured
-        if (context == null || context.getRealm() == null) {
-            _log.warn("missing context/realm");
+        if (this.context == null || this.context.getRealm() == null) {
+            this.log.warn("missing context/realm");
             sendError(response, HttpServletResponse.SC_SERVICE_UNAVAILABLE);
             return false;
         }
 
-        _log.debug("{} {}, contentlength: {}", request.getMethod(), request.getRequestURI(),
+        this.log.debug("{} {}, contentlength: {}", request.getMethod(), request.getRequestURI(),
                 Integer.valueOf(request.getContentLength()));
 
         boolean negotiateCheck = request.getParameter("j_negotiate_check") != null;
-        _log.debug("negotiateCheck: {}", Boolean.valueOf(negotiateCheck));
+        this.log.debug("negotiateCheck: {}", Boolean.valueOf(negotiateCheck));
         boolean securityCheck = request.getParameter("j_security_check") != null;
-        _log.debug("securityCheck: {}", Boolean.valueOf(securityCheck));
+        this.log.debug("securityCheck: {}", Boolean.valueOf(securityCheck));
 
         Principal principal = request.getUserPrincipal();
 
         AuthorizationHeader authorizationHeader = new AuthorizationHeader(request);
         boolean ntlmPost = authorizationHeader.isNtlmType1PostAuthorizationHeader();
-        _log.debug("authorization: {}, ntlm post: {}", authorizationHeader, Boolean.valueOf(ntlmPost));
+        this.log.debug("authorization: {}, ntlm post: {}", authorizationHeader, Boolean.valueOf(ntlmPost));
 
         if (principal != null && !ntlmPost) {
-            _log.debug("previously authenticated user: {}", principal.getName());
+            this.log.debug("previously authenticated user: {}", principal.getName());
             return true;
         } else if (negotiateCheck) {
             if (!authorizationHeader.isNull()) {
                 return negotiate(request, response, authorizationHeader);
             }
-            _log.debug("authorization required");
+            this.log.debug("authorization required");
             sendUnauthorized(response);
             return false;
         } else if (securityCheck) {
@@ -112,13 +112,13 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
         // maintain a connection-based session for NTLM tokens
         String connectionId = NtlmServletRequest.getConnectionId(request);
 
-        _log.debug("security package: {}, connection id: {}", securityPackage, connectionId);
+        this.log.debug("security package: {}, connection id: {}", securityPackage, connectionId);
 
         boolean ntlmPost = authorizationHeader.isNtlmType1PostAuthorizationHeader();
 
         if (ntlmPost) {
             // type 1 NTLM authentication message received
-            _auth.resetSecurityToken(connectionId);
+            this.auth.resetSecurityToken(connectionId);
         }
 
         // log the user in using the token
@@ -126,14 +126,14 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
 
         try {
             byte[] tokenBuffer = authorizationHeader.getTokenBytes();
-            _log.debug("token buffer: {} byte(s)", Integer.valueOf(tokenBuffer.length));
-            securityContext = _auth.acceptSecurityToken(connectionId, tokenBuffer, securityPackage);
-            _log.debug("continue required: {}", Boolean.valueOf(securityContext.isContinue()));
+            this.log.debug("token buffer: {} byte(s)", Integer.valueOf(tokenBuffer.length));
+            securityContext = this.auth.acceptSecurityToken(connectionId, tokenBuffer, securityPackage);
+            this.log.debug("continue required: {}", Boolean.valueOf(securityContext.isContinue()));
 
             byte[] continueTokenBytes = securityContext.getToken();
             if (continueTokenBytes != null && continueTokenBytes.length > 0) {
                 String continueToken = BaseEncoding.base64().encode(continueTokenBytes);
-                _log.debug("continue token: {}", continueToken);
+                this.log.debug("continue token: {}", continueToken);
                 response.addHeader("WWW-Authenticate", securityPackage + " " + continueToken);
             }
 
@@ -145,8 +145,8 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
             }
 
         } catch (IOException e) {
-            _log.warn("error logging in user: {}", e.getMessage());
-            _log.trace("{}", e);
+            this.log.warn("error logging in user: {}", e.getMessage());
+            this.log.trace("{}", e);
             sendUnauthorized(response);
             return false;
         }
@@ -155,27 +155,27 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
         IWindowsIdentity windowsIdentity = securityContext.getIdentity();
 
         // disable guest login
-        if (!_allowGuestLogin && windowsIdentity.isGuest()) {
-            _log.warn("guest login disabled: {}", windowsIdentity.getFqn());
+        if (!this.allowGuestLogin && windowsIdentity.isGuest()) {
+            this.log.warn("guest login disabled: {}", windowsIdentity.getFqn());
             sendUnauthorized(response);
             return false;
         }
 
         try {
 
-            _log.debug("logged in user: {} ({})", windowsIdentity.getFqn(), windowsIdentity.getSidString());
+            this.log.debug("logged in user: {} ({})", windowsIdentity.getFqn(), windowsIdentity.getSidString());
 
-            GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity, context.getRealm(),
-                    _principalFormat, _roleFormat);
+            GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity,
+                    this.context.getRealm(), this.principalFormat, this.roleFormat);
 
-            _log.debug("roles: {}", windowsPrincipal.getRolesString());
+            this.log.debug("roles: {}", windowsPrincipal.getRolesString());
 
             // create a session associated with this request if there's none
             HttpSession session = request.getSession(true);
-            _log.debug("session id: {}", session.getId());
+            this.log.debug("session id: {}", session.getId());
 
             register(request, response, windowsPrincipal, securityPackage, windowsPrincipal.getName(), null);
-            _log.info("successfully logged in user: {}", windowsPrincipal.getName());
+            this.log.info("successfully logged in user: {}", windowsPrincipal.getName());
 
         } finally {
             windowsIdentity.dispose();
@@ -189,37 +189,37 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
         String username = request.getParameter("j_username");
         String password = request.getParameter("j_password");
 
-        _log.debug("logging in: {}", username);
+        this.log.debug("logging in: {}", username);
 
         IWindowsIdentity windowsIdentity = null;
         try {
-            windowsIdentity = _auth.logonUser(username, password);
+            windowsIdentity = this.auth.logonUser(username, password);
         } catch (Exception e) {
-            _log.error(e.getMessage());
-            _log.trace("{}", e);
+            this.log.error(e.getMessage());
+            this.log.trace("{}", e);
             return false;
         }
 
         // disable guest login
-        if (!_allowGuestLogin && windowsIdentity.isGuest()) {
-            _log.warn("guest login disabled: {}", windowsIdentity.getFqn());
+        if (!this.allowGuestLogin && windowsIdentity.isGuest()) {
+            this.log.warn("guest login disabled: {}", windowsIdentity.getFqn());
             return false;
         }
 
         try {
-            _log.debug("successfully logged in {} ({})", username, windowsIdentity.getSidString());
+            this.log.debug("successfully logged in {} ({})", username, windowsIdentity.getSidString());
 
-            GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity, context.getRealm(),
-                    _principalFormat, _roleFormat);
+            GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity,
+                    this.context.getRealm(), this.principalFormat, this.roleFormat);
 
-            _log.debug("roles: {}", windowsPrincipal.getRolesString());
+            this.log.debug("roles: {}", windowsPrincipal.getRolesString());
 
             // create a session associated with this request if there's none
             HttpSession session = request.getSession(true);
-            _log.debug("session id: {}", session.getId());
+            this.log.debug("session id: {}", session.getId());
 
             register(request, response, windowsPrincipal, "FORM", windowsPrincipal.getName(), null);
-            _log.info("successfully logged in user: {}", windowsPrincipal.getName());
+            this.log.info("successfully logged in user: {}", windowsPrincipal.getName());
         } finally {
             windowsIdentity.dispose();
         }
@@ -229,17 +229,17 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
 
     private void redirectTo(Request request, Response response, String url) {
         try {
-            _log.debug("redirecting to: {}", url);
-            ServletContext servletContext = context.getServletContext();
+            this.log.debug("redirecting to: {}", url);
+            ServletContext servletContext = this.context.getServletContext();
             RequestDispatcher disp = servletContext.getRequestDispatcher(url);
             disp.forward(request.getRequest(), response);
         } catch (IOException e) {
-            _log.error(e.getMessage());
-            _log.trace("{}", e);
+            this.log.error(e.getMessage());
+            this.log.trace("{}", e);
             throw new RuntimeException(e);
         } catch (ServletException e) {
-            _log.error(e.getMessage());
-            _log.trace("{}", e);
+            this.log.error(e.getMessage());
+            this.log.trace("{}", e);
             throw new RuntimeException(e);
         }
     }

--- a/Source/JNA/waffle-tomcat5/src/main/java/waffle/apache/NegotiateAuthenticator.java
+++ b/Source/JNA/waffle-tomcat5/src/main/java/waffle/apache/NegotiateAuthenticator.java
@@ -40,19 +40,19 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
 
     public NegotiateAuthenticator() {
         super();
-        _log = LoggerFactory.getLogger(NegotiateAuthenticator.class);
-        _info = "waffle.apache.NegotiateAuthenticator/1.0";
-        _log.debug("[waffle.apache.NegotiateAuthenticator] loaded");
+        this.log = LoggerFactory.getLogger(NegotiateAuthenticator.class);
+        this.info = "waffle.apache.NegotiateAuthenticator/1.0";
+        this.log.debug("[waffle.apache.NegotiateAuthenticator] loaded");
     }
 
     @Override
     public void start() {
-        _log.info("[waffle.apache.NegotiateAuthenticator] started");
+        this.log.info("[waffle.apache.NegotiateAuthenticator] started");
     }
 
     @Override
     public void stop() {
-        _log.info("[waffle.apache.NegotiateAuthenticator] stopped");
+        this.log.info("[waffle.apache.NegotiateAuthenticator] stopped");
     }
 
     @Override
@@ -62,13 +62,13 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
         AuthorizationHeader authorizationHeader = new AuthorizationHeader(request);
         boolean ntlmPost = authorizationHeader.isNtlmType1PostAuthorizationHeader();
 
-        _log.debug("{} {}, contentlength: {}", request.getMethod(), request.getRequestURI(),
+        this.log.debug("{} {}, contentlength: {}", request.getMethod(), request.getRequestURI(),
                 Integer.valueOf(request.getContentLength()));
-        _log.debug("authorization: {}, ntlm post: {}", authorizationHeader, Boolean.valueOf(ntlmPost));
+        this.log.debug("authorization: {}, ntlm post: {}", authorizationHeader, Boolean.valueOf(ntlmPost));
 
         if (principal != null && !ntlmPost) {
             // user already authenticated
-            _log.debug("previously authenticated user: {}", principal.getName());
+            this.log.debug("previously authenticated user: {}", principal.getName());
             return true;
         }
 
@@ -79,11 +79,11 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
             // maintain a connection-based session for NTLM tokens
             String connectionId = NtlmServletRequest.getConnectionId(request);
 
-            _log.debug("security package: {}, connection id: {}", securityPackage, connectionId);
+            this.log.debug("security package: {}, connection id: {}", securityPackage, connectionId);
 
             if (ntlmPost) {
                 // type 1 NTLM authentication message received
-                _auth.resetSecurityToken(connectionId);
+                this.auth.resetSecurityToken(connectionId);
             }
 
             // log the user in using the token
@@ -91,14 +91,14 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
 
             try {
                 byte[] tokenBuffer = authorizationHeader.getTokenBytes();
-                _log.debug("token buffer: {} byte(s)", Integer.valueOf(tokenBuffer.length));
-                securityContext = _auth.acceptSecurityToken(connectionId, tokenBuffer, securityPackage);
-                _log.debug("continue required: {}", Boolean.valueOf(securityContext.isContinue()));
+                this.log.debug("token buffer: {} byte(s)", Integer.valueOf(tokenBuffer.length));
+                securityContext = this.auth.acceptSecurityToken(connectionId, tokenBuffer, securityPackage);
+                this.log.debug("continue required: {}", Boolean.valueOf(securityContext.isContinue()));
 
                 byte[] continueTokenBytes = securityContext.getToken();
                 if (continueTokenBytes != null && continueTokenBytes.length > 0) {
                     String continueToken = BaseEncoding.base64().encode(continueTokenBytes);
-                    _log.debug("continue token: {}", continueToken);
+                    this.log.debug("continue token: {}", continueToken);
                     response.addHeader("WWW-Authenticate", securityPackage + " " + continueToken);
                 }
 
@@ -110,15 +110,15 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
                 }
 
             } catch (IOException e) {
-                _log.warn("error logging in user: {}", e.getMessage());
-                _log.trace("{}", e);
+                this.log.warn("error logging in user: {}", e.getMessage());
+                this.log.trace("{}", e);
                 sendUnauthorized(response);
                 return false;
             }
 
             // realm: fail if no realm is configured
-            if (context == null || context.getRealm() == null) {
-                _log.warn("missing context/realm");
+            if (this.context == null || this.context.getRealm() == null) {
+                this.log.warn("missing context/realm");
                 sendError(response, HttpServletResponse.SC_SERVICE_UNAVAILABLE);
                 return false;
             }
@@ -127,29 +127,29 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
             IWindowsIdentity windowsIdentity = securityContext.getIdentity();
 
             // disable guest login
-            if (!_allowGuestLogin && windowsIdentity.isGuest()) {
-                _log.warn("guest login disabled: {}", windowsIdentity.getFqn());
+            if (!this.allowGuestLogin && windowsIdentity.isGuest()) {
+                this.log.warn("guest login disabled: {}", windowsIdentity.getFqn());
                 sendUnauthorized(response);
                 return false;
             }
 
             try {
-                _log.debug("logged in user: {} ({})", windowsIdentity.getFqn(), windowsIdentity.getSidString());
+                this.log.debug("logged in user: {} ({})", windowsIdentity.getFqn(), windowsIdentity.getSidString());
 
                 GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity,
-                        context.getRealm(), _principalFormat, _roleFormat);
+                        this.context.getRealm(), this.principalFormat, this.roleFormat);
 
-                _log.debug("roles: {}", windowsPrincipal.getRolesString());
+                this.log.debug("roles: {}", windowsPrincipal.getRolesString());
 
                 principal = windowsPrincipal;
 
                 // create a session associated with this request if there's none
                 HttpSession session = request.getSession(true);
-                _log.debug("session id: {}", session.getId());
+                this.log.debug("session id: {}", session.getId());
 
                 // register the authenticated principal
                 register(request, response, principal, securityPackage, principal.getName(), null);
-                _log.info("successfully logged in user: {}", principal.getName());
+                this.log.info("successfully logged in user: {}", principal.getName());
 
             } finally {
                 windowsIdentity.dispose();
@@ -158,7 +158,7 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
             return true;
         }
 
-        _log.debug("authorization required");
+        this.log.debug("authorization required");
         sendUnauthorized(response);
         return false;
     }

--- a/Source/JNA/waffle-tomcat5/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
+++ b/Source/JNA/waffle-tomcat5/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
@@ -36,14 +36,14 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
 
     private static final Set<String> SUPPORTED_PROTOCOLS = new LinkedHashSet<String>(asList("Negotiate", "NTLM"));
 
-    protected String                 _info;
-    protected Logger                 _log;
-    protected PrincipalFormat        _principalFormat    = PrincipalFormat.fqn;
-    protected PrincipalFormat        _roleFormat         = PrincipalFormat.fqn;
-    protected boolean                _allowGuestLogin    = true;
-    protected Set<String>            _protocols          = SUPPORTED_PROTOCOLS;
+    protected String                 info;
+    protected Logger                 log;
+    protected PrincipalFormat        principalFormat     = PrincipalFormat.fqn;
+    protected PrincipalFormat        roleFormat          = PrincipalFormat.fqn;
+    protected boolean                allowGuestLogin     = true;
+    protected Set<String>            protocols           = SUPPORTED_PROTOCOLS;
 
-    protected IWindowsAuthProvider   _auth               = new WindowsAuthProviderImpl();
+    protected IWindowsAuthProvider   auth                = new WindowsAuthProviderImpl();
 
     /**
      * Windows authentication provider.
@@ -51,7 +51,7 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
      * @return IWindowsAuthProvider.
      */
     public IWindowsAuthProvider getAuth() {
-        return _auth;
+        return this.auth;
     }
 
     /**
@@ -61,12 +61,12 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
      *            Class implements IWindowsAuthProvider.
      */
     public void setAuth(IWindowsAuthProvider provider) {
-        _auth = provider;
+        this.auth = provider;
     }
 
     @Override
     public String getInfo() {
-        return _info;
+        return this.info;
     }
 
     /**
@@ -76,8 +76,8 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
      *            Principal format.
      */
     public void setPrincipalFormat(String format) {
-        _principalFormat = PrincipalFormat.valueOf(format);
-        _log.debug("principal format: {}", _principalFormat);
+        this.principalFormat = PrincipalFormat.valueOf(format);
+        this.log.debug("principal format: {}", this.principalFormat);
     }
 
     /**
@@ -86,7 +86,7 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
      * @return Principal format.
      */
     public PrincipalFormat getPrincipalFormat() {
-        return _principalFormat;
+        return this.principalFormat;
     }
 
     /**
@@ -96,8 +96,8 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
      *            Role format.
      */
     public void setRoleFormat(String format) {
-        _roleFormat = PrincipalFormat.valueOf(format);
-        _log.debug("role format: {}", _roleFormat);
+        this.roleFormat = PrincipalFormat.valueOf(format);
+        this.log.debug("role format: {}", this.roleFormat);
     }
 
     /**
@@ -106,7 +106,7 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
      * @return Role format.
      */
     public PrincipalFormat getRoleFormat() {
-        return _roleFormat;
+        return this.roleFormat;
     }
 
     /**
@@ -115,7 +115,7 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
      * @return True if Guest login permitted, false otherwise.
      */
     public boolean isAllowGuestLogin() {
-        return _allowGuestLogin;
+        return this.allowGuestLogin;
     }
 
     /**
@@ -126,26 +126,26 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
      *            True or false.
      */
     public void setAllowGuestLogin(boolean value) {
-        _allowGuestLogin = value;
+        this.allowGuestLogin = value;
     }
 
     /**
      * Set the authentication protocols. Default is "Negotiate, NTLM".
      * 
-     * @param protocols
+     * @param value
      *            Authentication protocols
      */
-    public void setProtocols(String protocols) {
-        _protocols = new LinkedHashSet<String>();
-        String[] protocolNames = protocols.split(",");
+    public void setProtocols(String value) {
+        this.protocols = new LinkedHashSet<String>();
+        String[] protocolNames = value.split(",");
         for (String protocolName : protocolNames) {
             protocolName = protocolName.trim();
             if (!protocolName.isEmpty()) {
-                _log.debug("init protocol: {}", protocolName);
+                this.log.debug("init protocol: {}", protocolName);
                 if (SUPPORTED_PROTOCOLS.contains(protocolName)) {
-                    _protocols.add(protocolName);
+                    this.protocols.add(protocolName);
                 } else {
-                    _log.error("unsupported protocol: {}", protocolName);
+                    this.log.error("unsupported protocol: {}", protocolName);
                     throw new RuntimeException("Unsupported protocol: " + protocolName);
                 }
             }
@@ -160,7 +160,7 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
      */
     protected void sendUnauthorized(Response response) {
         try {
-            for (String protocol : _protocols) {
+            for (String protocol : this.protocols) {
                 response.addHeader("WWW-Authenticate", protocol);
             }
             response.setHeader("Connection", "close");
@@ -183,8 +183,8 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
         try {
             response.sendError(code);
         } catch (IOException e) {
-            _log.error(e.getMessage());
-            _log.trace("{}", e);
+            this.log.error(e.getMessage());
+            this.log.trace("{}", e);
             throw new RuntimeException(e);
         }
     }

--- a/Source/JNA/waffle-tomcat5/src/main/java/waffle/apache/WindowsRealm.java
+++ b/Source/JNA/waffle-tomcat5/src/main/java/waffle/apache/WindowsRealm.java
@@ -24,11 +24,11 @@ import org.apache.catalina.realm.RealmBase;
  */
 public class WindowsRealm extends RealmBase {
 
-    protected static final String _name = "waffle.apache.WindowsRealm/1.0";
+    protected static final String name = "waffle.apache.WindowsRealm/1.0";
 
     @Override
     protected String getName() {
-        return _name;
+        return name;
     }
 
     @Override

--- a/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/MixedAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/MixedAuthenticatorTests.java
@@ -44,26 +44,26 @@ import com.sun.jna.platform.win32.Sspi.SecBufferDesc;
  */
 public class MixedAuthenticatorTests {
 
-    private MixedAuthenticator _authenticator;
+    private MixedAuthenticator authenticator;
 
     @Before
     public void setUp() {
-        _authenticator = new MixedAuthenticator();
+        this.authenticator = new MixedAuthenticator();
         SimpleContext ctx = new SimpleContext();
         Realm realm = new SimpleRealm();
         ctx.setRealm(realm);
-        _authenticator.setContainer(ctx);
-        _authenticator.start();
+        this.authenticator.setContainer(ctx);
+        this.authenticator.start();
     }
 
     @After
     public void tearDown() {
-        _authenticator.stop();
+        this.authenticator.stop();
     }
 
     @Test
     public void testGetInfo() {
-        assertTrue(_authenticator.getInfo().length() > 0);
+        assertTrue(this.authenticator.getInfo().length() > 0);
     }
 
     @Test
@@ -72,7 +72,7 @@ public class MixedAuthenticatorTests {
         request.setMethod("GET");
         request.setQueryString("j_negotiate_check");
         SimpleHttpResponse response = new SimpleHttpResponse();
-        _authenticator.authenticate(request, response, null);
+        this.authenticator.authenticate(request, response, null);
         String[] wwwAuthenticates = response.getHeaderValues("WWW-Authenticate");
         assertEquals(2, wwwAuthenticates.length);
         assertEquals("Negotiate", wwwAuthenticates[0]);
@@ -104,7 +104,7 @@ public class MixedAuthenticatorTests {
             String clientToken = BaseEncoding.base64().encode(clientContext.getToken());
             request.addHeader("Authorization", securityPackage + " " + clientToken);
             SimpleHttpResponse response = new SimpleHttpResponse();
-            _authenticator.authenticate(request, response, null);
+            this.authenticator.authenticate(request, response, null);
             assertTrue(response.getHeader("WWW-Authenticate").startsWith(securityPackage + " "));
             assertEquals("keep-alive", response.getHeader("Connection"));
             assertEquals(2, response.getHeaderNames().length);
@@ -144,7 +144,7 @@ public class MixedAuthenticatorTests {
                 request.addHeader("Authorization", securityPackage + " " + clientToken);
 
                 SimpleHttpResponse response = new SimpleHttpResponse();
-                authenticated = _authenticator.authenticate(request, response, null);
+                authenticated = this.authenticator.authenticate(request, response, null);
 
                 if (authenticated) {
                     assertTrue(response.getHeaderNames().length >= 0);
@@ -180,7 +180,7 @@ public class MixedAuthenticatorTests {
         loginConfig.setLoginPage("login.html");
         SimpleHttpRequest request = new SimpleHttpRequest();
         SimpleHttpResponse response = new SimpleHttpResponse();
-        assertFalse(_authenticator.authenticate(request, response, loginConfig));
+        assertFalse(this.authenticator.authenticate(request, response, loginConfig));
         assertEquals(304, response.getStatus());
         assertEquals("login.html", response.getHeader("Location"));
         assertEquals(1, response.getHeaderNames().length);
@@ -196,7 +196,7 @@ public class MixedAuthenticatorTests {
         request.addParameter("j_username", "username");
         request.addParameter("j_password", "password");
         SimpleHttpResponse response = new SimpleHttpResponse();
-        assertFalse(_authenticator.authenticate(request, response, loginConfig));
+        assertFalse(this.authenticator.authenticate(request, response, loginConfig));
         assertEquals(304, response.getStatus());
         assertEquals("error.html", response.getHeader("Location"));
         assertEquals(1, response.getHeaderNames().length);
@@ -204,7 +204,7 @@ public class MixedAuthenticatorTests {
 
     @Test
     public void testSecurityCheckQueryString() {
-        _authenticator.setAuth(new MockWindowsAuthProvider());
+        this.authenticator.setAuth(new MockWindowsAuthProvider());
         LoginConfig loginConfig = new LoginConfig();
         loginConfig.setErrorPage("error.html");
         loginConfig.setLoginPage("login.html");
@@ -213,12 +213,12 @@ public class MixedAuthenticatorTests {
         request.addParameter("j_username", WindowsAccountImpl.getCurrentUsername());
         request.addParameter("j_password", "");
         SimpleHttpResponse response = new SimpleHttpResponse();
-        assertTrue(_authenticator.authenticate(request, response, loginConfig));
+        assertTrue(this.authenticator.authenticate(request, response, loginConfig));
     }
 
     @Test
     public void testSecurityCheckParameters() {
-        _authenticator.setAuth(new MockWindowsAuthProvider());
+        this.authenticator.setAuth(new MockWindowsAuthProvider());
         LoginConfig loginConfig = new LoginConfig();
         loginConfig.setErrorPage("error.html");
         loginConfig.setLoginPage("login.html");
@@ -227,6 +227,6 @@ public class MixedAuthenticatorTests {
         request.addParameter("j_username", WindowsAccountImpl.getCurrentUsername());
         request.addParameter("j_password", "");
         SimpleHttpResponse response = new SimpleHttpResponse();
-        assertTrue(_authenticator.authenticate(request, response, loginConfig));
+        assertTrue(this.authenticator.authenticate(request, response, loginConfig));
     }
 }

--- a/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
@@ -47,50 +47,50 @@ import com.sun.jna.platform.win32.Sspi.SecBufferDesc;
  */
 public class NegotiateAuthenticatorTests {
 
-    private static final Logger    logger = LoggerFactory.getLogger(NegotiateAuthenticatorTests.class);
+    private static final Logger    LOGGER = LoggerFactory.getLogger(NegotiateAuthenticatorTests.class);
 
-    private NegotiateAuthenticator _authenticator;
+    private NegotiateAuthenticator authenticator;
 
     @Before
     public void setUp() {
-        _authenticator = new NegotiateAuthenticator();
+        this.authenticator = new NegotiateAuthenticator();
         SimpleContext ctx = new SimpleContext();
         Realm realm = new SimpleRealm();
         ctx.setRealm(realm);
-        _authenticator.setContainer(ctx);
-        _authenticator.start();
+        this.authenticator.setContainer(ctx);
+        this.authenticator.start();
     }
 
     @After
     public void tearDown() {
-        _authenticator.stop();
+        this.authenticator.stop();
     }
 
     @Test
     public void testGetInfo() {
-        assertTrue(_authenticator.getInfo().length() > 0);
-        assertTrue(_authenticator.getAuth() instanceof WindowsAuthProviderImpl);
+        assertTrue(this.authenticator.getInfo().length() > 0);
+        assertTrue(this.authenticator.getAuth() instanceof WindowsAuthProviderImpl);
     }
 
     @Test
     public void testAllowGuestLogin() {
-        assertTrue(_authenticator.isAllowGuestLogin());
-        _authenticator.setAllowGuestLogin(false);
-        assertFalse(_authenticator.isAllowGuestLogin());
+        assertTrue(this.authenticator.isAllowGuestLogin());
+        this.authenticator.setAllowGuestLogin(false);
+        assertFalse(this.authenticator.isAllowGuestLogin());
     }
 
     @Test
     public void testPrincipalFormat() {
-        assertEquals(PrincipalFormat.fqn, _authenticator.getPrincipalFormat());
-        _authenticator.setPrincipalFormat("both");
-        assertEquals(PrincipalFormat.both, _authenticator.getPrincipalFormat());
+        assertEquals(PrincipalFormat.fqn, this.authenticator.getPrincipalFormat());
+        this.authenticator.setPrincipalFormat("both");
+        assertEquals(PrincipalFormat.both, this.authenticator.getPrincipalFormat());
     }
 
     @Test
     public void testRoleFormat() {
-        assertEquals(PrincipalFormat.fqn, _authenticator.getRoleFormat());
-        _authenticator.setRoleFormat("both");
-        assertEquals(PrincipalFormat.both, _authenticator.getRoleFormat());
+        assertEquals(PrincipalFormat.fqn, this.authenticator.getRoleFormat());
+        this.authenticator.setRoleFormat("both");
+        assertEquals(PrincipalFormat.both, this.authenticator.getRoleFormat());
     }
 
     @Test
@@ -98,7 +98,7 @@ public class NegotiateAuthenticatorTests {
         SimpleHttpRequest request = new SimpleHttpRequest();
         request.setMethod("GET");
         SimpleHttpResponse response = new SimpleHttpResponse();
-        _authenticator.authenticate(request, response, null);
+        this.authenticator.authenticate(request, response, null);
         String[] wwwAuthenticates = response.getHeaderValues("WWW-Authenticate");
         assertEquals(2, wwwAuthenticates.length);
         assertEquals("Negotiate", wwwAuthenticates[0]);
@@ -128,7 +128,7 @@ public class NegotiateAuthenticatorTests {
             String clientToken = BaseEncoding.base64().encode(clientContext.getToken());
             request.addHeader("Authorization", securityPackage + " " + clientToken);
             SimpleHttpResponse response = new SimpleHttpResponse();
-            _authenticator.authenticate(request, response, null);
+            this.authenticator.authenticate(request, response, null);
             assertTrue(response.getHeader("WWW-Authenticate").startsWith(securityPackage + " "));
             assertEquals("keep-alive", response.getHeader("Connection"));
             assertEquals(2, response.getHeaderNames().length);
@@ -169,9 +169,9 @@ public class NegotiateAuthenticatorTests {
 
                 SimpleHttpResponse response = new SimpleHttpResponse();
                 try {
-                    authenticated = _authenticator.authenticate(request, response, null);
+                    authenticated = this.authenticator.authenticate(request, response, null);
                 } catch (Exception e) {
-                    logger.error("{}", e);
+                    LOGGER.error("{}", e);
                     return;
                 }
 
@@ -225,7 +225,7 @@ public class NegotiateAuthenticatorTests {
                 request.addHeader("Authorization", securityPackage + " " + clientToken);
 
                 SimpleHttpResponse response = new SimpleHttpResponse();
-                authenticated = _authenticator.authenticate(request, response, null);
+                authenticated = this.authenticator.authenticate(request, response, null);
 
                 if (authenticated) {
                     assertNotNull(request.getUserPrincipal());

--- a/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/WaffleAuthenticatorBaseTest.java
+++ b/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/WaffleAuthenticatorBaseTest.java
@@ -31,9 +31,9 @@ public class WaffleAuthenticatorBaseTest {
 
     @Before
     public void init() {
-        waffleAuthenticatorBase = new WaffleAuthenticatorBase() {
+        this.waffleAuthenticatorBase = new WaffleAuthenticatorBase() {
             {
-                _log = LoggerFactory.getLogger(WaffleAuthenticatorBaseTest.class);
+                this.log = LoggerFactory.getLogger(WaffleAuthenticatorBaseTest.class);
             }
 
             @Override
@@ -45,31 +45,31 @@ public class WaffleAuthenticatorBaseTest {
 
     @Test
     public void should_accept_NTLM_protocol() throws Exception {
-        waffleAuthenticatorBase.setProtocols("  NTLM ");
+        this.waffleAuthenticatorBase.setProtocols("  NTLM ");
 
-        assertEquals("One protocol added", 1, waffleAuthenticatorBase._protocols.size());
-        assertEquals("NTLM", waffleAuthenticatorBase._protocols.iterator().next());
+        assertEquals("One protocol added", 1, this.waffleAuthenticatorBase.protocols.size());
+        assertEquals("NTLM", this.waffleAuthenticatorBase.protocols.iterator().next());
     }
 
     @Test
     public void should_accept_Negotiate_protocol() throws Exception {
-        waffleAuthenticatorBase.setProtocols(" Negotiate  ");
+        this.waffleAuthenticatorBase.setProtocols(" Negotiate  ");
 
-        assertEquals("One protocol added", 1, waffleAuthenticatorBase._protocols.size());
-        assertEquals("Negotiate", waffleAuthenticatorBase._protocols.iterator().next());
+        assertEquals("One protocol added", 1, this.waffleAuthenticatorBase.protocols.size());
+        assertEquals("Negotiate", this.waffleAuthenticatorBase.protocols.iterator().next());
     }
 
     @Test
     public void should_accept_both_protocols() throws Exception {
-        waffleAuthenticatorBase.setProtocols("  NTLM , , Negotiate   ");
+        this.waffleAuthenticatorBase.setProtocols("  NTLM , , Negotiate   ");
 
-        assertEquals("Two protocols added", 2, waffleAuthenticatorBase._protocols.size());
-        assertTrue("NTLM has been added", waffleAuthenticatorBase._protocols.contains("NTLM"));
-        assertTrue("Negotiate has been added", waffleAuthenticatorBase._protocols.contains("Negotiate"));
+        assertEquals("Two protocols added", 2, this.waffleAuthenticatorBase.protocols.size());
+        assertTrue("NTLM has been added", this.waffleAuthenticatorBase.protocols.contains("NTLM"));
+        assertTrue("Negotiate has been added", this.waffleAuthenticatorBase.protocols.contains("Negotiate"));
     }
 
     @Test(expected = RuntimeException.class)
     public void should_refuse_other_protocol() throws Exception {
-        waffleAuthenticatorBase.setProtocols("  NTLM , OTHER, Negotiate   ");
+        this.waffleAuthenticatorBase.setProtocols("  NTLM , OTHER, Negotiate   ");
     }
 }

--- a/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/WindowsAccountTests.java
+++ b/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/WindowsAccountTests.java
@@ -35,27 +35,27 @@ import waffle.windows.auth.WindowsAccount;
  */
 public class WindowsAccountTests {
 
-    private MockWindowsAccount _mockWindowsAccount = new MockWindowsAccount("localhost\\Administrator");
-    private WindowsAccount     _windowsAccount;
+    private MockWindowsAccount mockWindowsAccount = new MockWindowsAccount("localhost\\Administrator");
+    private WindowsAccount     windowsAccount;
 
     @Before
     public void setUp() {
-        _windowsAccount = new WindowsAccount(_mockWindowsAccount);
+        this.windowsAccount = new WindowsAccount(this.mockWindowsAccount);
     }
 
     @Test
     public void testProperties() {
-        assertEquals("localhost", _windowsAccount.getDomain());
-        assertEquals("localhost\\Administrator", _windowsAccount.getFqn());
-        assertEquals("Administrator", _windowsAccount.getName());
-        assertTrue(_windowsAccount.getSidString().startsWith("S-"));
+        assertEquals("localhost", this.windowsAccount.getDomain());
+        assertEquals("localhost\\Administrator", this.windowsAccount.getFqn());
+        assertEquals("Administrator", this.windowsAccount.getName());
+        assertTrue(this.windowsAccount.getSidString().startsWith("S-"));
     }
 
     @Test
     public void testEquals() {
-        assertEquals(_windowsAccount, new WindowsAccount(_mockWindowsAccount));
+        assertEquals(this.windowsAccount, new WindowsAccount(this.mockWindowsAccount));
         MockWindowsAccount mockWindowsAccount2 = new MockWindowsAccount("localhost\\Administrator2");
-        assertFalse(_windowsAccount.equals(new WindowsAccount(mockWindowsAccount2)));
+        assertFalse(this.windowsAccount.equals(new WindowsAccount(mockWindowsAccount2)));
     }
 
     @Test
@@ -63,7 +63,7 @@ public class WindowsAccountTests {
         // serialize
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(out);
-        oos.writeObject(_windowsAccount);
+        oos.writeObject(this.windowsAccount);
         oos.close();
         assertTrue(out.toByteArray().length > 0);
         // deserialize
@@ -72,10 +72,10 @@ public class WindowsAccountTests {
         Object o = ois.readObject();
         WindowsAccount copy = (WindowsAccount) o;
         // test
-        assertEquals(_windowsAccount, copy);
-        assertEquals(_windowsAccount.getDomain(), copy.getDomain());
-        assertEquals(_windowsAccount.getFqn(), copy.getFqn());
-        assertEquals(_windowsAccount.getName(), copy.getName());
-        assertEquals(_windowsAccount.getSidString(), copy.getSidString());
+        assertEquals(this.windowsAccount, copy);
+        assertEquals(this.windowsAccount.getDomain(), copy.getDomain());
+        assertEquals(this.windowsAccount.getFqn(), copy.getFqn());
+        assertEquals(this.windowsAccount.getName(), copy.getName());
+        assertEquals(this.windowsAccount.getSidString(), copy.getSidString());
     }
 }

--- a/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/catalina/SimpleContext.java
+++ b/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/catalina/SimpleContext.java
@@ -48,8 +48,8 @@ import org.apache.tomcat.util.http.mapper.Mapper;
  */
 public class SimpleContext implements Context {
 
-    private Realm          _realm;
-    private ServletContext _servletContext = new SimpleServletContext();
+    private Realm          realm;
+    private ServletContext servletContext = new SimpleServletContext();
 
     @Override
     public void addApplicationListener(String arg0) {
@@ -402,7 +402,7 @@ public class SimpleContext implements Context {
 
     @Override
     public ServletContext getServletContext() {
-        return _servletContext;
+        return this.servletContext;
     }
 
     @Override
@@ -771,7 +771,7 @@ public class SimpleContext implements Context {
 
     @Override
     public Realm getRealm() {
-        return _realm;
+        return this.realm;
     }
 
     @Override
@@ -836,7 +836,7 @@ public class SimpleContext implements Context {
 
     @Override
     public void setRealm(Realm realm) {
-        _realm = realm;
+        this.realm = realm;
     }
 
     @Override

--- a/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/catalina/SimpleFilterChain.java
+++ b/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/catalina/SimpleFilterChain.java
@@ -27,21 +27,21 @@ import javax.servlet.ServletResponse;
  */
 public class SimpleFilterChain implements FilterChain {
 
-    private ServletRequest  _request;
-    private ServletResponse _response;
+    private ServletRequest  request;
+    private ServletResponse response;
 
     public ServletRequest getRequest() {
-        return _request;
+        return this.request;
     }
 
     public ServletResponse getResponse() {
-        return _response;
+        return this.response;
     }
 
     @Override
     public void doFilter(ServletRequest sreq, ServletResponse srep) throws IOException, ServletException {
 
-        _request = sreq;
-        _response = srep;
+        this.request = sreq;
+        this.response = srep;
     }
 }

--- a/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/catalina/SimpleHttpRequest.java
+++ b/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/catalina/SimpleHttpRequest.java
@@ -26,101 +26,98 @@ import org.apache.catalina.connector.Request;
  */
 public class SimpleHttpRequest extends Request {
 
-    private static int          _remotePort_s;
+    private static int          remotePortS;
 
-    private String              _requestURI;
-    private String              _queryString;
-    private String              _remoteUser;
-    private String              _method     = "GET";
-    private String              _remoteHost;
-    private String              _remoteAddr;
-    private int                 _remotePort = -1;
-    private Map<String, String> _headers    = new HashMap<String, String>();
-    private Map<String, String> _parameters = new HashMap<String, String>();
-    private byte[]              _content;
-    private HttpSession         _session    = new SimpleHttpSession();
-    private Principal           _principal;
+    private String              requestURI;
+    private String              queryString;
+    private String              remoteUser;
+    private String              method      = "GET";
+    private Map<String, String> headers     = new HashMap<String, String>();
+    private Map<String, String> parameters  = new HashMap<String, String>();
+    private byte[]              content;
+    private HttpSession         httpSession = new SimpleHttpSession();
+    private Principal           principal;
 
     public SimpleHttpRequest() {
         super();
-        _remotePort = nextRemotePort();
+        this.remotePort = nextRemotePort();
     }
 
     public synchronized static int nextRemotePort() {
-        return ++_remotePort_s;
+        return ++remotePortS;
     }
 
     public synchronized static void resetRemotePort() {
-        _remotePort_s = 0;
+        remotePortS = 0;
     }
 
     @Override
     public void addHeader(String headerName, String headerValue) {
-        _headers.put(headerName, headerValue);
+        this.headers.put(headerName, headerValue);
     }
 
     @Override
     public String getHeader(String headerName) {
-        return _headers.get(headerName);
+        return this.headers.get(headerName);
     }
 
     @Override
     public String getMethod() {
-        return _method;
+        return this.method;
     }
 
     @Override
     public int getContentLength() {
-        return _content == null ? -1 : _content.length;
+        return this.content == null ? -1 : this.content.length;
     }
 
     @Override
     public int getRemotePort() {
-        return _remotePort;
+        return this.remotePort;
     }
 
     @Override
     public void setMethod(String methodName) {
-        _method = methodName;
+        this.method = methodName;
     }
 
     @Override
     public void setContentLength(int length) {
-        _content = new byte[length];
+        this.content = new byte[length];
     }
 
     public void setRemoteUser(String username) {
-        _remoteUser = username;
+        this.remoteUser = username;
     }
 
     @Override
     public String getRemoteUser() {
-        return _remoteUser;
+        return this.remoteUser;
     }
 
     @Override
     public HttpSession getSession() {
-        return _session;
+        return this.httpSession;
     }
 
     @Override
     public HttpSession getSession(boolean create) {
-        if (_session == null && create) {
-            _session = new SimpleHttpSession();
+        if (this.httpSession == null && create) {
+            this.httpSession = new SimpleHttpSession();
         }
-        return _session;
+        return this.httpSession;
     }
 
     @Override
     public String getQueryString() {
-        return _queryString;
+        return this.queryString;
     }
 
     @Override
-    public void setQueryString(String queryString) {
-        _queryString = queryString;
-        if (_queryString != null) {
-            for (String eachParameter : _queryString.split("[&]")) {
+    public void setQueryString(String query) {
+        this.queryString = query;
+        if (this.queryString != null) {
+            for (String eachParameter : this.queryString.split("[&]")) {
                 String[] pair = eachParameter.split("=");
                 String value = (pair.length == 2) ? pair[1] : "";
                 addParameter(pair[0], value);
@@ -130,50 +127,50 @@ public class SimpleHttpRequest extends Request {
 
     @Override
     public void setRequestURI(String uri) {
-        _requestURI = uri;
+        this.requestURI = uri;
     }
 
     @Override
     public String getRequestURI() {
-        return _requestURI;
+        return this.requestURI;
     }
 
     @Override
     public String getParameter(String parameterName) {
-        return _parameters.get(parameterName);
+        return this.parameters.get(parameterName);
     }
 
     public void addParameter(String parameterName, String parameterValue) {
-        _parameters.put(parameterName, parameterValue);
+        this.parameters.put(parameterName, parameterValue);
     }
 
     @Override
     public String getRemoteHost() {
-        return _remoteHost;
+        return this.remoteHost;
     }
 
     @Override
-    public void setRemoteHost(String remoteHost) {
-        _remoteHost = remoteHost;
+    public void setRemoteHost(String value) {
+        this.remoteHost = value;
     }
 
     @Override
     public String getRemoteAddr() {
-        return _remoteAddr;
+        return this.remoteAddr;
     }
 
     @Override
-    public void setRemoteAddr(String remoteAddr) {
-        _remoteAddr = remoteAddr;
+    public void setRemoteAddr(String value) {
+        this.remoteAddr = value;
     }
 
     @Override
     public Principal getUserPrincipal() {
-        return _principal;
+        return this.principal;
     }
 
     @Override
-    public void setUserPrincipal(Principal principal) {
-        _principal = principal;
+    public void setUserPrincipal(Principal value) {
+        this.principal = value;
     }
 }

--- a/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/catalina/SimpleHttpResponse.java
+++ b/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/catalina/SimpleHttpResponse.java
@@ -27,45 +27,45 @@ import org.slf4j.LoggerFactory;
  */
 public class SimpleHttpResponse extends Response {
 
-    private static final Logger       logger   = LoggerFactory.getLogger(SimpleHttpResponse.class);
+    private static final Logger       LOGGER  = LoggerFactory.getLogger(SimpleHttpResponse.class);
 
-    private int                       _status  = 500;
-    private Map<String, List<String>> _headers = new HashMap<String, List<String>>();
+    private int                       status  = 500;
+    private Map<String, List<String>> headers = new HashMap<String, List<String>>();
 
     @Override
     public int getStatus() {
-        return _status;
+        return this.status;
     }
 
     @Override
     public void addHeader(String headerName, String headerValue) {
-        List<String> current = _headers.get(headerName);
+        List<String> current = this.headers.get(headerName);
         if (current == null) {
             current = new ArrayList<String>();
         }
         current.add(headerValue);
-        _headers.put(headerName, current);
+        this.headers.put(headerName, current);
     }
 
     @Override
     public void setHeader(String headerName, String headerValue) {
-        List<String> current = _headers.get(headerName);
+        List<String> current = this.headers.get(headerName);
         if (current == null) {
             current = new ArrayList<String>();
         } else {
             current.clear();
         }
         current.add(headerValue);
-        _headers.put(headerName, current);
+        this.headers.put(headerName, current);
     }
 
     @Override
     public void setStatus(int value) {
-        _status = value;
+        this.status = value;
     }
 
     public String getStatusString() {
-        if (_status == 401) {
+        if (this.status == 401) {
             return "Unauthorized";
         }
         return "Unknown";
@@ -73,23 +73,23 @@ public class SimpleHttpResponse extends Response {
 
     @Override
     public void flushBuffer() {
-        this.logger.info("{} {}", Integer.valueOf(_status), getStatusString());
-        for (String header : _headers.keySet()) {
-            for (String headerValue : _headers.get(header)) {
-                this.logger.info("{}: {}", header, headerValue);
+        this.LOGGER.info("{} {}", Integer.valueOf(this.status), getStatusString());
+        for (String header : this.headers.keySet()) {
+            for (String headerValue : this.headers.get(header)) {
+                this.LOGGER.info("{}: {}", header, headerValue);
             }
         }
     }
 
     @Override
     public String[] getHeaderValues(String headerName) {
-        List<String> headerValues = _headers.get(headerName);
+        List<String> headerValues = this.headers.get(headerName);
         return headerValues == null ? null : headerValues.toArray(new String[0]);
     }
 
     @Override
     public String getHeader(String headerName) {
-        List<String> headerValues = _headers.get(headerName);
+        List<String> headerValues = this.headers.get(headerName);
         if (headerValues == null) {
             return null;
         }
@@ -105,16 +105,16 @@ public class SimpleHttpResponse extends Response {
 
     @Override
     public String[] getHeaderNames() {
-        return _headers.keySet().toArray(new String[0]);
+        return this.headers.keySet().toArray(new String[0]);
     }
 
     @Override
     public void sendError(int rc, String message) {
-        _status = rc;
+        this.status = rc;
     }
 
     @Override
     public void sendError(int rc) {
-        _status = rc;
+        this.status = rc;
     }
 }

--- a/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/catalina/SimpleHttpSession.java
+++ b/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/catalina/SimpleHttpSession.java
@@ -29,11 +29,11 @@ import javax.servlet.http.HttpSessionContext;
 @SuppressWarnings("deprecation")
 public class SimpleHttpSession implements HttpSession {
 
-    private Map<String, Object> _attributes = new HashMap<String, Object>();
+    private Map<String, Object> attributes = new HashMap<String, Object>();
 
     @Override
     public Object getAttribute(String attributeName) {
-        return _attributes.get(attributeName);
+        return this.attributes.get(attributeName);
     }
 
     @Override
@@ -97,7 +97,7 @@ public class SimpleHttpSession implements HttpSession {
 
     @Override
     public void removeAttribute(String attributeName) {
-        _attributes.remove(attributeName);
+        this.attributes.remove(attributeName);
     }
 
     @Override
@@ -107,7 +107,7 @@ public class SimpleHttpSession implements HttpSession {
 
     @Override
     public void setAttribute(String attributeName, Object attributeValue) {
-        _attributes.put(attributeName, attributeValue);
+        this.attributes.put(attributeName, attributeValue);
     }
 
     @Override

--- a/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/catalina/SimpleRequestDispatcher.java
+++ b/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/catalina/SimpleRequestDispatcher.java
@@ -26,17 +26,17 @@ import javax.servlet.http.HttpServletResponse;
  */
 public class SimpleRequestDispatcher implements RequestDispatcher {
 
-    private String _url;
+    private String url;
 
     public SimpleRequestDispatcher(String url) {
-        _url = url;
+        this.url = url;
     }
 
     @Override
     public void forward(ServletRequest request, ServletResponse response) throws ServletException, IOException {
         HttpServletResponse httpResponse = (HttpServletResponse) response;
         httpResponse.setStatus(304);
-        httpResponse.addHeader("Location", _url);
+        httpResponse.addHeader("Location", this.url);
     }
 
     @Override

--- a/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/catalina/SimpleServletContext.java
+++ b/Source/JNA/waffle-tomcat5/src/test/java/waffle/apache/catalina/SimpleServletContext.java
@@ -108,6 +108,7 @@ public class SimpleServletContext implements ServletContext {
         return null;
     }
 
+    @Deprecated
     @Override
     public Servlet getServlet(String arg0) throws ServletException {
         return null;
@@ -118,11 +119,13 @@ public class SimpleServletContext implements ServletContext {
         return null;
     }
 
+    @Deprecated
     @Override
     public Enumeration<String> getServletNames() {
         return null;
     }
 
+    @Deprecated
     @Override
     public Enumeration<Servlet> getServlets() {
         return null;
@@ -133,6 +136,7 @@ public class SimpleServletContext implements ServletContext {
 
     }
 
+    @Deprecated
     @Override
     public void log(Exception arg0, String arg1) {
 

--- a/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/GenericWindowsPrincipal.java
+++ b/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/GenericWindowsPrincipal.java
@@ -33,9 +33,9 @@ import waffle.windows.auth.WindowsAccount;
  */
 public class GenericWindowsPrincipal extends GenericPrincipal {
 
-    private byte[]                      _sid;
-    private String                      _sidString;
-    private Map<String, WindowsAccount> _groups;
+    private byte[]                      sid;
+    private String                      sidString;
+    private Map<String, WindowsAccount> groups;
 
     /**
      * A windows principal.
@@ -52,9 +52,9 @@ public class GenericWindowsPrincipal extends GenericPrincipal {
     public GenericWindowsPrincipal(IWindowsIdentity windowsIdentity, Realm realm, PrincipalFormat principalFormat,
             PrincipalFormat roleFormat) {
         super(realm, windowsIdentity.getFqn(), "", getRoles(windowsIdentity, principalFormat, roleFormat));
-        _sid = windowsIdentity.getSid();
-        _sidString = windowsIdentity.getSidString();
-        _groups = getGroups(windowsIdentity.getGroups());
+        this.sid = windowsIdentity.getSid();
+        this.sidString = windowsIdentity.getSidString();
+        this.groups = getGroups(windowsIdentity.getGroups());
     }
 
     private static List<String> getRoles(IWindowsIdentity windowsIdentity, PrincipalFormat principalFormat,
@@ -81,7 +81,7 @@ public class GenericWindowsPrincipal extends GenericPrincipal {
      * @return Array of bytes.
      */
     public byte[] getSid() {
-        return _sid.clone();
+        return this.sid.clone();
     }
 
     /**
@@ -90,7 +90,7 @@ public class GenericWindowsPrincipal extends GenericPrincipal {
      * @return String.
      */
     public String getSidString() {
-        return _sidString;
+        return this.sidString;
     }
 
     /**
@@ -99,7 +99,7 @@ public class GenericWindowsPrincipal extends GenericPrincipal {
      * @return A map of group names to groups.
      */
     public Map<String, WindowsAccount> getGroups() {
-        return _groups;
+        return this.groups;
     }
 
     /**

--- a/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/MixedAuthenticator.java
+++ b/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/MixedAuthenticator.java
@@ -43,53 +43,53 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
 
     public MixedAuthenticator() {
         super();
-        _log = LoggerFactory.getLogger(MixedAuthenticator.class);
-        _info = "waffle.apache.MixedAuthenticator/1.0";
-        _log.debug("[waffle.apache.MixedAuthenticator] loaded");
+        this.log = LoggerFactory.getLogger(MixedAuthenticator.class);
+        this.info = "waffle.apache.MixedAuthenticator/1.0";
+        this.log.debug("[waffle.apache.MixedAuthenticator] loaded");
     }
 
     @Override
     public void start() {
-        _log.info("[waffle.apache.MixedAuthenticator] started");
+        this.log.info("[waffle.apache.MixedAuthenticator] started");
     }
 
     @Override
     public void stop() {
-        _log.info("[waffle.apache.MixedAuthenticator] stopped");
+        this.log.info("[waffle.apache.MixedAuthenticator] stopped");
     }
 
     @Override
     public boolean authenticate(Request request, Response response, LoginConfig loginConfig) {
 
         // realm: fail if no realm is configured
-        if (context == null || context.getRealm() == null) {
-            _log.warn("missing context/realm");
+        if (this.context == null || this.context.getRealm() == null) {
+            this.log.warn("missing context/realm");
             sendError(response, HttpServletResponse.SC_SERVICE_UNAVAILABLE);
             return false;
         }
 
-        _log.debug("{} {}, contentlength: {}", request.getMethod(), request.getRequestURI(),
+        this.log.debug("{} {}, contentlength: {}", request.getMethod(), request.getRequestURI(),
                 Integer.valueOf(request.getContentLength()));
 
         boolean negotiateCheck = request.getParameter("j_negotiate_check") != null;
-        _log.debug("negotiateCheck: {}", Boolean.valueOf(negotiateCheck));
+        this.log.debug("negotiateCheck: {}", Boolean.valueOf(negotiateCheck));
         boolean securityCheck = request.getParameter("j_security_check") != null;
-        _log.debug("securityCheck: {}", Boolean.valueOf(securityCheck));
+        this.log.debug("securityCheck: {}", Boolean.valueOf(securityCheck));
 
         Principal principal = request.getUserPrincipal();
 
         AuthorizationHeader authorizationHeader = new AuthorizationHeader(request);
         boolean ntlmPost = authorizationHeader.isNtlmType1PostAuthorizationHeader();
-        _log.debug("authorization: {}, ntlm post: {}", authorizationHeader, Boolean.valueOf(ntlmPost));
+        this.log.debug("authorization: {}, ntlm post: {}", authorizationHeader, Boolean.valueOf(ntlmPost));
 
         if (principal != null && !ntlmPost) {
-            _log.debug("previously authenticated user: {}", principal.getName());
+            this.log.debug("previously authenticated user: {}", principal.getName());
             return true;
         } else if (negotiateCheck) {
             if (!authorizationHeader.isNull()) {
                 return negotiate(request, response, authorizationHeader);
             }
-            _log.debug("authorization required");
+            this.log.debug("authorization required");
             sendUnauthorized(response);
             return false;
         } else if (securityCheck) {
@@ -112,13 +112,13 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
         // maintain a connection-based session for NTLM tokens
         String connectionId = NtlmServletRequest.getConnectionId(request);
 
-        _log.debug("security package: {}, connection id: {}", securityPackage, connectionId);
+        this.log.debug("security package: {}, connection id: {}", securityPackage, connectionId);
 
         boolean ntlmPost = authorizationHeader.isNtlmType1PostAuthorizationHeader();
 
         if (ntlmPost) {
             // type 1 NTLM authentication message received
-            _auth.resetSecurityToken(connectionId);
+            this.auth.resetSecurityToken(connectionId);
         }
 
         // log the user in using the token
@@ -126,14 +126,14 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
 
         try {
             byte[] tokenBuffer = authorizationHeader.getTokenBytes();
-            _log.debug("token buffer: {} byte(s)", Integer.valueOf(tokenBuffer.length));
-            securityContext = _auth.acceptSecurityToken(connectionId, tokenBuffer, securityPackage);
-            _log.debug("continue required: {}", Boolean.valueOf(securityContext.isContinue()));
+            this.log.debug("token buffer: {} byte(s)", Integer.valueOf(tokenBuffer.length));
+            securityContext = this.auth.acceptSecurityToken(connectionId, tokenBuffer, securityPackage);
+            this.log.debug("continue required: {}", Boolean.valueOf(securityContext.isContinue()));
 
             byte[] continueTokenBytes = securityContext.getToken();
             if (continueTokenBytes != null && continueTokenBytes.length > 0) {
                 String continueToken = BaseEncoding.base64().encode(continueTokenBytes);
-                _log.debug("continue token: {}", continueToken);
+                this.log.debug("continue token: {}", continueToken);
                 response.addHeader("WWW-Authenticate", securityPackage + " " + continueToken);
             }
 
@@ -145,8 +145,8 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
             }
 
         } catch (IOException e) {
-            _log.warn("error logging in user: {}", e.getMessage());
-            _log.trace("{}", e);
+            this.log.warn("error logging in user: {}", e.getMessage());
+            this.log.trace("{}", e);
             sendUnauthorized(response);
             return false;
         }
@@ -155,27 +155,27 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
         IWindowsIdentity windowsIdentity = securityContext.getIdentity();
 
         // disable guest login
-        if (!_allowGuestLogin && windowsIdentity.isGuest()) {
-            _log.warn("guest login disabled: {}", windowsIdentity.getFqn());
+        if (!this.allowGuestLogin && windowsIdentity.isGuest()) {
+            this.log.warn("guest login disabled: {}", windowsIdentity.getFqn());
             sendUnauthorized(response);
             return false;
         }
 
         try {
 
-            _log.debug("logged in user: {} ({})", windowsIdentity.getFqn(), windowsIdentity.getSidString());
+            this.log.debug("logged in user: {} ({})", windowsIdentity.getFqn(), windowsIdentity.getSidString());
 
-            GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity, context.getRealm(),
-                    _principalFormat, _roleFormat);
+            GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity,
+                    this.context.getRealm(), this.principalFormat, this.roleFormat);
 
-            _log.debug("roles: {}", windowsPrincipal.getRolesString());
+            this.log.debug("roles: {}", windowsPrincipal.getRolesString());
 
             // create a session associated with this request if there's none
             HttpSession session = request.getSession(true);
-            _log.debug("session id: {}", session.getId());
+            this.log.debug("session id: {}", session.getId());
 
             register(request, response, windowsPrincipal, securityPackage, windowsPrincipal.getName(), null);
-            _log.info("successfully logged in user: {}", windowsPrincipal.getName());
+            this.log.info("successfully logged in user: {}", windowsPrincipal.getName());
 
         } finally {
             windowsIdentity.dispose();
@@ -189,37 +189,37 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
         String username = request.getParameter("j_username");
         String password = request.getParameter("j_password");
 
-        _log.debug("logging in: {}", username);
+        this.log.debug("logging in: {}", username);
 
         IWindowsIdentity windowsIdentity = null;
         try {
-            windowsIdentity = _auth.logonUser(username, password);
+            windowsIdentity = this.auth.logonUser(username, password);
         } catch (Exception e) {
-            _log.error(e.getMessage());
-            _log.trace("{}", e);
+            this.log.error(e.getMessage());
+            this.log.trace("{}", e);
             return false;
         }
 
         // disable guest login
-        if (!_allowGuestLogin && windowsIdentity.isGuest()) {
-            _log.warn("guest login disabled: {}", windowsIdentity.getFqn());
+        if (!this.allowGuestLogin && windowsIdentity.isGuest()) {
+            this.log.warn("guest login disabled: {}", windowsIdentity.getFqn());
             return false;
         }
 
         try {
-            _log.debug("successfully logged in {} ({})", username, windowsIdentity.getSidString());
+            this.log.debug("successfully logged in {} ({})", username, windowsIdentity.getSidString());
 
-            GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity, context.getRealm(),
-                    _principalFormat, _roleFormat);
+            GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity,
+                    this.context.getRealm(), this.principalFormat, this.roleFormat);
 
-            _log.debug("roles: {}", windowsPrincipal.getRolesString());
+            this.log.debug("roles: {}", windowsPrincipal.getRolesString());
 
             // create a session associated with this request if there's none
             HttpSession session = request.getSession(true);
-            _log.debug("session id: {}", session.getId());
+            this.log.debug("session id: {}", session.getId());
 
             register(request, response, windowsPrincipal, "FORM", windowsPrincipal.getName(), null);
-            _log.info("successfully logged in user: {}", windowsPrincipal.getName());
+            this.log.info("successfully logged in user: {}", windowsPrincipal.getName());
         } finally {
             windowsIdentity.dispose();
         }
@@ -229,17 +229,17 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
 
     private void redirectTo(Request request, Response response, String url) {
         try {
-            _log.debug("redirecting to: {}", url);
-            ServletContext servletContext = context.getServletContext();
+            this.log.debug("redirecting to: {}", url);
+            ServletContext servletContext = this.context.getServletContext();
             RequestDispatcher disp = servletContext.getRequestDispatcher(url);
             disp.forward(request.getRequest(), response);
         } catch (IOException e) {
-            _log.error(e.getMessage());
-            _log.trace("{}", e);
+            this.log.error(e.getMessage());
+            this.log.trace("{}", e);
             throw new RuntimeException(e);
         } catch (ServletException e) {
-            _log.error(e.getMessage());
-            _log.trace("{}", e);
+            this.log.error(e.getMessage());
+            this.log.trace("{}", e);
             throw new RuntimeException(e);
         }
     }

--- a/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/NegotiateAuthenticator.java
+++ b/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/NegotiateAuthenticator.java
@@ -40,19 +40,19 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
 
     public NegotiateAuthenticator() {
         super();
-        _log = LoggerFactory.getLogger(NegotiateAuthenticator.class);
-        _info = "waffle.apache.NegotiateAuthenticator/1.0";
-        _log.debug("[waffle.apache.NegotiateAuthenticator] loaded");
+        this.log = LoggerFactory.getLogger(NegotiateAuthenticator.class);
+        this.info = "waffle.apache.NegotiateAuthenticator/1.0";
+        this.log.debug("[waffle.apache.NegotiateAuthenticator] loaded");
     }
 
     @Override
     public void start() {
-        _log.info("[waffle.apache.NegotiateAuthenticator] started");
+        this.log.info("[waffle.apache.NegotiateAuthenticator] started");
     }
 
     @Override
     public void stop() {
-        _log.info("[waffle.apache.NegotiateAuthenticator] stopped");
+        this.log.info("[waffle.apache.NegotiateAuthenticator] stopped");
     }
 
     @Override
@@ -62,13 +62,13 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
         AuthorizationHeader authorizationHeader = new AuthorizationHeader(request);
         boolean ntlmPost = authorizationHeader.isNtlmType1PostAuthorizationHeader();
 
-        _log.debug("{} {}, contentlength: {}", request.getMethod(), request.getRequestURI(),
+        this.log.debug("{} {}, contentlength: {}", request.getMethod(), request.getRequestURI(),
                 Integer.valueOf(request.getContentLength()));
-        _log.debug("authorization: {}, ntlm post: {}", authorizationHeader, Boolean.valueOf(ntlmPost));
+        this.log.debug("authorization: {}, ntlm post: {}", authorizationHeader, Boolean.valueOf(ntlmPost));
 
         if (principal != null && !ntlmPost) {
             // user already authenticated
-            _log.debug("previously authenticated user: {}", principal.getName());
+            this.log.debug("previously authenticated user: {}", principal.getName());
             return true;
         }
 
@@ -79,11 +79,11 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
             // maintain a connection-based session for NTLM tokens
             String connectionId = NtlmServletRequest.getConnectionId(request);
 
-            _log.debug("security package: {}, connection id: {}", securityPackage, connectionId);
+            this.log.debug("security package: {}, connection id: {}", securityPackage, connectionId);
 
             if (ntlmPost) {
                 // type 1 NTLM authentication message received
-                _auth.resetSecurityToken(connectionId);
+                this.auth.resetSecurityToken(connectionId);
             }
 
             // log the user in using the token
@@ -91,14 +91,14 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
 
             try {
                 byte[] tokenBuffer = authorizationHeader.getTokenBytes();
-                _log.debug("token buffer: {} byte(s)", Integer.valueOf(tokenBuffer.length));
-                securityContext = _auth.acceptSecurityToken(connectionId, tokenBuffer, securityPackage);
-                _log.debug("continue required: {}", Boolean.valueOf(securityContext.isContinue()));
+                this.log.debug("token buffer: {} byte(s)", Integer.valueOf(tokenBuffer.length));
+                securityContext = this.auth.acceptSecurityToken(connectionId, tokenBuffer, securityPackage);
+                this.log.debug("continue required: {}", Boolean.valueOf(securityContext.isContinue()));
 
                 byte[] continueTokenBytes = securityContext.getToken();
                 if (continueTokenBytes != null && continueTokenBytes.length > 0) {
                     String continueToken = BaseEncoding.base64().encode(continueTokenBytes);
-                    _log.debug("continue token: {}", continueToken);
+                    this.log.debug("continue token: {}", continueToken);
                     response.addHeader("WWW-Authenticate", securityPackage + " " + continueToken);
                 }
 
@@ -110,15 +110,15 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
                 }
 
             } catch (IOException e) {
-                _log.warn("error logging in user: {}", e.getMessage());
-                _log.trace("{}", e);
+                this.log.warn("error logging in user: {}", e.getMessage());
+                this.log.trace("{}", e);
                 sendUnauthorized(response);
                 return false;
             }
 
             // realm: fail if no realm is configured
-            if (context == null || context.getRealm() == null) {
-                _log.warn("missing context/realm");
+            if (this.context == null || this.context.getRealm() == null) {
+                this.log.warn("missing context/realm");
                 sendError(response, HttpServletResponse.SC_SERVICE_UNAVAILABLE);
                 return false;
             }
@@ -127,29 +127,29 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
             IWindowsIdentity windowsIdentity = securityContext.getIdentity();
 
             // disable guest login
-            if (!_allowGuestLogin && windowsIdentity.isGuest()) {
-                _log.warn("guest login disabled: {}", windowsIdentity.getFqn());
+            if (!this.allowGuestLogin && windowsIdentity.isGuest()) {
+                this.log.warn("guest login disabled: {}", windowsIdentity.getFqn());
                 sendUnauthorized(response);
                 return false;
             }
 
             try {
-                _log.debug("logged in user: {} ({})", windowsIdentity.getFqn(), windowsIdentity.getSidString());
+                this.log.debug("logged in user: {} ({})", windowsIdentity.getFqn(), windowsIdentity.getSidString());
 
                 GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity,
-                        context.getRealm(), _principalFormat, _roleFormat);
+                        this.context.getRealm(), this.principalFormat, this.roleFormat);
 
-                _log.debug("roles: {}", windowsPrincipal.getRolesString());
+                this.log.debug("roles: {}", windowsPrincipal.getRolesString());
 
                 principal = windowsPrincipal;
 
                 // create a session associated with this request if there's none
                 HttpSession session = request.getSession(true);
-                _log.debug("session id: {}", session.getId());
+                this.log.debug("session id: {}", session.getId());
 
                 // register the authenticated principal
                 register(request, response, principal, securityPackage, principal.getName(), null);
-                _log.info("successfully logged in user: {}", principal.getName());
+                this.log.info("successfully logged in user: {}", principal.getName());
 
             } finally {
                 windowsIdentity.dispose();
@@ -158,7 +158,7 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
             return true;
         }
 
-        _log.debug("authorization required");
+        this.log.debug("authorization required");
         sendUnauthorized(response);
         return false;
     }

--- a/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
+++ b/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
@@ -36,14 +36,14 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
 
     private static final Set<String> SUPPORTED_PROTOCOLS = new LinkedHashSet<String>(asList("Negotiate", "NTLM"));
 
-    protected String                 _info;
-    protected Logger                 _log;
-    protected PrincipalFormat        _principalFormat    = PrincipalFormat.fqn;
-    protected PrincipalFormat        _roleFormat         = PrincipalFormat.fqn;
-    protected boolean                _allowGuestLogin    = true;
-    protected Set<String>            _protocols          = SUPPORTED_PROTOCOLS;
+    protected String                 info;
+    protected Logger                 log;
+    protected PrincipalFormat        principalFormat     = PrincipalFormat.fqn;
+    protected PrincipalFormat        roleFormat          = PrincipalFormat.fqn;
+    protected boolean                allowGuestLogin     = true;
+    protected Set<String>            protocols           = SUPPORTED_PROTOCOLS;
 
-    protected IWindowsAuthProvider   _auth               = new WindowsAuthProviderImpl();
+    protected IWindowsAuthProvider   auth                = new WindowsAuthProviderImpl();
 
     /**
      * Windows authentication provider.
@@ -51,7 +51,7 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
      * @return IWindowsAuthProvider.
      */
     public IWindowsAuthProvider getAuth() {
-        return _auth;
+        return this.auth;
     }
 
     /**
@@ -61,12 +61,12 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
      *            Class implements IWindowsAuthProvider.
      */
     public void setAuth(IWindowsAuthProvider provider) {
-        _auth = provider;
+        this.auth = provider;
     }
 
     @Override
     public String getInfo() {
-        return _info;
+        return this.info;
     }
 
     /**
@@ -76,8 +76,8 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
      *            Principal format.
      */
     public void setPrincipalFormat(String format) {
-        _principalFormat = PrincipalFormat.valueOf(format);
-        _log.debug("principal format: {}", _principalFormat);
+        this.principalFormat = PrincipalFormat.valueOf(format);
+        this.log.debug("principal format: {}", this.principalFormat);
     }
 
     /**
@@ -86,7 +86,7 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
      * @return Principal format.
      */
     public PrincipalFormat getPrincipalFormat() {
-        return _principalFormat;
+        return this.principalFormat;
     }
 
     /**
@@ -96,8 +96,8 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
      *            Role format.
      */
     public void setRoleFormat(String format) {
-        _roleFormat = PrincipalFormat.valueOf(format);
-        _log.debug("role format: {}", _roleFormat);
+        this.roleFormat = PrincipalFormat.valueOf(format);
+        this.log.debug("role format: {}", this.roleFormat);
     }
 
     /**
@@ -106,7 +106,7 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
      * @return Role format.
      */
     public PrincipalFormat getRoleFormat() {
-        return _roleFormat;
+        return this.roleFormat;
     }
 
     /**
@@ -115,7 +115,7 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
      * @return True if Guest login permitted, false otherwise.
      */
     public boolean isAllowGuestLogin() {
-        return _allowGuestLogin;
+        return this.allowGuestLogin;
     }
 
     /**
@@ -126,26 +126,26 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
      *            True or false.
      */
     public void setAllowGuestLogin(boolean value) {
-        _allowGuestLogin = value;
+        this.allowGuestLogin = value;
     }
 
     /**
      * Set the authentication protocols. Default is "Negotiate, NTLM".
      * 
-     * @param protocols
+     * @param value
      *            Authentication protocols
      */
-    public void setProtocols(String protocols) {
-        _protocols = new LinkedHashSet<String>();
-        String[] protocolNames = protocols.split(",");
+    public void setProtocols(String value) {
+        this.protocols = new LinkedHashSet<String>();
+        String[] protocolNames = value.split(",");
         for (String protocolName : protocolNames) {
             protocolName = protocolName.trim();
             if (!protocolName.isEmpty()) {
-                _log.debug("init protocol: {}", protocolName);
+                this.log.debug("init protocol: {}", protocolName);
                 if (SUPPORTED_PROTOCOLS.contains(protocolName)) {
-                    _protocols.add(protocolName);
+                    this.protocols.add(protocolName);
                 } else {
-                    _log.error("unsupported protocol: {}", protocolName);
+                    this.log.error("unsupported protocol: {}", protocolName);
                     throw new RuntimeException("Unsupported protocol: " + protocolName);
                 }
             }
@@ -160,7 +160,7 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
      */
     protected void sendUnauthorized(Response response) {
         try {
-            for (String protocol : _protocols) {
+            for (String protocol : this.protocols) {
                 response.addHeader("WWW-Authenticate", protocol);
             }
             response.setHeader("Connection", "close");
@@ -183,8 +183,8 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
         try {
             response.sendError(code);
         } catch (IOException e) {
-            _log.error(e.getMessage());
-            _log.trace("{}", e);
+            this.log.error(e.getMessage());
+            this.log.trace("{}", e);
             throw new RuntimeException(e);
         }
     }

--- a/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/WindowsRealm.java
+++ b/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/WindowsRealm.java
@@ -24,11 +24,11 @@ import org.apache.catalina.realm.RealmBase;
  */
 public class WindowsRealm extends RealmBase {
 
-    protected static final String _name = "waffle.apache.WindowsRealm/1.0";
+    protected static final String name = "waffle.apache.WindowsRealm/1.0";
 
     @Override
     protected String getName() {
-        return _name;
+        return name;
     }
 
     @Override

--- a/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/MixedAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/MixedAuthenticatorTests.java
@@ -44,26 +44,26 @@ import com.sun.jna.platform.win32.Sspi.SecBufferDesc;
  */
 public class MixedAuthenticatorTests {
 
-    private MixedAuthenticator _authenticator;
+    private MixedAuthenticator authenticator;
 
     @Before
     public void setUp() {
-        _authenticator = new MixedAuthenticator();
+        this.authenticator = new MixedAuthenticator();
         SimpleContext ctx = new SimpleContext();
         Realm realm = new SimpleRealm();
         ctx.setRealm(realm);
-        _authenticator.setContainer(ctx);
-        _authenticator.start();
+        this.authenticator.setContainer(ctx);
+        this.authenticator.start();
     }
 
     @After
     public void tearDown() {
-        _authenticator.stop();
+        this.authenticator.stop();
     }
 
     @Test
     public void testGetInfo() {
-        assertTrue(_authenticator.getInfo().length() > 0);
+        assertTrue(this.authenticator.getInfo().length() > 0);
     }
 
     @Test
@@ -72,7 +72,7 @@ public class MixedAuthenticatorTests {
         request.setMethod("GET");
         request.setQueryString("j_negotiate_check");
         SimpleHttpResponse response = new SimpleHttpResponse();
-        _authenticator.authenticate(request, response, null);
+        this.authenticator.authenticate(request, response, null);
         String[] wwwAuthenticates = response.getHeaderValues("WWW-Authenticate");
         assertEquals(2, wwwAuthenticates.length);
         assertEquals("Negotiate", wwwAuthenticates[0]);
@@ -104,7 +104,7 @@ public class MixedAuthenticatorTests {
             String clientToken = BaseEncoding.base64().encode(clientContext.getToken());
             request.addHeader("Authorization", securityPackage + " " + clientToken);
             SimpleHttpResponse response = new SimpleHttpResponse();
-            _authenticator.authenticate(request, response, null);
+            this.authenticator.authenticate(request, response, null);
             assertTrue(response.getHeader("WWW-Authenticate").startsWith(securityPackage + " "));
             assertEquals("keep-alive", response.getHeader("Connection"));
             assertEquals(2, response.getHeaderNames().length);
@@ -144,7 +144,7 @@ public class MixedAuthenticatorTests {
                 request.addHeader("Authorization", securityPackage + " " + clientToken);
 
                 SimpleHttpResponse response = new SimpleHttpResponse();
-                authenticated = _authenticator.authenticate(request, response, null);
+                authenticated = this.authenticator.authenticate(request, response, null);
 
                 if (authenticated) {
                     assertTrue(response.getHeaderNames().length >= 0);
@@ -180,7 +180,7 @@ public class MixedAuthenticatorTests {
         loginConfig.setLoginPage("login.html");
         SimpleHttpRequest request = new SimpleHttpRequest();
         SimpleHttpResponse response = new SimpleHttpResponse();
-        assertFalse(_authenticator.authenticate(request, response, loginConfig));
+        assertFalse(this.authenticator.authenticate(request, response, loginConfig));
         assertEquals(304, response.getStatus());
         assertEquals("login.html", response.getHeader("Location"));
         assertEquals(1, response.getHeaderNames().length);
@@ -196,7 +196,7 @@ public class MixedAuthenticatorTests {
         request.addParameter("j_username", "username");
         request.addParameter("j_password", "password");
         SimpleHttpResponse response = new SimpleHttpResponse();
-        assertFalse(_authenticator.authenticate(request, response, loginConfig));
+        assertFalse(this.authenticator.authenticate(request, response, loginConfig));
         assertEquals(304, response.getStatus());
         assertEquals("error.html", response.getHeader("Location"));
         assertEquals(1, response.getHeaderNames().length);
@@ -204,7 +204,7 @@ public class MixedAuthenticatorTests {
 
     @Test
     public void testSecurityCheckQueryString() {
-        _authenticator.setAuth(new MockWindowsAuthProvider());
+        this.authenticator.setAuth(new MockWindowsAuthProvider());
         LoginConfig loginConfig = new LoginConfig();
         loginConfig.setErrorPage("error.html");
         loginConfig.setLoginPage("login.html");
@@ -213,12 +213,12 @@ public class MixedAuthenticatorTests {
         request.addParameter("j_username", WindowsAccountImpl.getCurrentUsername());
         request.addParameter("j_password", "");
         SimpleHttpResponse response = new SimpleHttpResponse();
-        assertTrue(_authenticator.authenticate(request, response, loginConfig));
+        assertTrue(this.authenticator.authenticate(request, response, loginConfig));
     }
 
     @Test
     public void testSecurityCheckParameters() {
-        _authenticator.setAuth(new MockWindowsAuthProvider());
+        this.authenticator.setAuth(new MockWindowsAuthProvider());
         LoginConfig loginConfig = new LoginConfig();
         loginConfig.setErrorPage("error.html");
         loginConfig.setLoginPage("login.html");
@@ -227,6 +227,6 @@ public class MixedAuthenticatorTests {
         request.addParameter("j_username", WindowsAccountImpl.getCurrentUsername());
         request.addParameter("j_password", "");
         SimpleHttpResponse response = new SimpleHttpResponse();
-        assertTrue(_authenticator.authenticate(request, response, loginConfig));
+        assertTrue(this.authenticator.authenticate(request, response, loginConfig));
     }
 }

--- a/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
@@ -47,50 +47,50 @@ import com.sun.jna.platform.win32.Sspi.SecBufferDesc;
  */
 public class NegotiateAuthenticatorTests {
 
-    private static final Logger    logger = LoggerFactory.getLogger(NegotiateAuthenticatorTests.class);
+    private static final Logger    LOGGER = LoggerFactory.getLogger(NegotiateAuthenticatorTests.class);
 
-    private NegotiateAuthenticator _authenticator;
+    private NegotiateAuthenticator authenticator;
 
     @Before
     public void setUp() {
-        _authenticator = new NegotiateAuthenticator();
+        this.authenticator = new NegotiateAuthenticator();
         SimpleContext ctx = new SimpleContext();
         Realm realm = new SimpleRealm();
         ctx.setRealm(realm);
-        _authenticator.setContainer(ctx);
-        _authenticator.start();
+        this.authenticator.setContainer(ctx);
+        this.authenticator.start();
     }
 
     @After
     public void tearDown() {
-        _authenticator.stop();
+        this.authenticator.stop();
     }
 
     @Test
     public void testGetInfo() {
-        assertTrue(_authenticator.getInfo().length() > 0);
-        assertTrue(_authenticator.getAuth() instanceof WindowsAuthProviderImpl);
+        assertTrue(this.authenticator.getInfo().length() > 0);
+        assertTrue(this.authenticator.getAuth() instanceof WindowsAuthProviderImpl);
     }
 
     @Test
     public void testAllowGuestLogin() {
-        assertTrue(_authenticator.isAllowGuestLogin());
-        _authenticator.setAllowGuestLogin(false);
-        assertFalse(_authenticator.isAllowGuestLogin());
+        assertTrue(this.authenticator.isAllowGuestLogin());
+        this.authenticator.setAllowGuestLogin(false);
+        assertFalse(this.authenticator.isAllowGuestLogin());
     }
 
     @Test
     public void testPrincipalFormat() {
-        assertEquals(PrincipalFormat.fqn, _authenticator.getPrincipalFormat());
-        _authenticator.setPrincipalFormat("both");
-        assertEquals(PrincipalFormat.both, _authenticator.getPrincipalFormat());
+        assertEquals(PrincipalFormat.fqn, this.authenticator.getPrincipalFormat());
+        this.authenticator.setPrincipalFormat("both");
+        assertEquals(PrincipalFormat.both, this.authenticator.getPrincipalFormat());
     }
 
     @Test
     public void testRoleFormat() {
-        assertEquals(PrincipalFormat.fqn, _authenticator.getRoleFormat());
-        _authenticator.setRoleFormat("both");
-        assertEquals(PrincipalFormat.both, _authenticator.getRoleFormat());
+        assertEquals(PrincipalFormat.fqn, this.authenticator.getRoleFormat());
+        this.authenticator.setRoleFormat("both");
+        assertEquals(PrincipalFormat.both, this.authenticator.getRoleFormat());
     }
 
     @Test
@@ -98,7 +98,7 @@ public class NegotiateAuthenticatorTests {
         SimpleHttpRequest request = new SimpleHttpRequest();
         request.setMethod("GET");
         SimpleHttpResponse response = new SimpleHttpResponse();
-        _authenticator.authenticate(request, response, null);
+        this.authenticator.authenticate(request, response, null);
         String[] wwwAuthenticates = response.getHeaderValues("WWW-Authenticate");
         assertEquals(2, wwwAuthenticates.length);
         assertEquals("Negotiate", wwwAuthenticates[0]);
@@ -128,7 +128,7 @@ public class NegotiateAuthenticatorTests {
             String clientToken = BaseEncoding.base64().encode(clientContext.getToken());
             request.addHeader("Authorization", securityPackage + " " + clientToken);
             SimpleHttpResponse response = new SimpleHttpResponse();
-            _authenticator.authenticate(request, response, null);
+            this.authenticator.authenticate(request, response, null);
             assertTrue(response.getHeader("WWW-Authenticate").startsWith(securityPackage + " "));
             assertEquals("keep-alive", response.getHeader("Connection"));
             assertEquals(2, response.getHeaderNames().length);
@@ -169,9 +169,9 @@ public class NegotiateAuthenticatorTests {
 
                 SimpleHttpResponse response = new SimpleHttpResponse();
                 try {
-                    authenticated = _authenticator.authenticate(request, response, null);
+                    authenticated = this.authenticator.authenticate(request, response, null);
                 } catch (Exception e) {
-                    logger.error("{}", e);
+                    LOGGER.error("{}", e);
                     return;
                 }
 
@@ -225,7 +225,7 @@ public class NegotiateAuthenticatorTests {
                 request.addHeader("Authorization", securityPackage + " " + clientToken);
 
                 SimpleHttpResponse response = new SimpleHttpResponse();
-                authenticated = _authenticator.authenticate(request, response, null);
+                authenticated = this.authenticator.authenticate(request, response, null);
 
                 if (authenticated) {
                     assertNotNull(request.getUserPrincipal());

--- a/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/WaffleAuthenticatorBaseTest.java
+++ b/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/WaffleAuthenticatorBaseTest.java
@@ -31,9 +31,9 @@ public class WaffleAuthenticatorBaseTest {
 
     @Before
     public void init() {
-        waffleAuthenticatorBase = new WaffleAuthenticatorBase() {
+        this.waffleAuthenticatorBase = new WaffleAuthenticatorBase() {
             {
-                _log = LoggerFactory.getLogger(WaffleAuthenticatorBaseTest.class);
+                this.log = LoggerFactory.getLogger(WaffleAuthenticatorBaseTest.class);
             }
 
             @Override
@@ -45,31 +45,31 @@ public class WaffleAuthenticatorBaseTest {
 
     @Test
     public void should_accept_NTLM_protocol() throws Exception {
-        waffleAuthenticatorBase.setProtocols("  NTLM ");
+        this.waffleAuthenticatorBase.setProtocols("  NTLM ");
 
-        assertEquals("One protocol added", 1, waffleAuthenticatorBase._protocols.size());
-        assertEquals("NTLM", waffleAuthenticatorBase._protocols.iterator().next());
+        assertEquals("One protocol added", 1, this.waffleAuthenticatorBase.protocols.size());
+        assertEquals("NTLM", this.waffleAuthenticatorBase.protocols.iterator().next());
     }
 
     @Test
     public void should_accept_Negotiate_protocol() throws Exception {
-        waffleAuthenticatorBase.setProtocols(" Negotiate  ");
+        this.waffleAuthenticatorBase.setProtocols(" Negotiate  ");
 
-        assertEquals("One protocol added", 1, waffleAuthenticatorBase._protocols.size());
-        assertEquals("Negotiate", waffleAuthenticatorBase._protocols.iterator().next());
+        assertEquals("One protocol added", 1, this.waffleAuthenticatorBase.protocols.size());
+        assertEquals("Negotiate", this.waffleAuthenticatorBase.protocols.iterator().next());
     }
 
     @Test
     public void should_accept_both_protocols() throws Exception {
-        waffleAuthenticatorBase.setProtocols("  NTLM , , Negotiate   ");
+        this.waffleAuthenticatorBase.setProtocols("  NTLM , , Negotiate   ");
 
-        assertEquals("Two protocols added", 2, waffleAuthenticatorBase._protocols.size());
-        assertTrue("NTLM has been added", waffleAuthenticatorBase._protocols.contains("NTLM"));
-        assertTrue("Negotiate has been added", waffleAuthenticatorBase._protocols.contains("Negotiate"));
+        assertEquals("Two protocols added", 2, this.waffleAuthenticatorBase.protocols.size());
+        assertTrue("NTLM has been added", this.waffleAuthenticatorBase.protocols.contains("NTLM"));
+        assertTrue("Negotiate has been added", this.waffleAuthenticatorBase.protocols.contains("Negotiate"));
     }
 
     @Test(expected = RuntimeException.class)
     public void should_refuse_other_protocol() throws Exception {
-        waffleAuthenticatorBase.setProtocols("  NTLM , OTHER, Negotiate   ");
+        this.waffleAuthenticatorBase.setProtocols("  NTLM , OTHER, Negotiate   ");
     }
 }

--- a/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/WindowsAccountTests.java
+++ b/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/WindowsAccountTests.java
@@ -35,27 +35,27 @@ import waffle.windows.auth.WindowsAccount;
  */
 public class WindowsAccountTests {
 
-    private MockWindowsAccount _mockWindowsAccount = new MockWindowsAccount("localhost\\Administrator");
-    private WindowsAccount     _windowsAccount;
+    private MockWindowsAccount mockWindowsAccount = new MockWindowsAccount("localhost\\Administrator");
+    private WindowsAccount     windowsAccount;
 
     @Before
     public void setUp() {
-        _windowsAccount = new WindowsAccount(_mockWindowsAccount);
+        this.windowsAccount = new WindowsAccount(this.mockWindowsAccount);
     }
 
     @Test
     public void testProperties() {
-        assertEquals("localhost", _windowsAccount.getDomain());
-        assertEquals("localhost\\Administrator", _windowsAccount.getFqn());
-        assertEquals("Administrator", _windowsAccount.getName());
-        assertTrue(_windowsAccount.getSidString().startsWith("S-"));
+        assertEquals("localhost", this.windowsAccount.getDomain());
+        assertEquals("localhost\\Administrator", this.windowsAccount.getFqn());
+        assertEquals("Administrator", this.windowsAccount.getName());
+        assertTrue(this.windowsAccount.getSidString().startsWith("S-"));
     }
 
     @Test
     public void testEquals() {
-        assertEquals(_windowsAccount, new WindowsAccount(_mockWindowsAccount));
+        assertEquals(this.windowsAccount, new WindowsAccount(this.mockWindowsAccount));
         MockWindowsAccount mockWindowsAccount2 = new MockWindowsAccount("localhost\\Administrator2");
-        assertFalse(_windowsAccount.equals(new WindowsAccount(mockWindowsAccount2)));
+        assertFalse(this.windowsAccount.equals(new WindowsAccount(mockWindowsAccount2)));
     }
 
     @Test
@@ -63,7 +63,7 @@ public class WindowsAccountTests {
         // serialize
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(out);
-        oos.writeObject(_windowsAccount);
+        oos.writeObject(this.windowsAccount);
         oos.close();
         assertTrue(out.toByteArray().length > 0);
         // deserialize
@@ -72,10 +72,10 @@ public class WindowsAccountTests {
         Object o = ois.readObject();
         WindowsAccount copy = (WindowsAccount) o;
         // test
-        assertEquals(_windowsAccount, copy);
-        assertEquals(_windowsAccount.getDomain(), copy.getDomain());
-        assertEquals(_windowsAccount.getFqn(), copy.getFqn());
-        assertEquals(_windowsAccount.getName(), copy.getName());
-        assertEquals(_windowsAccount.getSidString(), copy.getSidString());
+        assertEquals(this.windowsAccount, copy);
+        assertEquals(this.windowsAccount.getDomain(), copy.getDomain());
+        assertEquals(this.windowsAccount.getFqn(), copy.getFqn());
+        assertEquals(this.windowsAccount.getName(), copy.getName());
+        assertEquals(this.windowsAccount.getSidString(), copy.getSidString());
     }
 }

--- a/Source/JNA/waffle-tomcat7/pom.xml
+++ b/Source/JNA/waffle-tomcat7/pom.xml
@@ -13,7 +13,7 @@
     <name>waffle-tomcat7</name>
     <description>Tomcat 7 integration for WAFFLE</description>
     <properties>
-        <tomcat.version>7.0.54</tomcat.version>
+        <tomcat.version>7.0.55</tomcat.version>
     </properties>
     <dependencies>
         <dependency>

--- a/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/GenericWindowsPrincipal.java
+++ b/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/GenericWindowsPrincipal.java
@@ -32,9 +32,9 @@ import waffle.windows.auth.WindowsAccount;
  */
 public class GenericWindowsPrincipal extends GenericPrincipal {
 
-    private byte[]                      _sid;
-    private String                      _sidString;
-    private Map<String, WindowsAccount> _groups;
+    private byte[]                      sid;
+    private String                      sidString;
+    private Map<String, WindowsAccount> groups;
 
     /**
      * A windows principal.
@@ -49,9 +49,9 @@ public class GenericWindowsPrincipal extends GenericPrincipal {
     public GenericWindowsPrincipal(IWindowsIdentity windowsIdentity, PrincipalFormat principalFormat,
             PrincipalFormat roleFormat) {
         super(windowsIdentity.getFqn(), "", getRoles(windowsIdentity, principalFormat, roleFormat));
-        _sid = windowsIdentity.getSid();
-        _sidString = windowsIdentity.getSidString();
-        _groups = getGroups(windowsIdentity.getGroups());
+        this.sid = windowsIdentity.getSid();
+        this.sidString = windowsIdentity.getSidString();
+        this.groups = getGroups(windowsIdentity.getGroups());
     }
 
     private static List<String> getRoles(IWindowsIdentity windowsIdentity, PrincipalFormat principalFormat,
@@ -78,7 +78,7 @@ public class GenericWindowsPrincipal extends GenericPrincipal {
      * @return Array of bytes.
      */
     public byte[] getSid() {
-        return _sid.clone();
+        return this.sid.clone();
     }
 
     /**
@@ -87,7 +87,7 @@ public class GenericWindowsPrincipal extends GenericPrincipal {
      * @return String.
      */
     public String getSidString() {
-        return _sidString;
+        return this.sidString;
     }
 
     /**
@@ -96,7 +96,7 @@ public class GenericWindowsPrincipal extends GenericPrincipal {
      * @return A map of group names to groups.
      */
     public Map<String, WindowsAccount> getGroups() {
-        return _groups;
+        return this.groups;
     }
 
     /**

--- a/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/NegotiateAuthenticator.java
+++ b/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/NegotiateAuthenticator.java
@@ -40,21 +40,21 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
 
     public NegotiateAuthenticator() {
         super();
-        _log = LoggerFactory.getLogger(NegotiateAuthenticator.class);
-        _info = "waffle.apache.NegotiateAuthenticator/1.0";
-        _log.debug("[waffle.apache.NegotiateAuthenticator] loaded");
+        this.log = LoggerFactory.getLogger(NegotiateAuthenticator.class);
+        this.info = "waffle.apache.NegotiateAuthenticator/1.0";
+        this.log.debug("[waffle.apache.NegotiateAuthenticator] loaded");
     }
 
     @Override
     public synchronized void startInternal() throws LifecycleException {
-        _log.info("[waffle.apache.NegotiateAuthenticator] started");
+        this.log.info("[waffle.apache.NegotiateAuthenticator] started");
         super.startInternal();
     }
 
     @Override
     public synchronized void stopInternal() throws LifecycleException {
         super.stopInternal();
-        _log.info("[waffle.apache.NegotiateAuthenticator] stopped");
+        this.log.info("[waffle.apache.NegotiateAuthenticator] stopped");
     }
 
     @Override
@@ -64,13 +64,13 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
         AuthorizationHeader authorizationHeader = new AuthorizationHeader(request);
         boolean ntlmPost = authorizationHeader.isNtlmType1PostAuthorizationHeader();
 
-        _log.debug("{} {}, contentlength: {}", request.getMethod(), request.getRequestURI(),
+        this.log.debug("{} {}, contentlength: {}", request.getMethod(), request.getRequestURI(),
                 Integer.valueOf(request.getContentLength()));
-        _log.debug("authorization: {}, ntlm post: {}", authorizationHeader, Boolean.valueOf(ntlmPost));
+        this.log.debug("authorization: {}, ntlm post: {}", authorizationHeader, Boolean.valueOf(ntlmPost));
 
         if (principal != null && !ntlmPost) {
             // user already authenticated
-            _log.debug("previously authenticated user: {}", principal.getName());
+            this.log.debug("previously authenticated user: {}", principal.getName());
             return true;
         }
 
@@ -81,11 +81,11 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
             // maintain a connection-based session for NTLM tokens
             String connectionId = NtlmServletRequest.getConnectionId(request);
 
-            _log.debug("security package: {}, connection id: {}", securityPackage, connectionId);
+            this.log.debug("security package: {}, connection id: {}", securityPackage, connectionId);
 
             if (ntlmPost) {
                 // type 1 NTLM authentication message received
-                _auth.resetSecurityToken(connectionId);
+                this.auth.resetSecurityToken(connectionId);
             }
 
             // log the user in using the token
@@ -93,14 +93,14 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
 
             try {
                 byte[] tokenBuffer = authorizationHeader.getTokenBytes();
-                _log.debug("token buffer: {} byte(s)", Integer.valueOf(tokenBuffer.length));
-                securityContext = _auth.acceptSecurityToken(connectionId, tokenBuffer, securityPackage);
-                _log.debug("continue required: {}", Boolean.valueOf(securityContext.isContinue()));
+                this.log.debug("token buffer: {} byte(s)", Integer.valueOf(tokenBuffer.length));
+                securityContext = this.auth.acceptSecurityToken(connectionId, tokenBuffer, securityPackage);
+                this.log.debug("continue required: {}", Boolean.valueOf(securityContext.isContinue()));
 
                 byte[] continueTokenBytes = securityContext.getToken();
                 if (continueTokenBytes != null && continueTokenBytes.length > 0) {
                     String continueToken = BaseEncoding.base64().encode(continueTokenBytes);
-                    _log.debug("continue token: {}", continueToken);
+                    this.log.debug("continue token: {}", continueToken);
                     response.addHeader("WWW-Authenticate", securityPackage + " " + continueToken);
                 }
 
@@ -112,15 +112,15 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
                 }
 
             } catch (IOException e) {
-                _log.warn("error logging in user: {}", e.getMessage());
-                _log.trace("{}", e);
+                this.log.warn("error logging in user: {}", e.getMessage());
+                this.log.trace("{}", e);
                 sendUnauthorized(response);
                 return false;
             }
 
             // realm: fail if no realm is configured
-            if (context == null || context.getRealm() == null) {
-                _log.warn("missing context/realm");
+            if (this.context == null || this.context.getRealm() == null) {
+                this.log.warn("missing context/realm");
                 sendError(response, HttpServletResponse.SC_SERVICE_UNAVAILABLE);
                 return false;
             }
@@ -129,29 +129,29 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
             IWindowsIdentity windowsIdentity = securityContext.getIdentity();
 
             // disable guest login
-            if (!_allowGuestLogin && windowsIdentity.isGuest()) {
-                _log.warn("guest login disabled: {}", windowsIdentity.getFqn());
+            if (!this.allowGuestLogin && windowsIdentity.isGuest()) {
+                this.log.warn("guest login disabled: {}", windowsIdentity.getFqn());
                 sendUnauthorized(response);
                 return false;
             }
 
             try {
-                _log.debug("logged in user: {} ({})", windowsIdentity.getFqn(), windowsIdentity.getSidString());
+                this.log.debug("logged in user: {} ({})", windowsIdentity.getFqn(), windowsIdentity.getSidString());
 
                 GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity,
-                        _principalFormat, _roleFormat);
+                        this.principalFormat, this.roleFormat);
 
-                _log.debug("roles: {}", windowsPrincipal.getRolesString());
+                this.log.debug("roles: {}", windowsPrincipal.getRolesString());
 
                 principal = windowsPrincipal;
 
                 // create a session associated with this request if there's none
                 HttpSession session = request.getSession(true);
-                _log.debug("session id: {}", session.getId());
+                this.log.debug("session id: {}", session.getId());
 
                 // register the authenticated principal
                 register(request, response, principal, securityPackage, principal.getName(), null);
-                _log.info("successfully logged in user: {}", principal.getName());
+                this.log.info("successfully logged in user: {}", principal.getName());
 
             } finally {
                 windowsIdentity.dispose();
@@ -160,7 +160,7 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
             return true;
         }
 
-        _log.debug("authorization required");
+        this.log.debug("authorization required");
         sendUnauthorized(response);
         return false;
     }

--- a/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
+++ b/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
@@ -39,14 +39,14 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
 
     private static final Set<String> SUPPORTED_PROTOCOLS = new LinkedHashSet<String>(asList("Negotiate", "NTLM"));
 
-    protected String                 _info;
-    protected Logger                 _log;
-    protected PrincipalFormat        _principalFormat    = PrincipalFormat.fqn;
-    protected PrincipalFormat        _roleFormat         = PrincipalFormat.fqn;
-    protected boolean                _allowGuestLogin    = true;
-    protected Set<String>            _protocols          = SUPPORTED_PROTOCOLS;
+    protected String                 info;
+    protected Logger                 log;
+    protected PrincipalFormat        principalFormat     = PrincipalFormat.fqn;
+    protected PrincipalFormat        roleFormat          = PrincipalFormat.fqn;
+    protected boolean                allowGuestLogin     = true;
+    protected Set<String>            protocols           = SUPPORTED_PROTOCOLS;
 
-    protected IWindowsAuthProvider   _auth               = new WindowsAuthProviderImpl();
+    protected IWindowsAuthProvider   auth                = new WindowsAuthProviderImpl();
 
     /**
      * Windows authentication provider.
@@ -54,7 +54,7 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
      * @return IWindowsAuthProvider.
      */
     public IWindowsAuthProvider getAuth() {
-        return _auth;
+        return this.auth;
     }
 
     /**
@@ -64,12 +64,12 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
      *            Class implements IWindowsAuthProvider.
      */
     public void setAuth(IWindowsAuthProvider provider) {
-        _auth = provider;
+        this.auth = provider;
     }
 
     @Override
     public String getInfo() {
-        return _info;
+        return this.info;
     }
 
     /**
@@ -79,8 +79,8 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
      *            Principal format.
      */
     public void setPrincipalFormat(String format) {
-        _principalFormat = PrincipalFormat.valueOf(format);
-        _log.debug("principal format: {}", _principalFormat);
+        this.principalFormat = PrincipalFormat.valueOf(format);
+        this.log.debug("principal format: {}", this.principalFormat);
     }
 
     /**
@@ -89,7 +89,7 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
      * @return Principal format.
      */
     public PrincipalFormat getPrincipalFormat() {
-        return _principalFormat;
+        return this.principalFormat;
     }
 
     /**
@@ -99,8 +99,8 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
      *            Role format.
      */
     public void setRoleFormat(String format) {
-        _roleFormat = PrincipalFormat.valueOf(format);
-        _log.debug("role format: {}", _roleFormat);
+        this.roleFormat = PrincipalFormat.valueOf(format);
+        this.log.debug("role format: {}", this.roleFormat);
     }
 
     /**
@@ -109,7 +109,7 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
      * @return Role format.
      */
     public PrincipalFormat getRoleFormat() {
-        return _roleFormat;
+        return this.roleFormat;
     }
 
     /**
@@ -118,7 +118,7 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
      * @return True if Guest login permitted, false otherwise.
      */
     public boolean isAllowGuestLogin() {
-        return _allowGuestLogin;
+        return this.allowGuestLogin;
     }
 
     /**
@@ -129,7 +129,7 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
      *            True or false.
      */
     public void setAllowGuestLogin(boolean value) {
-        _allowGuestLogin = value;
+        this.allowGuestLogin = value;
     }
 
     /**
@@ -139,16 +139,16 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
      *            Authentication protocols
      */
     public void setProtocols(String protocols) {
-        _protocols = new LinkedHashSet<String>();
+        this.protocols = new LinkedHashSet<String>();
         String[] protocolNames = protocols.split(",");
         for (String protocolName : protocolNames) {
             protocolName = protocolName.trim();
             if (!protocolName.isEmpty()) {
-                _log.debug("init protocol: {}", protocolName);
+                this.log.debug("init protocol: {}", protocolName);
                 if (SUPPORTED_PROTOCOLS.contains(protocolName)) {
-                    _protocols.add(protocolName);
+                    this.protocols.add(protocolName);
                 } else {
-                    _log.error("unsupported protocol: {}", protocolName);
+                    this.log.error("unsupported protocol: {}", protocolName);
                     throw new RuntimeException("Unsupported protocol: " + protocolName);
                 }
             }
@@ -163,7 +163,7 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
      */
     protected void sendUnauthorized(HttpServletResponse response) {
         try {
-            for (String protocol : _protocols) {
+            for (String protocol : this.protocols) {
                 response.addHeader("WWW-Authenticate", protocol);
             }
             response.setHeader("Connection", "close");
@@ -186,8 +186,8 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
         try {
             response.sendError(code);
         } catch (IOException e) {
-            _log.error(e.getMessage());
-            _log.trace("{}", e);
+            this.log.error(e.getMessage());
+            this.log.trace("{}", e);
             throw new RuntimeException(e);
         }
     }
@@ -199,25 +199,25 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
 
     @Override
     protected Principal doLogin(Request request, String username, String password) throws ServletException {
-        _log.debug("logging in: {}", username);
+        this.log.debug("logging in: {}", username);
         IWindowsIdentity windowsIdentity;
         try {
-            windowsIdentity = _auth.logonUser(username, password);
+            windowsIdentity = this.auth.logonUser(username, password);
         } catch (Exception e) {
-            _log.error(e.getMessage());
-            _log.trace("{}", e);
+            this.log.error(e.getMessage());
+            this.log.trace("{}", e);
             return super.doLogin(request, username, password);
         }
         // disable guest login
-        if (!_allowGuestLogin && windowsIdentity.isGuest()) {
-            _log.warn("guest login disabled: {}", windowsIdentity.getFqn());
+        if (!this.allowGuestLogin && windowsIdentity.isGuest()) {
+            this.log.warn("guest login disabled: {}", windowsIdentity.getFqn());
             return super.doLogin(request, username, password);
         }
         try {
-            _log.debug("successfully logged in {} ({})", username, windowsIdentity.getSidString());
-            GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity, _principalFormat,
-                    _roleFormat);
-            _log.debug("roles: {}", windowsPrincipal.getRolesString());
+            this.log.debug("successfully logged in {} ({})", username, windowsIdentity.getSidString());
+            GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity,
+                    this.principalFormat, this.roleFormat);
+            this.log.debug("roles: {}", windowsPrincipal.getRolesString());
             return windowsPrincipal;
         } finally {
             windowsIdentity.dispose();

--- a/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/WindowsRealm.java
+++ b/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/WindowsRealm.java
@@ -24,11 +24,11 @@ import org.apache.catalina.realm.RealmBase;
  */
 public class WindowsRealm extends RealmBase {
 
-    protected static final String _name = "waffle.apache.WindowsRealm/1.0";
+    protected static final String name = "waffle.apache.WindowsRealm/1.0";
 
     @Override
     protected String getName() {
-        return _name;
+        return name;
     }
 
     @Override

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/MixedAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/MixedAuthenticatorTests.java
@@ -50,11 +50,11 @@ import com.sun.jna.platform.win32.Sspi.SecBufferDesc;
  */
 public class MixedAuthenticatorTests {
 
-    private MixedAuthenticator _authenticator;
+    private MixedAuthenticator authenticator;
 
     @Before
     public void setUp() throws LifecycleException {
-        _authenticator = new MixedAuthenticator();
+        this.authenticator = new MixedAuthenticator();
         SimpleContext ctx = new SimpleContext();
         Realm realm = new SimpleRealm();
         ctx.setRealm(realm);
@@ -63,19 +63,19 @@ public class MixedAuthenticatorTests {
         SimplePipeline pipeline = new SimplePipeline();
         engine.setPipeline(pipeline);
         ctx.setPipeline(pipeline);
-        ctx.setAuthenticator(_authenticator);
-        _authenticator.setContainer(ctx);
-        _authenticator.start();
+        ctx.setAuthenticator(this.authenticator);
+        this.authenticator.setContainer(ctx);
+        this.authenticator.start();
     }
 
     @After
     public void tearDown() throws LifecycleException {
-        _authenticator.stop();
+        this.authenticator.stop();
     }
 
     @Test
     public void testGetInfo() {
-        assertTrue(_authenticator.getInfo().length() > 0);
+        assertTrue(this.authenticator.getInfo().length() > 0);
     }
 
     @Test
@@ -84,7 +84,7 @@ public class MixedAuthenticatorTests {
         request.setMethod("GET");
         request.setQueryString("j_negotiate_check");
         SimpleHttpResponse response = new SimpleHttpResponse();
-        _authenticator.authenticate(request, response, null);
+        this.authenticator.authenticate(request, response, null);
         String[] wwwAuthenticates = response.getHeaderValues("WWW-Authenticate");
         assertEquals(2, wwwAuthenticates.length);
         assertEquals("Negotiate", wwwAuthenticates[0]);
@@ -116,7 +116,7 @@ public class MixedAuthenticatorTests {
             String clientToken = BaseEncoding.base64().encode(clientContext.getToken());
             request.addHeader("Authorization", securityPackage + " " + clientToken);
             SimpleHttpResponse response = new SimpleHttpResponse();
-            _authenticator.authenticate(request, response, null);
+            this.authenticator.authenticate(request, response, null);
             assertTrue(response.getHeader("WWW-Authenticate").startsWith(securityPackage + " "));
             assertEquals("keep-alive", response.getHeader("Connection"));
             assertEquals(2, response.getHeaderNames().size());
@@ -156,7 +156,7 @@ public class MixedAuthenticatorTests {
                 request.addHeader("Authorization", securityPackage + " " + clientToken);
 
                 SimpleHttpResponse response = new SimpleHttpResponse();
-                authenticated = _authenticator.authenticate(request, response, null);
+                authenticated = this.authenticator.authenticate(request, response, null);
 
                 if (authenticated) {
                     assertTrue(response.getHeaderNames().size() >= 0);
@@ -192,7 +192,7 @@ public class MixedAuthenticatorTests {
         loginConfig.setLoginPage("login.html");
         SimpleHttpRequest request = new SimpleHttpRequest();
         SimpleHttpResponse response = new SimpleHttpResponse();
-        assertFalse(_authenticator.authenticate(request, response, loginConfig));
+        assertFalse(this.authenticator.authenticate(request, response, loginConfig));
         assertEquals(304, response.getStatus());
         assertEquals("login.html", response.getHeader("Location"));
         assertEquals(1, response.getHeaderNames().size());
@@ -208,7 +208,7 @@ public class MixedAuthenticatorTests {
         request.addParameter("j_username", "username");
         request.addParameter("j_password", "password");
         SimpleHttpResponse response = new SimpleHttpResponse();
-        assertFalse(_authenticator.authenticate(request, response, loginConfig));
+        assertFalse(this.authenticator.authenticate(request, response, loginConfig));
         assertEquals(304, response.getStatus());
         assertEquals("error.html", response.getHeader("Location"));
         assertEquals(1, response.getHeaderNames().size());
@@ -216,7 +216,7 @@ public class MixedAuthenticatorTests {
 
     @Test
     public void testSecurityCheckQueryString() {
-        _authenticator.setAuth(new MockWindowsAuthProvider());
+        this.authenticator.setAuth(new MockWindowsAuthProvider());
         LoginConfig loginConfig = new LoginConfig();
         loginConfig.setErrorPage("error.html");
         loginConfig.setLoginPage("login.html");
@@ -225,12 +225,12 @@ public class MixedAuthenticatorTests {
         request.addParameter("j_username", WindowsAccountImpl.getCurrentUsername());
         request.addParameter("j_password", "");
         SimpleHttpResponse response = new SimpleHttpResponse();
-        assertTrue(_authenticator.authenticate(request, response, loginConfig));
+        assertTrue(this.authenticator.authenticate(request, response, loginConfig));
     }
 
     @Test
     public void testSecurityCheckParameters() {
-        _authenticator.setAuth(new MockWindowsAuthProvider());
+        this.authenticator.setAuth(new MockWindowsAuthProvider());
         LoginConfig loginConfig = new LoginConfig();
         loginConfig.setErrorPage("error.html");
         loginConfig.setLoginPage("login.html");
@@ -239,13 +239,13 @@ public class MixedAuthenticatorTests {
         request.addParameter("j_username", WindowsAccountImpl.getCurrentUsername());
         request.addParameter("j_password", "");
         SimpleHttpResponse response = new SimpleHttpResponse();
-        assertTrue(_authenticator.authenticate(request, response, loginConfig));
+        assertTrue(this.authenticator.authenticate(request, response, loginConfig));
     }
 
     public void testProgrammaticSecurity() throws ServletException {
-        _authenticator.setAuth(new MockWindowsAuthProvider());
+        this.authenticator.setAuth(new MockWindowsAuthProvider());
         SimpleHttpRequest request = new SimpleHttpRequest();
-        request.setContext((Context) _authenticator.getContainer());
+        request.setContext((Context) this.authenticator.getContainer());
 
         request.login(WindowsAccountImpl.getCurrentUsername(), "");
 

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
@@ -52,11 +52,11 @@ public class NegotiateAuthenticatorTests {
 
     private static final Logger    logger = LoggerFactory.getLogger(NegotiateAuthenticatorTests.class);
 
-    private NegotiateAuthenticator _authenticator;
+    private NegotiateAuthenticator authenticator;
 
     @Before
     public void setUp() throws LifecycleException {
-        _authenticator = new NegotiateAuthenticator();
+        this.authenticator = new NegotiateAuthenticator();
         SimpleContext ctx = new SimpleContext();
         Realm realm = new SimpleRealm();
         ctx.setRealm(realm);
@@ -65,40 +65,40 @@ public class NegotiateAuthenticatorTests {
         SimplePipeline pipeline = new SimplePipeline();
         engine.setPipeline(pipeline);
         ctx.setPipeline(pipeline);
-        _authenticator.setContainer(ctx);
-        _authenticator.start();
+        this.authenticator.setContainer(ctx);
+        this.authenticator.start();
     }
 
     @After
     public void tearDown() throws LifecycleException {
-        _authenticator.stop();
+        this.authenticator.stop();
     }
 
     @Test
     public void testGetInfo() {
-        assertTrue(_authenticator.getInfo().length() > 0);
-        assertTrue(_authenticator.getAuth() instanceof WindowsAuthProviderImpl);
+        assertTrue(this.authenticator.getInfo().length() > 0);
+        assertTrue(this.authenticator.getAuth() instanceof WindowsAuthProviderImpl);
     }
 
     @Test
     public void testAllowGuestLogin() {
-        assertTrue(_authenticator.isAllowGuestLogin());
-        _authenticator.setAllowGuestLogin(false);
-        assertFalse(_authenticator.isAllowGuestLogin());
+        assertTrue(this.authenticator.isAllowGuestLogin());
+        this.authenticator.setAllowGuestLogin(false);
+        assertFalse(this.authenticator.isAllowGuestLogin());
     }
 
     @Test
     public void testPrincipalFormat() {
-        assertEquals(PrincipalFormat.fqn, _authenticator.getPrincipalFormat());
-        _authenticator.setPrincipalFormat("both");
-        assertEquals(PrincipalFormat.both, _authenticator.getPrincipalFormat());
+        assertEquals(PrincipalFormat.fqn, this.authenticator.getPrincipalFormat());
+        this.authenticator.setPrincipalFormat("both");
+        assertEquals(PrincipalFormat.both, this.authenticator.getPrincipalFormat());
     }
 
     @Test
     public void testRoleFormat() {
-        assertEquals(PrincipalFormat.fqn, _authenticator.getRoleFormat());
-        _authenticator.setRoleFormat("both");
-        assertEquals(PrincipalFormat.both, _authenticator.getRoleFormat());
+        assertEquals(PrincipalFormat.fqn, this.authenticator.getRoleFormat());
+        this.authenticator.setRoleFormat("both");
+        assertEquals(PrincipalFormat.both, this.authenticator.getRoleFormat());
     }
 
     @Test
@@ -106,7 +106,7 @@ public class NegotiateAuthenticatorTests {
         SimpleHttpRequest request = new SimpleHttpRequest();
         request.setMethod("GET");
         SimpleHttpResponse response = new SimpleHttpResponse();
-        _authenticator.authenticate(request, response, null);
+        this.authenticator.authenticate(request, response, null);
         String[] wwwAuthenticates = response.getHeaderValues("WWW-Authenticate");
         assertEquals(2, wwwAuthenticates.length);
         assertEquals("Negotiate", wwwAuthenticates[0]);
@@ -136,7 +136,7 @@ public class NegotiateAuthenticatorTests {
             String clientToken = BaseEncoding.base64().encode(clientContext.getToken());
             request.addHeader("Authorization", securityPackage + " " + clientToken);
             SimpleHttpResponse response = new SimpleHttpResponse();
-            _authenticator.authenticate(request, response, null);
+            this.authenticator.authenticate(request, response, null);
             assertTrue(response.getHeader("WWW-Authenticate").startsWith(securityPackage + " "));
             assertEquals("keep-alive", response.getHeader("Connection"));
             assertEquals(2, response.getHeaderNames().size());
@@ -177,7 +177,7 @@ public class NegotiateAuthenticatorTests {
 
                 SimpleHttpResponse response = new SimpleHttpResponse();
                 try {
-                    authenticated = _authenticator.authenticate(request, response, null);
+                    authenticated = this.authenticator.authenticate(request, response, null);
                 } catch (Exception e) {
                     logger.error("{}", e);
                     return;
@@ -233,7 +233,7 @@ public class NegotiateAuthenticatorTests {
                 request.addHeader("Authorization", securityPackage + " " + clientToken);
 
                 SimpleHttpResponse response = new SimpleHttpResponse();
-                authenticated = _authenticator.authenticate(request, response, null);
+                authenticated = this.authenticator.authenticate(request, response, null);
 
                 if (authenticated) {
                     assertNotNull(request.getUserPrincipal());

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/WaffleAuthenticatorBaseTest.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/WaffleAuthenticatorBaseTest.java
@@ -31,9 +31,9 @@ public class WaffleAuthenticatorBaseTest {
 
     @Before
     public void init() {
-        waffleAuthenticatorBase = new WaffleAuthenticatorBase() {
+        this.waffleAuthenticatorBase = new WaffleAuthenticatorBase() {
             {
-                _log = LoggerFactory.getLogger(WaffleAuthenticatorBaseTest.class);
+                this.log = LoggerFactory.getLogger(WaffleAuthenticatorBaseTest.class);
             }
 
             @Override
@@ -46,31 +46,31 @@ public class WaffleAuthenticatorBaseTest {
 
     @Test
     public void should_accept_NTLM_protocol() throws Exception {
-        waffleAuthenticatorBase.setProtocols("  NTLM ");
+        this.waffleAuthenticatorBase.setProtocols("  NTLM ");
 
-        assertEquals("One protocol added", 1, waffleAuthenticatorBase._protocols.size());
-        assertEquals("NTLM", waffleAuthenticatorBase._protocols.iterator().next());
+        assertEquals("One protocol added", 1, this.waffleAuthenticatorBase.protocols.size());
+        assertEquals("NTLM", this.waffleAuthenticatorBase.protocols.iterator().next());
     }
 
     @Test
     public void should_accept_Negotiate_protocol() throws Exception {
-        waffleAuthenticatorBase.setProtocols(" Negotiate  ");
+        this.waffleAuthenticatorBase.setProtocols(" Negotiate  ");
 
-        assertEquals("One protocol added", 1, waffleAuthenticatorBase._protocols.size());
-        assertEquals("Negotiate", waffleAuthenticatorBase._protocols.iterator().next());
+        assertEquals("One protocol added", 1, this.waffleAuthenticatorBase.protocols.size());
+        assertEquals("Negotiate", this.waffleAuthenticatorBase.protocols.iterator().next());
     }
 
     @Test
     public void should_accept_both_protocols() throws Exception {
-        waffleAuthenticatorBase.setProtocols("  NTLM , , Negotiate   ");
+        this.waffleAuthenticatorBase.setProtocols("  NTLM , , Negotiate   ");
 
-        assertEquals("Two protocols added", 2, waffleAuthenticatorBase._protocols.size());
-        assertTrue("NTLM has been added", waffleAuthenticatorBase._protocols.contains("NTLM"));
-        assertTrue("Negotiate has been added", waffleAuthenticatorBase._protocols.contains("Negotiate"));
+        assertEquals("Two protocols added", 2, this.waffleAuthenticatorBase.protocols.size());
+        assertTrue("NTLM has been added", this.waffleAuthenticatorBase.protocols.contains("NTLM"));
+        assertTrue("Negotiate has been added", this.waffleAuthenticatorBase.protocols.contains("Negotiate"));
     }
 
     @Test(expected = RuntimeException.class)
     public void should_refuse_other_protocol() throws Exception {
-        waffleAuthenticatorBase.setProtocols("  NTLM , OTHER, Negotiate   ");
+        this.waffleAuthenticatorBase.setProtocols("  NTLM , OTHER, Negotiate   ");
     }
 }

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/WindowsAccountTests.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/WindowsAccountTests.java
@@ -35,27 +35,27 @@ import waffle.windows.auth.WindowsAccount;
  */
 public class WindowsAccountTests {
 
-    private MockWindowsAccount _mockWindowsAccount = new MockWindowsAccount("localhost\\Administrator");
-    private WindowsAccount     _windowsAccount;
+    private MockWindowsAccount mockWindowsAccount = new MockWindowsAccount("localhost\\Administrator");
+    private WindowsAccount     windowsAccount;
 
     @Before
     public void setUp() {
-        _windowsAccount = new WindowsAccount(_mockWindowsAccount);
+        this.windowsAccount = new WindowsAccount(this.mockWindowsAccount);
     }
 
     @Test
     public void testProperties() {
-        assertEquals("localhost", _windowsAccount.getDomain());
-        assertEquals("localhost\\Administrator", _windowsAccount.getFqn());
-        assertEquals("Administrator", _windowsAccount.getName());
-        assertTrue(_windowsAccount.getSidString().startsWith("S-"));
+        assertEquals("localhost", this.windowsAccount.getDomain());
+        assertEquals("localhost\\Administrator", this.windowsAccount.getFqn());
+        assertEquals("Administrator", this.windowsAccount.getName());
+        assertTrue(this.windowsAccount.getSidString().startsWith("S-"));
     }
 
     @Test
     public void testEquals() {
-        assertEquals(_windowsAccount, new WindowsAccount(_mockWindowsAccount));
+        assertEquals(this.windowsAccount, new WindowsAccount(this.mockWindowsAccount));
         MockWindowsAccount mockWindowsAccount2 = new MockWindowsAccount("localhost\\Administrator2");
-        assertFalse(_windowsAccount.equals(new WindowsAccount(mockWindowsAccount2)));
+        assertFalse(this.windowsAccount.equals(new WindowsAccount(mockWindowsAccount2)));
     }
 
     @Test
@@ -63,7 +63,7 @@ public class WindowsAccountTests {
         // serialize
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(out);
-        oos.writeObject(_windowsAccount);
+        oos.writeObject(this.windowsAccount);
         oos.close();
         assertTrue(out.toByteArray().length > 0);
         // deserialize
@@ -72,10 +72,10 @@ public class WindowsAccountTests {
         Object o = ois.readObject();
         WindowsAccount copy = (WindowsAccount) o;
         // test
-        assertEquals(_windowsAccount, copy);
-        assertEquals(_windowsAccount.getDomain(), copy.getDomain());
-        assertEquals(_windowsAccount.getFqn(), copy.getFqn());
-        assertEquals(_windowsAccount.getName(), copy.getName());
-        assertEquals(_windowsAccount.getSidString(), copy.getSidString());
+        assertEquals(this.windowsAccount, copy);
+        assertEquals(this.windowsAccount.getDomain(), copy.getDomain());
+        assertEquals(this.windowsAccount.getFqn(), copy.getFqn());
+        assertEquals(this.windowsAccount.getName(), copy.getName());
+        assertEquals(this.windowsAccount.getSidString(), copy.getSidString());
     }
 }

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleContext.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleContext.java
@@ -65,13 +65,13 @@ import org.apache.tomcat.util.http.mapper.Mapper;
  */
 public class SimpleContext implements Context {
 
-    private String         _path           = "/";
-    private String         _name           = "SimpleContext";
-    private Realm          _realm;
-    private Container      _parent;
-    private ServletContext _servletContext = new SimpleServletContext();
-    private Pipeline       _pipeline;
-    private Authenticator  _authenticator;
+    private String         path           = "/";
+    private String         name           = "SimpleContext";
+    private Realm          realm;
+    private Container      parent;
+    private ServletContext servletContext = new SimpleServletContext();
+    private Pipeline       pipeline;
+    private Authenticator  authenticator;
 
     @Override
     public void addApplicationListener(String arg0) {
@@ -385,7 +385,7 @@ public class SimpleContext implements Context {
 
     @Override
     public String getPath() {
-        return _path;
+        return this.path;
     }
 
     @Override
@@ -405,7 +405,7 @@ public class SimpleContext implements Context {
 
     @Override
     public ServletContext getServletContext() {
-        return _servletContext;
+        return this.servletContext;
     }
 
     @Override
@@ -605,7 +605,7 @@ public class SimpleContext implements Context {
 
     @Override
     public void setPath(String path) {
-        _path = path;
+        this.path = path;
     }
 
     @Override
@@ -735,7 +735,7 @@ public class SimpleContext implements Context {
 
     @Override
     public String getName() {
-        return _name;
+        return this.name;
     }
 
     @Override
@@ -745,7 +745,7 @@ public class SimpleContext implements Context {
 
     @Override
     public Container getParent() {
-        return _parent;
+        return this.parent;
     }
 
     @Override
@@ -755,16 +755,16 @@ public class SimpleContext implements Context {
 
     @Override
     public Pipeline getPipeline() {
-        return _pipeline;
+        return this.pipeline;
     }
 
     public void setPipeline(Pipeline pipeline) {
-        _pipeline = pipeline;
+        this.pipeline = pipeline;
     }
 
     @Override
     public Realm getRealm() {
-        return _realm;
+        return this.realm;
     }
 
     @Override
@@ -814,12 +814,12 @@ public class SimpleContext implements Context {
 
     @Override
     public void setName(String name) {
-        _name = name;
+        this.name = name;
     }
 
     @Override
     public void setParent(Container container) {
-        _parent = container;
+        this.parent = container;
     }
 
     @Override
@@ -829,7 +829,7 @@ public class SimpleContext implements Context {
 
     @Override
     public void setRealm(Realm realm) {
-        _realm = realm;
+        this.realm = realm;
     }
 
     @Override
@@ -954,11 +954,11 @@ public class SimpleContext implements Context {
 
     @Override
     public Authenticator getAuthenticator() {
-        return _authenticator;
+        return this.authenticator;
     }
 
     public void setAuthenticator(Authenticator authenticator) {
-        _authenticator = authenticator;
+        this.authenticator = authenticator;
     }
 
     @Override

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleEngine.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleEngine.java
@@ -38,7 +38,7 @@ import org.apache.juli.logging.Log;
 
 public class SimpleEngine implements org.apache.catalina.Engine {
 
-    private Pipeline _pipeline;
+    private Pipeline pipeline;
 
     @Override
     public String getInfo() {
@@ -82,11 +82,11 @@ public class SimpleEngine implements org.apache.catalina.Engine {
 
     @Override
     public Pipeline getPipeline() {
-        return _pipeline;
+        return this.pipeline;
     }
 
     public void setPipeline(Pipeline pipeline) {
-        _pipeline = pipeline;
+        this.pipeline = pipeline;
     }
 
     @Override

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleFilterChain.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleFilterChain.java
@@ -27,21 +27,21 @@ import javax.servlet.ServletResponse;
  */
 public class SimpleFilterChain implements FilterChain {
 
-    private ServletRequest  _request;
-    private ServletResponse _response;
+    private ServletRequest  request;
+    private ServletResponse response;
 
     public ServletRequest getRequest() {
-        return _request;
+        return this.request;
     }
 
     public ServletResponse getResponse() {
-        return _response;
+        return this.response;
     }
 
     @Override
     public void doFilter(ServletRequest sreq, ServletResponse srep) throws IOException, ServletException {
 
-        _request = sreq;
-        _response = srep;
+        this.request = sreq;
+        this.response = srep;
     }
 }

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleHttpRequest.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleHttpRequest.java
@@ -26,97 +26,94 @@ import org.apache.catalina.connector.Request;
  */
 public class SimpleHttpRequest extends Request {
 
-    private static int          _remotePort_s;
+    private static int          remotePortS;
 
-    private String              _requestURI;
-    private String              _queryString;
-    private String              _remoteUser;
-    private String              _method     = "GET";
-    private String              _remoteHost;
-    private String              _remoteAddr;
-    private int                 _remotePort = -1;
-    private Map<String, String> _headers    = new HashMap<String, String>();
-    private Map<String, String> _parameters = new HashMap<String, String>();
-    private byte[]              _content;
-    private HttpSession         _session    = new SimpleHttpSession();
-    private Principal           _principal;
+    private String              requestURI;
+    private String              queryString;
+    private String              remoteUser;
+    private String              method      = "GET";
+    private Map<String, String> headers     = new HashMap<String, String>();
+    private Map<String, String> parameters  = new HashMap<String, String>();
+    private byte[]              content;
+    private HttpSession         httpSession = new SimpleHttpSession();
+    private Principal           principal;
 
     public SimpleHttpRequest() {
         super();
-        _remotePort = nextRemotePort();
+        this.remotePort = nextRemotePort();
     }
 
     public synchronized static int nextRemotePort() {
-        return ++_remotePort_s;
+        return ++remotePortS;
     }
 
     public synchronized static void resetRemotePort() {
-        _remotePort_s = 0;
+        remotePortS = 0;
     }
 
     public void addHeader(String headerName, String headerValue) {
-        _headers.put(headerName, headerValue);
+        this.headers.put(headerName, headerValue);
     }
 
     @Override
     public String getHeader(String headerName) {
-        return _headers.get(headerName);
+        return this.headers.get(headerName);
     }
 
     @Override
     public String getMethod() {
-        return _method;
+        return this.method;
     }
 
     @Override
     public int getContentLength() {
-        return _content == null ? -1 : _content.length;
+        return this.content == null ? -1 : this.content.length;
     }
 
     @Override
     public int getRemotePort() {
-        return _remotePort;
+        return this.remotePort;
     }
 
     public void setMethod(String methodName) {
-        _method = methodName;
+        this.method = methodName;
     }
 
     public void setContentLength(int length) {
-        _content = new byte[length];
+        this.content = new byte[length];
     }
 
     public void setRemoteUser(String username) {
-        _remoteUser = username;
+        this.remoteUser = username;
     }
 
     @Override
     public String getRemoteUser() {
-        return _remoteUser;
+        return this.remoteUser;
     }
 
     @Override
     public HttpSession getSession() {
-        return _session;
+        return this.httpSession;
     }
 
     @Override
     public HttpSession getSession(boolean create) {
-        if (_session == null && create) {
-            _session = new SimpleHttpSession();
+        if (this.httpSession == null && create) {
+            this.httpSession = new SimpleHttpSession();
         }
-        return _session;
+        return this.httpSession;
     }
 
     @Override
     public String getQueryString() {
-        return _queryString;
+        return this.queryString;
     }
 
     public void setQueryString(String queryString) {
-        _queryString = queryString;
-        if (_queryString != null) {
-            for (String eachParameter : _queryString.split("[&]")) {
+        this.queryString = queryString;
+        if (this.queryString != null) {
+            for (String eachParameter : this.queryString.split("[&]")) {
                 String[] pair = eachParameter.split("=");
                 String value = (pair.length == 2) ? pair[1] : "";
                 addParameter(pair[0], value);
@@ -125,50 +122,50 @@ public class SimpleHttpRequest extends Request {
     }
 
     public void setRequestURI(String uri) {
-        _requestURI = uri;
+        this.requestURI = uri;
     }
 
     @Override
     public String getRequestURI() {
-        return _requestURI;
+        return this.requestURI;
     }
 
     @Override
     public String getParameter(String parameterName) {
-        return _parameters.get(parameterName);
+        return this.parameters.get(parameterName);
     }
 
     public void addParameter(String parameterName, String parameterValue) {
-        _parameters.put(parameterName, parameterValue);
+        this.parameters.put(parameterName, parameterValue);
     }
 
     @Override
     public String getRemoteHost() {
-        return _remoteHost;
+        return this.remoteHost;
     }
 
     @Override
     public void setRemoteHost(String remoteHost) {
-        _remoteHost = remoteHost;
+        this.remoteHost = remoteHost;
     }
 
     @Override
     public String getRemoteAddr() {
-        return _remoteAddr;
+        return this.remoteAddr;
     }
 
     @Override
     public void setRemoteAddr(String remoteAddr) {
-        _remoteAddr = remoteAddr;
+        this.remoteAddr = remoteAddr;
     }
 
     @Override
     public Principal getUserPrincipal() {
-        return _principal;
+        return this.principal;
     }
 
     @Override
     public void setUserPrincipal(Principal principal) {
-        _principal = principal;
+        this.principal = principal;
     }
 }

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleHttpResponse.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleHttpResponse.java
@@ -28,45 +28,45 @@ import org.slf4j.LoggerFactory;
  */
 public class SimpleHttpResponse extends Response {
 
-    private static final Logger       logger   = LoggerFactory.getLogger(SimpleHttpResponse.class);
+    private static final Logger       logger  = LoggerFactory.getLogger(SimpleHttpResponse.class);
 
-    private int                       _status  = 500;
-    private Map<String, List<String>> _headers = new HashMap<String, List<String>>();
+    private int                       status  = 500;
+    private Map<String, List<String>> headers = new HashMap<String, List<String>>();
 
     @Override
     public int getStatus() {
-        return _status;
+        return this.status;
     }
 
     @Override
     public void addHeader(String headerName, String headerValue) {
-        List<String> current = _headers.get(headerName);
+        List<String> current = this.headers.get(headerName);
         if (current == null) {
             current = new ArrayList<String>();
         }
         current.add(headerValue);
-        _headers.put(headerName, current);
+        this.headers.put(headerName, current);
     }
 
     @Override
     public void setHeader(String headerName, String headerValue) {
-        List<String> current = _headers.get(headerName);
+        List<String> current = this.headers.get(headerName);
         if (current == null) {
             current = new ArrayList<String>();
         } else {
             current.clear();
         }
         current.add(headerValue);
-        _headers.put(headerName, current);
+        this.headers.put(headerName, current);
     }
 
     @Override
     public void setStatus(int value) {
-        _status = value;
+        this.status = value;
     }
 
     public String getStatusString() {
-        if (_status == 401) {
+        if (this.status == 401) {
             return "Unauthorized";
         }
         return "Unknown";
@@ -74,22 +74,22 @@ public class SimpleHttpResponse extends Response {
 
     @Override
     public void flushBuffer() {
-        this.logger.info("{} {}", Integer.valueOf(_status), getStatusString());
-        for (String header : _headers.keySet()) {
-            for (String headerValue : _headers.get(header)) {
+        this.logger.info("{} {}", Integer.valueOf(this.status), getStatusString());
+        for (String header : this.headers.keySet()) {
+            for (String headerValue : this.headers.get(header)) {
                 this.logger.info("{}: {}", header, headerValue);
             }
         }
     }
 
     public String[] getHeaderValues(String headerName) {
-        List<String> headerValues = _headers.get(headerName);
+        List<String> headerValues = this.headers.get(headerName);
         return headerValues == null ? null : headerValues.toArray(new String[0]);
     }
 
     @Override
     public String getHeader(String headerName) {
-        List<String> headerValues = _headers.get(headerName);
+        List<String> headerValues = this.headers.get(headerName);
         if (headerValues == null) {
             return null;
         }
@@ -105,16 +105,16 @@ public class SimpleHttpResponse extends Response {
 
     @Override
     public Collection<String> getHeaderNames() {
-        return _headers.keySet();
+        return this.headers.keySet();
     }
 
     @Override
     public void sendError(int rc, String message) {
-        _status = rc;
+        this.status = rc;
     }
 
     @Override
     public void sendError(int rc) {
-        _status = rc;
+        this.status = rc;
     }
 }

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleHttpSession.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleHttpSession.java
@@ -29,11 +29,11 @@ import javax.servlet.http.HttpSessionContext;
 @SuppressWarnings("deprecation")
 public class SimpleHttpSession implements HttpSession {
 
-    private Map<String, Object> _attributes = new HashMap<String, Object>();
+    private Map<String, Object> attributes = new HashMap<String, Object>();
 
     @Override
     public Object getAttribute(String attributeName) {
-        return _attributes.get(attributeName);
+        return this.attributes.get(attributeName);
     }
 
     @Override
@@ -97,7 +97,7 @@ public class SimpleHttpSession implements HttpSession {
 
     @Override
     public void removeAttribute(String attributeName) {
-        _attributes.remove(attributeName);
+        this.attributes.remove(attributeName);
     }
 
     @Override
@@ -107,7 +107,7 @@ public class SimpleHttpSession implements HttpSession {
 
     @Override
     public void setAttribute(String attributeName, Object attributeValue) {
-        _attributes.put(attributeName, attributeValue);
+        this.attributes.put(attributeName, attributeValue);
     }
 
     @Override

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimplePipeline.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimplePipeline.java
@@ -19,7 +19,7 @@ import org.apache.catalina.Valve;
 
 public class SimplePipeline implements Pipeline {
 
-    private Valve[] _valves = new Valve[0];
+    private Valve[] valves = new Valve[0];
 
     @Override
     public void addValve(Valve arg0) {
@@ -43,7 +43,7 @@ public class SimplePipeline implements Pipeline {
 
     @Override
     public Valve[] getValves() {
-        return _valves.clone();
+        return this.valves.clone();
     }
 
     @Override

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleRequestDispatcher.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/catalina/SimpleRequestDispatcher.java
@@ -26,17 +26,17 @@ import javax.servlet.http.HttpServletResponse;
  */
 public class SimpleRequestDispatcher implements RequestDispatcher {
 
-    private String _url;
+    private String url;
 
     public SimpleRequestDispatcher(String url) {
-        _url = url;
+        this.url = url;
     }
 
     @Override
     public void forward(ServletRequest request, ServletResponse response) throws ServletException, IOException {
         HttpServletResponse httpResponse = (HttpServletResponse) response;
         httpResponse.setStatus(304);
-        httpResponse.addHeader("Location", _url);
+        httpResponse.addHeader("Location", this.url);
     }
 
     @Override

--- a/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/GenericWindowsPrincipal.java
+++ b/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/GenericWindowsPrincipal.java
@@ -32,9 +32,9 @@ import waffle.windows.auth.WindowsAccount;
  */
 public class GenericWindowsPrincipal extends GenericPrincipal {
 
-    private byte[]                      _sid;
-    private String                      _sidString;
-    private Map<String, WindowsAccount> _groups;
+    private byte[]                      sid;
+    private String                      sidString;
+    private Map<String, WindowsAccount> groups;
 
     /**
      * A windows principal.
@@ -49,9 +49,9 @@ public class GenericWindowsPrincipal extends GenericPrincipal {
     public GenericWindowsPrincipal(IWindowsIdentity windowsIdentity, PrincipalFormat principalFormat,
             PrincipalFormat roleFormat) {
         super(windowsIdentity.getFqn(), "", getRoles(windowsIdentity, principalFormat, roleFormat));
-        _sid = windowsIdentity.getSid();
-        _sidString = windowsIdentity.getSidString();
-        _groups = getGroups(windowsIdentity.getGroups());
+        this.sid = windowsIdentity.getSid();
+        this.sidString = windowsIdentity.getSidString();
+        this.groups = getGroups(windowsIdentity.getGroups());
     }
 
     private static List<String> getRoles(IWindowsIdentity windowsIdentity, PrincipalFormat principalFormat,
@@ -78,7 +78,7 @@ public class GenericWindowsPrincipal extends GenericPrincipal {
      * @return Array of bytes.
      */
     public byte[] getSid() {
-        return _sid.clone();
+        return this.sid.clone();
     }
 
     /**
@@ -87,7 +87,7 @@ public class GenericWindowsPrincipal extends GenericPrincipal {
      * @return String.
      */
     public String getSidString() {
-        return _sidString;
+        return this.sidString;
     }
 
     /**
@@ -96,7 +96,7 @@ public class GenericWindowsPrincipal extends GenericPrincipal {
      * @return A map of group names to groups.
      */
     public Map<String, WindowsAccount> getGroups() {
-        return _groups;
+        return this.groups;
     }
 
     /**
@@ -109,7 +109,6 @@ public class GenericWindowsPrincipal extends GenericPrincipal {
      * @return List of role principal objects.
      */
     private static List<String> getRoleNames(IWindowsAccount group, PrincipalFormat principalFormat) {
-
         List<String> principals = new ArrayList<String>();
         switch (principalFormat) {
             case fqn:
@@ -127,7 +126,6 @@ public class GenericWindowsPrincipal extends GenericPrincipal {
             default:
                 break;
         }
-
         return principals;
     }
 
@@ -141,7 +139,6 @@ public class GenericWindowsPrincipal extends GenericPrincipal {
      * @return A list of user principal objects.
      */
     private static List<String> getPrincipalNames(IWindowsIdentity windowsIdentity, PrincipalFormat principalFormat) {
-
         List<String> principals = new ArrayList<String>();
         switch (principalFormat) {
             case fqn:
@@ -159,7 +156,6 @@ public class GenericWindowsPrincipal extends GenericPrincipal {
             default:
                 break;
         }
-
         return principals;
     }
 

--- a/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/MixedAuthenticator.java
+++ b/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/MixedAuthenticator.java
@@ -43,59 +43,59 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
 
     public MixedAuthenticator() {
         super();
-        _log = LoggerFactory.getLogger(MixedAuthenticator.class);
-        _info = "waffle.apache.MixedAuthenticator/1.0";
-        _log.debug("[waffle.apache.MixedAuthenticator] loaded");
+        this.log = LoggerFactory.getLogger(MixedAuthenticator.class);
+        this.info = "waffle.apache.MixedAuthenticator/1.0";
+        this.log.debug("[waffle.apache.MixedAuthenticator] loaded");
     }
 
     @Override
     public synchronized void startInternal() throws LifecycleException {
-        _log.info("[waffle.apache.MixedAuthenticator] started");
+        this.log.info("[waffle.apache.MixedAuthenticator] started");
         super.startInternal();
     }
 
     @Override
     public synchronized void stopInternal() throws LifecycleException {
         super.stopInternal();
-        _log.info("[waffle.apache.MixedAuthenticator] stopped");
+        this.log.info("[waffle.apache.MixedAuthenticator] stopped");
     }
 
     @Override
     public boolean authenticate(Request request, HttpServletResponse response) {
 
         // realm: fail if no realm is configured
-        if (context == null || context.getRealm() == null) {
-            _log.warn("missing context/realm");
+        if (this.context == null || this.context.getRealm() == null) {
+            this.log.warn("missing context/realm");
             sendError(response, HttpServletResponse.SC_SERVICE_UNAVAILABLE);
             return false;
         }
 
-        _log.debug("{} {}, contentlength: {}", request.getMethod(), request.getRequestURI(),
+        this.log.debug("{} {}, contentlength: {}", request.getMethod(), request.getRequestURI(),
                 Integer.valueOf(request.getContentLength()));
 
         boolean negotiateCheck = request.getParameter("j_negotiate_check") != null;
-        _log.debug("negotiateCheck: {}", Boolean.valueOf(negotiateCheck));
+        this.log.debug("negotiateCheck: {}", Boolean.valueOf(negotiateCheck));
         boolean securityCheck = request.getParameter("j_security_check") != null;
-        _log.debug("securityCheck: {}", Boolean.valueOf(securityCheck));
+        this.log.debug("securityCheck: {}", Boolean.valueOf(securityCheck));
 
         Principal principal = request.getUserPrincipal();
 
         AuthorizationHeader authorizationHeader = new AuthorizationHeader(request);
         boolean ntlmPost = authorizationHeader.isNtlmType1PostAuthorizationHeader();
-        _log.debug("authorization: {}, ntlm post: {}", authorizationHeader, Boolean.valueOf(ntlmPost));
+        this.log.debug("authorization: {}, ntlm post: {}", authorizationHeader, Boolean.valueOf(ntlmPost));
 
         LoginConfig loginConfig = new LoginConfig();
         loginConfig.setErrorPage("error.html");
         loginConfig.setLoginPage("login.html");
 
         if (principal != null && !ntlmPost) {
-            _log.debug("previously authenticated user: {}", principal.getName());
+            this.log.debug("previously authenticated user: {}", principal.getName());
             return true;
         } else if (negotiateCheck) {
             if (!authorizationHeader.isNull()) {
                 return negotiate(request, response, authorizationHeader);
             }
-            _log.debug("authorization required");
+            this.log.debug("authorization required");
             sendUnauthorized(response);
             return false;
         } else if (securityCheck) {
@@ -118,13 +118,13 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
         // maintain a connection-based session for NTLM tokens
         String connectionId = NtlmServletRequest.getConnectionId(request);
 
-        _log.debug("security package: {}, connection id: {}", securityPackage, connectionId);
+        this.log.debug("security package: {}, connection id: {}", securityPackage, connectionId);
 
         boolean ntlmPost = authorizationHeader.isNtlmType1PostAuthorizationHeader();
 
         if (ntlmPost) {
             // type 1 NTLM authentication message received
-            _auth.resetSecurityToken(connectionId);
+            this.auth.resetSecurityToken(connectionId);
         }
 
         // log the user in using the token
@@ -132,14 +132,14 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
 
         try {
             byte[] tokenBuffer = authorizationHeader.getTokenBytes();
-            _log.debug("token buffer: {} byte(s)", Integer.valueOf(tokenBuffer.length));
-            securityContext = _auth.acceptSecurityToken(connectionId, tokenBuffer, securityPackage);
-            _log.debug("continue required: {}", Boolean.valueOf(securityContext.isContinue()));
+            this.log.debug("token buffer: {} byte(s)", Integer.valueOf(tokenBuffer.length));
+            securityContext = this.auth.acceptSecurityToken(connectionId, tokenBuffer, securityPackage);
+            this.log.debug("continue required: {}", Boolean.valueOf(securityContext.isContinue()));
 
             byte[] continueTokenBytes = securityContext.getToken();
             if (continueTokenBytes != null && continueTokenBytes.length > 0) {
                 String continueToken = BaseEncoding.base64().encode(continueTokenBytes);
-                _log.debug("continue token: {}", continueToken);
+                this.log.debug("continue token: {}", continueToken);
                 response.addHeader("WWW-Authenticate", securityPackage + " " + continueToken);
             }
 
@@ -151,8 +151,8 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
             }
 
         } catch (IOException e) {
-            _log.warn("error logging in user: {}", e.getMessage());
-            _log.trace("{}", e);
+            this.log.warn("error logging in user: {}", e.getMessage());
+            this.log.trace("{}", e);
             sendUnauthorized(response);
             return false;
         }
@@ -161,27 +161,26 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
         IWindowsIdentity windowsIdentity = securityContext.getIdentity();
 
         // disable guest login
-        if (!_allowGuestLogin && windowsIdentity.isGuest()) {
-            _log.warn("guest login disabled: {}", windowsIdentity.getFqn());
+        if (!this.allowGuestLogin && windowsIdentity.isGuest()) {
+            this.log.warn("guest login disabled: {}", windowsIdentity.getFqn());
             sendUnauthorized(response);
             return false;
         }
 
         try {
+            this.log.debug("logged in user: {} ({})", windowsIdentity.getFqn(), windowsIdentity.getSidString());
 
-            _log.debug("logged in user: {} ({})", windowsIdentity.getFqn(), windowsIdentity.getSidString());
+            GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity,
+                    this.principalFormat, this.roleFormat);
 
-            GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity, _principalFormat,
-                    _roleFormat);
-
-            _log.debug("roles: {}", windowsPrincipal.getRolesString());
+            this.log.debug("roles: {}", windowsPrincipal.getRolesString());
 
             // create a session associated with this request if there's none
             HttpSession session = request.getSession(true);
-            _log.debug("session id: {}", session.getId());
+            this.log.debug("session id: {}", session.getId());
 
             register(request, response, windowsPrincipal, securityPackage, windowsPrincipal.getName(), null);
-            _log.info("successfully logged in user: {}", windowsPrincipal.getName());
+            this.log.info("successfully logged in user: {}", windowsPrincipal.getName());
 
         } finally {
             windowsIdentity.dispose();
@@ -195,37 +194,37 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
         String username = request.getParameter("j_username");
         String password = request.getParameter("j_password");
 
-        _log.debug("logging in: {}", username);
+        this.log.debug("logging in: {}", username);
 
         IWindowsIdentity windowsIdentity = null;
         try {
-            windowsIdentity = _auth.logonUser(username, password);
+            windowsIdentity = this.auth.logonUser(username, password);
         } catch (Exception e) {
-            _log.error(e.getMessage());
-            _log.trace("{}", e);
+            this.log.error(e.getMessage());
+            this.log.trace("{}", e);
             return false;
         }
 
         // disable guest login
-        if (!_allowGuestLogin && windowsIdentity.isGuest()) {
-            _log.warn("guest login disabled: {}", windowsIdentity.getFqn());
+        if (!this.allowGuestLogin && windowsIdentity.isGuest()) {
+            this.log.warn("guest login disabled: {}", windowsIdentity.getFqn());
             return false;
         }
 
         try {
-            _log.debug("successfully logged in {} ({})", username, windowsIdentity.getSidString());
+            this.log.debug("successfully logged in {} ({})", username, windowsIdentity.getSidString());
 
-            GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity, _principalFormat,
-                    _roleFormat);
+            GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity,
+                    this.principalFormat, this.roleFormat);
 
-            _log.debug("roles: {}", windowsPrincipal.getRolesString());
+            this.log.debug("roles: {}", windowsPrincipal.getRolesString());
 
             // create a session associated with this request if there's none
             HttpSession session = request.getSession(true);
-            _log.debug("session id: {}", session.getId());
+            this.log.debug("session id: {}", session.getId());
 
             register(request, response, windowsPrincipal, "FORM", windowsPrincipal.getName(), null);
-            _log.info("successfully logged in user: {}", windowsPrincipal.getName());
+            this.log.info("successfully logged in user: {}", windowsPrincipal.getName());
         } finally {
             windowsIdentity.dispose();
         }
@@ -235,17 +234,17 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
 
     private void redirectTo(Request request, HttpServletResponse response, String url) {
         try {
-            _log.debug("redirecting to: {}", url);
-            ServletContext servletContext = context.getServletContext();
+            this.log.debug("redirecting to: {}", url);
+            ServletContext servletContext = this.context.getServletContext();
             RequestDispatcher disp = servletContext.getRequestDispatcher(url);
             disp.forward(request.getRequest(), response);
         } catch (IOException e) {
-            _log.error(e.getMessage());
-            _log.trace("{}", e);
+            this.log.error(e.getMessage());
+            this.log.trace("{}", e);
             throw new RuntimeException(e);
         } catch (ServletException e) {
-            _log.error(e.getMessage());
-            _log.trace("{}", e);
+            this.log.error(e.getMessage());
+            this.log.trace("{}", e);
             throw new RuntimeException(e);
         }
     }

--- a/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/NegotiateAuthenticator.java
+++ b/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/NegotiateAuthenticator.java
@@ -39,21 +39,21 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
 
     public NegotiateAuthenticator() {
         super();
-        _log = LoggerFactory.getLogger(NegotiateAuthenticator.class);
-        _info = "waffle.apache.NegotiateAuthenticator/1.0";
-        _log.debug("[waffle.apache.NegotiateAuthenticator] loaded");
+        this.log = LoggerFactory.getLogger(NegotiateAuthenticator.class);
+        this.info = "waffle.apache.NegotiateAuthenticator/1.0";
+        this.log.debug("[waffle.apache.NegotiateAuthenticator] loaded");
     }
 
     @Override
     public synchronized void startInternal() throws LifecycleException {
-        _log.info("[waffle.apache.NegotiateAuthenticator] started");
+        this.log.info("[waffle.apache.NegotiateAuthenticator] started");
         super.startInternal();
     }
 
     @Override
     public synchronized void stopInternal() throws LifecycleException {
         super.stopInternal();
-        _log.info("[waffle.apache.NegotiateAuthenticator] stopped");
+        this.log.info("[waffle.apache.NegotiateAuthenticator] stopped");
     }
 
     @Override
@@ -63,13 +63,13 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
         AuthorizationHeader authorizationHeader = new AuthorizationHeader(request);
         boolean ntlmPost = authorizationHeader.isNtlmType1PostAuthorizationHeader();
 
-        _log.debug("{} {}, contentlength: {}", request.getMethod(), request.getRequestURI(),
+        this.log.debug("{} {}, contentlength: {}", request.getMethod(), request.getRequestURI(),
                 Integer.valueOf(request.getContentLength()));
-        _log.debug("authorization: {}, ntlm post: {}", authorizationHeader, Boolean.valueOf(ntlmPost));
+        this.log.debug("authorization: {}, ntlm post: {}", authorizationHeader, Boolean.valueOf(ntlmPost));
 
         if (principal != null && !ntlmPost) {
             // user already authenticated
-            _log.debug("previously authenticated user: {}", principal.getName());
+            this.log.debug("previously authenticated user: {}", principal.getName());
             return true;
         }
 
@@ -80,11 +80,11 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
             // maintain a connection-based session for NTLM tokens
             String connectionId = NtlmServletRequest.getConnectionId(request);
 
-            _log.debug("security package: {}, connection id: {}", securityPackage, connectionId);
+            this.log.debug("security package: {}, connection id: {}", securityPackage, connectionId);
 
             if (ntlmPost) {
                 // type 1 NTLM authentication message received
-                _auth.resetSecurityToken(connectionId);
+                this.auth.resetSecurityToken(connectionId);
             }
 
             // log the user in using the token
@@ -92,14 +92,14 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
 
             try {
                 byte[] tokenBuffer = authorizationHeader.getTokenBytes();
-                _log.debug("token buffer: {} byte(s)", Integer.valueOf(tokenBuffer.length));
-                securityContext = _auth.acceptSecurityToken(connectionId, tokenBuffer, securityPackage);
-                _log.debug("continue required: {}", Boolean.valueOf(securityContext.isContinue()));
+                this.log.debug("token buffer: {} byte(s)", Integer.valueOf(tokenBuffer.length));
+                securityContext = this.auth.acceptSecurityToken(connectionId, tokenBuffer, securityPackage);
+                this.log.debug("continue required: {}", Boolean.valueOf(securityContext.isContinue()));
 
                 byte[] continueTokenBytes = securityContext.getToken();
                 if (continueTokenBytes != null && continueTokenBytes.length > 0) {
                     String continueToken = BaseEncoding.base64().encode(continueTokenBytes);
-                    _log.debug("continue token: {}", continueToken);
+                    this.log.debug("continue token: {}", continueToken);
                     response.addHeader("WWW-Authenticate", securityPackage + " " + continueToken);
                 }
 
@@ -111,15 +111,15 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
                 }
 
             } catch (IOException e) {
-                _log.warn("error logging in user: {}", e.getMessage());
-                _log.trace("{}", e);
+                this.log.warn("error logging in user: {}", e.getMessage());
+                this.log.trace("{}", e);
                 sendUnauthorized(response);
                 return false;
             }
 
             // realm: fail if no realm is configured
-            if (context == null || context.getRealm() == null) {
-                _log.warn("missing context/realm");
+            if (this.context == null || this.context.getRealm() == null) {
+                this.log.warn("missing context/realm");
                 sendError(response, HttpServletResponse.SC_SERVICE_UNAVAILABLE);
                 return false;
             }
@@ -128,29 +128,29 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
             IWindowsIdentity windowsIdentity = securityContext.getIdentity();
 
             // disable guest login
-            if (!_allowGuestLogin && windowsIdentity.isGuest()) {
-                _log.warn("guest login disabled: {}", windowsIdentity.getFqn());
+            if (!this.allowGuestLogin && windowsIdentity.isGuest()) {
+                this.log.warn("guest login disabled: {}", windowsIdentity.getFqn());
                 sendUnauthorized(response);
                 return false;
             }
 
             try {
-                _log.debug("logged in user: {} ({})", windowsIdentity.getFqn(), windowsIdentity.getSidString());
+                this.log.debug("logged in user: {} ({})", windowsIdentity.getFqn(), windowsIdentity.getSidString());
 
                 GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity,
-                        _principalFormat, _roleFormat);
+                        this.principalFormat, this.roleFormat);
 
-                _log.debug("roles: {}", windowsPrincipal.getRolesString());
+                this.log.debug("roles: {}", windowsPrincipal.getRolesString());
 
                 principal = windowsPrincipal;
 
                 // create a session associated with this request if there's none
                 HttpSession session = request.getSession(true);
-                _log.debug("session id: {}", session.getId());
+                this.log.debug("session id: {}", session.getId());
 
                 // register the authenticated principal
                 register(request, response, principal, securityPackage, principal.getName(), null);
-                _log.info("successfully logged in user: {}", principal.getName());
+                this.log.info("successfully logged in user: {}", principal.getName());
 
             } finally {
                 windowsIdentity.dispose();
@@ -159,7 +159,7 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
             return true;
         }
 
-        _log.debug("authorization required");
+        this.log.debug("authorization required");
         sendUnauthorized(response);
         return false;
     }

--- a/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
+++ b/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
@@ -39,14 +39,14 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
 
     private static final Set<String> SUPPORTED_PROTOCOLS = new LinkedHashSet<String>(asList("Negotiate", "NTLM"));
 
-    protected String                 _info;
-    protected Logger                 _log;
-    protected PrincipalFormat        _principalFormat    = PrincipalFormat.fqn;
-    protected PrincipalFormat        _roleFormat         = PrincipalFormat.fqn;
-    protected boolean                _allowGuestLogin    = true;
-    protected Set<String>            _protocols          = SUPPORTED_PROTOCOLS;
+    protected String                 info;
+    protected Logger                 log;
+    protected PrincipalFormat        principalFormat     = PrincipalFormat.fqn;
+    protected PrincipalFormat        roleFormat          = PrincipalFormat.fqn;
+    protected boolean                allowGuestLogin     = true;
+    protected Set<String>            protocols           = SUPPORTED_PROTOCOLS;
 
-    protected IWindowsAuthProvider   _auth               = new WindowsAuthProviderImpl();
+    protected IWindowsAuthProvider   auth                = new WindowsAuthProviderImpl();
 
     /**
      * Windows authentication provider.
@@ -54,7 +54,7 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
      * @return IWindowsAuthProvider.
      */
     public IWindowsAuthProvider getAuth() {
-        return _auth;
+        return this.auth;
     }
 
     /**
@@ -64,11 +64,11 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
      *            Class implements IWindowsAuthProvider.
      */
     public void setAuth(IWindowsAuthProvider provider) {
-        _auth = provider;
+        this.auth = provider;
     }
 
     public String getInfo() {
-        return _info;
+        return this.info;
     }
 
     /**
@@ -78,8 +78,8 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
      *            Principal format.
      */
     public void setPrincipalFormat(String format) {
-        _principalFormat = PrincipalFormat.valueOf(format);
-        _log.debug("principal format: {}", _principalFormat);
+        this.principalFormat = PrincipalFormat.valueOf(format);
+        this.log.debug("principal format: {}", this.principalFormat);
     }
 
     /**
@@ -88,7 +88,7 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
      * @return Principal format.
      */
     public PrincipalFormat getPrincipalFormat() {
-        return _principalFormat;
+        return this.principalFormat;
     }
 
     /**
@@ -98,8 +98,8 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
      *            Role format.
      */
     public void setRoleFormat(String format) {
-        _roleFormat = PrincipalFormat.valueOf(format);
-        _log.debug("role format: {}", _roleFormat);
+        this.roleFormat = PrincipalFormat.valueOf(format);
+        this.log.debug("role format: {}", this.roleFormat);
     }
 
     /**
@@ -108,7 +108,7 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
      * @return Role format.
      */
     public PrincipalFormat getRoleFormat() {
-        return _roleFormat;
+        return this.roleFormat;
     }
 
     /**
@@ -117,7 +117,7 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
      * @return True if Guest login permitted, false otherwise.
      */
     public boolean isAllowGuestLogin() {
-        return _allowGuestLogin;
+        return this.allowGuestLogin;
     }
 
     /**
@@ -128,26 +128,26 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
      *            True or false.
      */
     public void setAllowGuestLogin(boolean value) {
-        _allowGuestLogin = value;
+        this.allowGuestLogin = value;
     }
 
     /**
      * Set the authentication protocols. Default is "Negotiate, NTLM".
      * 
-     * @param protocols
+     * @param value
      *            Authentication protocols
      */
-    public void setProtocols(String protocols) {
-        _protocols = new LinkedHashSet<String>();
-        String[] protocolNames = protocols.split(",");
+    public void setProtocols(String value) {
+        this.protocols = new LinkedHashSet<String>();
+        String[] protocolNames = value.split(",");
         for (String protocolName : protocolNames) {
             protocolName = protocolName.trim();
             if (!protocolName.isEmpty()) {
-                _log.debug("init protocol: {}", protocolName);
+                this.log.debug("init protocol: {}", protocolName);
                 if (SUPPORTED_PROTOCOLS.contains(protocolName)) {
-                    _protocols.add(protocolName);
+                    this.protocols.add(protocolName);
                 } else {
-                    _log.error("unsupported protocol: {}", protocolName);
+                    this.log.error("unsupported protocol: {}", protocolName);
                     throw new RuntimeException("Unsupported protocol: " + protocolName);
                 }
             }
@@ -162,7 +162,7 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
      */
     protected void sendUnauthorized(HttpServletResponse response) {
         try {
-            for (String protocol : _protocols) {
+            for (String protocol : this.protocols) {
                 response.addHeader("WWW-Authenticate", protocol);
             }
             response.setHeader("Connection", "close");
@@ -185,8 +185,8 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
         try {
             response.sendError(code);
         } catch (IOException e) {
-            _log.error(e.getMessage());
-            _log.trace("{}", e);
+            this.log.error(e.getMessage());
+            this.log.trace("{}", e);
             throw new RuntimeException(e);
         }
     }
@@ -198,25 +198,25 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
 
     @Override
     protected Principal doLogin(Request request, String username, String password) throws ServletException {
-        _log.debug("logging in: {}", username);
+        this.log.debug("logging in: {}", username);
         IWindowsIdentity windowsIdentity;
         try {
-            windowsIdentity = _auth.logonUser(username, password);
+            windowsIdentity = this.auth.logonUser(username, password);
         } catch (Exception e) {
-            _log.error(e.getMessage());
-            _log.trace("{}", e);
+            this.log.error(e.getMessage());
+            this.log.trace("{}", e);
             return super.doLogin(request, username, password);
         }
         // disable guest login
-        if (!_allowGuestLogin && windowsIdentity.isGuest()) {
-            _log.warn("guest login disabled: {}", windowsIdentity.getFqn());
+        if (!this.allowGuestLogin && windowsIdentity.isGuest()) {
+            this.log.warn("guest login disabled: {}", windowsIdentity.getFqn());
             return super.doLogin(request, username, password);
         }
         try {
-            _log.debug("successfully logged in {} ({})", username, windowsIdentity.getSidString());
-            GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity, _principalFormat,
-                    _roleFormat);
-            _log.debug("roles: {}", windowsPrincipal.getRolesString());
+            this.log.debug("successfully logged in {} ({})", username, windowsIdentity.getSidString());
+            GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity,
+                    this.principalFormat, this.roleFormat);
+            this.log.debug("roles: {}", windowsPrincipal.getRolesString());
             return windowsPrincipal;
         } finally {
             windowsIdentity.dispose();

--- a/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/WindowsRealm.java
+++ b/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/WindowsRealm.java
@@ -24,20 +24,20 @@ import org.apache.catalina.realm.RealmBase;
  */
 public class WindowsRealm extends RealmBase {
 
-    protected static final String _name = "waffle.apache.WindowsRealm/1.0";
+    protected static final String name = "waffle.apache.WindowsRealm/1.0";
 
     @Override
     protected String getName() {
-        return _name;
+        return name;
     }
 
     @Override
-    protected String getPassword(String arg0) {
+    protected String getPassword(String value) {
         return null;
     }
 
     @Override
-    protected Principal getPrincipal(String arg0) {
+    protected Principal getPrincipal(String value) {
         return null;
     }
 }

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/MixedAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/MixedAuthenticatorTests.java
@@ -49,11 +49,11 @@ import com.sun.jna.platform.win32.Sspi.SecBufferDesc;
  */
 public class MixedAuthenticatorTests {
 
-    private MixedAuthenticator _authenticator;
+    private MixedAuthenticator authenticator;
 
     @Before
     public void setUp() throws LifecycleException {
-        _authenticator = new MixedAuthenticator();
+        this.authenticator = new MixedAuthenticator();
         SimpleContext ctx = new SimpleContext();
         Realm realm = new SimpleRealm();
         ctx.setRealm(realm);
@@ -62,19 +62,19 @@ public class MixedAuthenticatorTests {
         SimplePipeline pipeline = new SimplePipeline();
         engine.setPipeline(pipeline);
         ctx.setPipeline(pipeline);
-        ctx.setAuthenticator(_authenticator);
-        _authenticator.setContainer(ctx);
-        _authenticator.start();
+        ctx.setAuthenticator(this.authenticator);
+        this.authenticator.setContainer(ctx);
+        this.authenticator.start();
     }
 
     @After
     public void tearDown() throws LifecycleException {
-        _authenticator.stop();
+        this.authenticator.stop();
     }
 
     @Test
     public void testGetInfo() {
-        assertTrue(_authenticator.getInfo().length() > 0);
+        assertTrue(this.authenticator.getInfo().length() > 0);
     }
 
     @Test
@@ -83,7 +83,7 @@ public class MixedAuthenticatorTests {
         request.setMethod("GET");
         request.setQueryString("j_negotiate_check");
         SimpleHttpResponse response = new SimpleHttpResponse();
-        _authenticator.authenticate(request, response);
+        this.authenticator.authenticate(request, response);
         String[] wwwAuthenticates = response.getHeaderValues("WWW-Authenticate");
         assertEquals(2, wwwAuthenticates.length);
         assertEquals("Negotiate", wwwAuthenticates[0]);
@@ -115,7 +115,7 @@ public class MixedAuthenticatorTests {
             String clientToken = BaseEncoding.base64().encode(clientContext.getToken());
             request.addHeader("Authorization", securityPackage + " " + clientToken);
             SimpleHttpResponse response = new SimpleHttpResponse();
-            _authenticator.authenticate(request, response);
+            this.authenticator.authenticate(request, response);
             assertTrue(response.getHeader("WWW-Authenticate").startsWith(securityPackage + " "));
             assertEquals("keep-alive", response.getHeader("Connection"));
             assertEquals(2, response.getHeaderNames().size());
@@ -133,7 +133,6 @@ public class MixedAuthenticatorTests {
     @Test
     public void testNegotiate() {
         String securityPackage = "Negotiate";
-        // client credentials handle
         IWindowsCredentialsHandle clientCredentials = null;
         WindowsSecurityContextImpl clientContext = null;
         try {
@@ -155,7 +154,7 @@ public class MixedAuthenticatorTests {
                 request.addHeader("Authorization", securityPackage + " " + clientToken);
 
                 SimpleHttpResponse response = new SimpleHttpResponse();
-                authenticated = _authenticator.authenticate(request, response);
+                authenticated = this.authenticator.authenticate(request, response);
 
                 if (authenticated) {
                     assertTrue(response.getHeaderNames().size() >= 0);
@@ -188,7 +187,7 @@ public class MixedAuthenticatorTests {
     public void testGet() {
         SimpleHttpRequest request = new SimpleHttpRequest();
         SimpleHttpResponse response = new SimpleHttpResponse();
-        assertFalse(_authenticator.authenticate(request, response));
+        assertFalse(this.authenticator.authenticate(request, response));
         assertEquals(304, response.getStatus());
         assertEquals("login.html", response.getHeader("Location"));
         assertEquals(1, response.getHeaderNames().size());
@@ -201,7 +200,7 @@ public class MixedAuthenticatorTests {
         request.addParameter("j_username", "username");
         request.addParameter("j_password", "password");
         SimpleHttpResponse response = new SimpleHttpResponse();
-        assertFalse(_authenticator.authenticate(request, response));
+        assertFalse(this.authenticator.authenticate(request, response));
         assertEquals(304, response.getStatus());
         assertEquals("error.html", response.getHeader("Location"));
         assertEquals(1, response.getHeaderNames().size());
@@ -209,30 +208,30 @@ public class MixedAuthenticatorTests {
 
     @Test
     public void testSecurityCheckQueryString() {
-        _authenticator.setAuth(new MockWindowsAuthProvider());
+        this.authenticator.setAuth(new MockWindowsAuthProvider());
         SimpleHttpRequest request = new SimpleHttpRequest();
         request.setQueryString("j_security_check");
         request.addParameter("j_username", WindowsAccountImpl.getCurrentUsername());
         request.addParameter("j_password", "");
         SimpleHttpResponse response = new SimpleHttpResponse();
-        assertTrue(_authenticator.authenticate(request, response));
+        assertTrue(this.authenticator.authenticate(request, response));
     }
 
     @Test
     public void testSecurityCheckParameters() {
-        _authenticator.setAuth(new MockWindowsAuthProvider());
+        this.authenticator.setAuth(new MockWindowsAuthProvider());
         SimpleHttpRequest request = new SimpleHttpRequest();
         request.addParameter("j_security_check", "");
         request.addParameter("j_username", WindowsAccountImpl.getCurrentUsername());
         request.addParameter("j_password", "");
         SimpleHttpResponse response = new SimpleHttpResponse();
-        assertTrue(_authenticator.authenticate(request, response));
+        assertTrue(this.authenticator.authenticate(request, response));
     }
 
     public void testProgrammaticSecurity() throws ServletException {
-        _authenticator.setAuth(new MockWindowsAuthProvider());
+        this.authenticator.setAuth(new MockWindowsAuthProvider());
         SimpleHttpRequest request = new SimpleHttpRequest();
-        request.setContext((Context) _authenticator.getContainer());
+        request.setContext((Context) this.authenticator.getContainer());
 
         request.login(WindowsAccountImpl.getCurrentUsername(), "");
 

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
@@ -50,13 +50,13 @@ import com.sun.jna.platform.win32.Sspi.SecBufferDesc;
  */
 public class NegotiateAuthenticatorTests {
 
-    private static final Logger    logger = LoggerFactory.getLogger(NegotiateAuthenticatorTests.class);
+    private static final Logger    LOGGER = LoggerFactory.getLogger(NegotiateAuthenticatorTests.class);
 
     private NegotiateAuthenticator authenticator;
 
     @Before
     public void setUp() throws LifecycleException {
-        authenticator = new NegotiateAuthenticator();
+        this.authenticator = new NegotiateAuthenticator();
         SimpleContext ctx = new SimpleContext();
         Realm realm = new SimpleRealm();
         ctx.setRealm(realm);
@@ -65,40 +65,40 @@ public class NegotiateAuthenticatorTests {
         SimplePipeline pipeline = new SimplePipeline();
         engine.setPipeline(pipeline);
         ctx.setPipeline(pipeline);
-        authenticator.setContainer(ctx);
-        authenticator.start();
+        this.authenticator.setContainer(ctx);
+        this.authenticator.start();
     }
 
     @After
     public void tearDown() throws LifecycleException {
-        authenticator.stop();
+        this.authenticator.stop();
     }
 
     @Test
     public void testGetInfo() {
-        assertTrue(authenticator.getInfo().length() > 0);
-        assertTrue(authenticator.getAuth() instanceof WindowsAuthProviderImpl);
+        assertTrue(this.authenticator.getInfo().length() > 0);
+        assertTrue(this.authenticator.getAuth() instanceof WindowsAuthProviderImpl);
     }
 
     @Test
     public void testAllowGuestLogin() {
-        assertTrue(authenticator.isAllowGuestLogin());
-        authenticator.setAllowGuestLogin(false);
-        assertFalse(authenticator.isAllowGuestLogin());
+        assertTrue(this.authenticator.isAllowGuestLogin());
+        this.authenticator.setAllowGuestLogin(false);
+        assertFalse(this.authenticator.isAllowGuestLogin());
     }
 
     @Test
     public void testPrincipalFormat() {
-        assertEquals(PrincipalFormat.fqn, authenticator.getPrincipalFormat());
-        authenticator.setPrincipalFormat("both");
-        assertEquals(PrincipalFormat.both, authenticator.getPrincipalFormat());
+        assertEquals(PrincipalFormat.fqn, this.authenticator.getPrincipalFormat());
+        this.authenticator.setPrincipalFormat("both");
+        assertEquals(PrincipalFormat.both, this.authenticator.getPrincipalFormat());
     }
 
     @Test
     public void testRoleFormat() {
-        assertEquals(PrincipalFormat.fqn, authenticator.getRoleFormat());
-        authenticator.setRoleFormat("both");
-        assertEquals(PrincipalFormat.both, authenticator.getRoleFormat());
+        assertEquals(PrincipalFormat.fqn, this.authenticator.getRoleFormat());
+        this.authenticator.setRoleFormat("both");
+        assertEquals(PrincipalFormat.both, this.authenticator.getRoleFormat());
     }
 
     @Test
@@ -106,7 +106,7 @@ public class NegotiateAuthenticatorTests {
         SimpleHttpRequest request = new SimpleHttpRequest();
         request.setMethod("GET");
         SimpleHttpResponse response = new SimpleHttpResponse();
-        authenticator.authenticate(request, response);
+        this.authenticator.authenticate(request, response);
         String[] wwwAuthenticates = response.getHeaderValues("WWW-Authenticate");
         assertEquals(2, wwwAuthenticates.length);
         assertEquals("Negotiate", wwwAuthenticates[0]);
@@ -122,6 +122,7 @@ public class NegotiateAuthenticatorTests {
         IWindowsCredentialsHandle clientCredentials = null;
         WindowsSecurityContextImpl clientContext = null;
         try {
+            // client credentials handle
             clientCredentials = WindowsCredentialsHandleImpl.getCurrent(securityPackage);
             clientCredentials.initialize();
             // initial client security context
@@ -136,7 +137,7 @@ public class NegotiateAuthenticatorTests {
             String clientToken = BaseEncoding.base64().encode(clientContext.getToken());
             request.addHeader("Authorization", securityPackage + " " + clientToken);
             SimpleHttpResponse response = new SimpleHttpResponse();
-            authenticator.authenticate(request, response);
+            this.authenticator.authenticate(request, response);
             assertTrue(response.getHeader("WWW-Authenticate").startsWith(securityPackage + " "));
             assertEquals("keep-alive", response.getHeader("Connection"));
             assertEquals(2, response.getHeaderNames().size());
@@ -182,9 +183,9 @@ public class NegotiateAuthenticatorTests {
 
                 response = new SimpleHttpResponse();
                 try {
-                    authenticated = authenticator.authenticate(request, response);
+                    authenticated = this.authenticator.authenticate(request, response);
                 } catch (Exception e) {
-                    logger.error("{}", e);
+                    LOGGER.error("{}", e);
                     return;
                 }
 
@@ -238,7 +239,7 @@ public class NegotiateAuthenticatorTests {
                 request.addHeader("Authorization", securityPackage + " " + clientToken);
 
                 SimpleHttpResponse response = new SimpleHttpResponse();
-                authenticated = authenticator.authenticate(request, response);
+                authenticated = this.authenticator.authenticate(request, response);
 
                 if (authenticated) {
                     assertNotNull(request.getUserPrincipal());

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/WaffleAuthenticatorBaseTest.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/WaffleAuthenticatorBaseTest.java
@@ -30,9 +30,9 @@ public class WaffleAuthenticatorBaseTest {
 
     @Before
     public void init() {
-        waffleAuthenticatorBase = new WaffleAuthenticatorBase() {
+        this.waffleAuthenticatorBase = new WaffleAuthenticatorBase() {
             {
-                _log = LoggerFactory.getLogger(WaffleAuthenticatorBaseTest.class);
+                this.log = LoggerFactory.getLogger(WaffleAuthenticatorBaseTest.class);
             }
 
             @Override
@@ -44,31 +44,31 @@ public class WaffleAuthenticatorBaseTest {
 
     @Test
     public void should_accept_NTLM_protocol() throws Exception {
-        waffleAuthenticatorBase.setProtocols("  NTLM ");
+        this.waffleAuthenticatorBase.setProtocols("  NTLM ");
 
-        assertEquals("One protocol added", 1, waffleAuthenticatorBase._protocols.size());
-        assertEquals("NTLM", waffleAuthenticatorBase._protocols.iterator().next());
+        assertEquals("One protocol added", 1, this.waffleAuthenticatorBase.protocols.size());
+        assertEquals("NTLM", this.waffleAuthenticatorBase.protocols.iterator().next());
     }
 
     @Test
     public void should_accept_Negotiate_protocol() throws Exception {
-        waffleAuthenticatorBase.setProtocols(" Negotiate  ");
+        this.waffleAuthenticatorBase.setProtocols(" Negotiate  ");
 
-        assertEquals("One protocol added", 1, waffleAuthenticatorBase._protocols.size());
-        assertEquals("Negotiate", waffleAuthenticatorBase._protocols.iterator().next());
+        assertEquals("One protocol added", 1, this.waffleAuthenticatorBase.protocols.size());
+        assertEquals("Negotiate", this.waffleAuthenticatorBase.protocols.iterator().next());
     }
 
     @Test
     public void should_accept_both_protocols() throws Exception {
-        waffleAuthenticatorBase.setProtocols("  NTLM , , Negotiate   ");
+        this.waffleAuthenticatorBase.setProtocols("  NTLM , , Negotiate   ");
 
-        assertEquals("Two protocols added", 2, waffleAuthenticatorBase._protocols.size());
-        assertTrue("NTLM has been added", waffleAuthenticatorBase._protocols.contains("NTLM"));
-        assertTrue("Negotiate has been added", waffleAuthenticatorBase._protocols.contains("Negotiate"));
+        assertEquals("Two protocols added", 2, this.waffleAuthenticatorBase.protocols.size());
+        assertTrue("NTLM has been added", this.waffleAuthenticatorBase.protocols.contains("NTLM"));
+        assertTrue("Negotiate has been added", this.waffleAuthenticatorBase.protocols.contains("Negotiate"));
     }
 
     @Test(expected = RuntimeException.class)
     public void should_refuse_other_protocol() throws Exception {
-        waffleAuthenticatorBase.setProtocols("  NTLM , OTHER, Negotiate   ");
+        this.waffleAuthenticatorBase.setProtocols("  NTLM , OTHER, Negotiate   ");
     }
 }

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/WindowsAccountTests.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/WindowsAccountTests.java
@@ -35,27 +35,27 @@ import waffle.windows.auth.WindowsAccount;
  */
 public class WindowsAccountTests {
 
-    private MockWindowsAccount _mockWindowsAccount = new MockWindowsAccount("localhost\\Administrator");
-    private WindowsAccount     _windowsAccount;
+    private MockWindowsAccount mockWindowsAccount = new MockWindowsAccount("localhost\\Administrator");
+    private WindowsAccount     windowsAccount;
 
     @Before
     public void setUp() {
-        _windowsAccount = new WindowsAccount(_mockWindowsAccount);
+        this.windowsAccount = new WindowsAccount(this.mockWindowsAccount);
     }
 
     @Test
     public void testProperties() {
-        assertEquals("localhost", _windowsAccount.getDomain());
-        assertEquals("localhost\\Administrator", _windowsAccount.getFqn());
-        assertEquals("Administrator", _windowsAccount.getName());
-        assertTrue(_windowsAccount.getSidString().startsWith("S-"));
+        assertEquals("localhost", this.windowsAccount.getDomain());
+        assertEquals("localhost\\Administrator", this.windowsAccount.getFqn());
+        assertEquals("Administrator", this.windowsAccount.getName());
+        assertTrue(this.windowsAccount.getSidString().startsWith("S-"));
     }
 
     @Test
     public void testEquals() {
-        assertEquals(_windowsAccount, new WindowsAccount(_mockWindowsAccount));
+        assertEquals(this.windowsAccount, new WindowsAccount(this.mockWindowsAccount));
         MockWindowsAccount mockWindowsAccount2 = new MockWindowsAccount("localhost\\Administrator2");
-        assertFalse(_windowsAccount.equals(new WindowsAccount(mockWindowsAccount2)));
+        assertFalse(this.windowsAccount.equals(new WindowsAccount(mockWindowsAccount2)));
     }
 
     @Test
@@ -63,7 +63,7 @@ public class WindowsAccountTests {
         // serialize
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(out);
-        oos.writeObject(_windowsAccount);
+        oos.writeObject(this.windowsAccount);
         oos.close();
         assertTrue(out.toByteArray().length > 0);
         // deserialize
@@ -72,10 +72,10 @@ public class WindowsAccountTests {
         Object o = ois.readObject();
         WindowsAccount copy = (WindowsAccount) o;
         // test
-        assertEquals(_windowsAccount, copy);
-        assertEquals(_windowsAccount.getDomain(), copy.getDomain());
-        assertEquals(_windowsAccount.getFqn(), copy.getFqn());
-        assertEquals(_windowsAccount.getName(), copy.getName());
-        assertEquals(_windowsAccount.getSidString(), copy.getSidString());
+        assertEquals(this.windowsAccount, copy);
+        assertEquals(this.windowsAccount.getDomain(), copy.getDomain());
+        assertEquals(this.windowsAccount.getFqn(), copy.getFqn());
+        assertEquals(this.windowsAccount.getName(), copy.getName());
+        assertEquals(this.windowsAccount.getSidString(), copy.getSidString());
     }
 }

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleContext.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleContext.java
@@ -62,1169 +62,1321 @@ import org.apache.tomcat.util.descriptor.web.SecurityConstraint;
  */
 public class SimpleContext implements Context {
 
-    private String         _path           = "/";
-    private String         _name           = "SimpleContext";
-    private Realm          _realm;
-    private Container      _parent;
-    private ServletContext _servletContext = new SimpleServletContext();
-    private Pipeline       _pipeline;
-    private Authenticator  _authenticator;
+    private String         path           = "/";
+    private String         name           = "SimpleContext";
+    private Realm          realm;
+    private Container      parent;
+    private ServletContext servletContext = new SimpleServletContext();
+    private Pipeline       pipeline;
+    private Authenticator  authenticator;
 
     @Override
-    public void addApplicationParameter(ApplicationParameter arg0) {
-
+    public void addApplicationParameter(ApplicationParameter value) {
+        // Not Implemented
     }
 
     @Override
-    public void addConstraint(SecurityConstraint arg0) {
-
+    public void addConstraint(SecurityConstraint value) {
+        // Not Implemented
     }
 
     @Override
-    public void addErrorPage(ErrorPage arg0) {
-
+    public void addErrorPage(ErrorPage value) {
+        // Not Implemented
     }
 
     @Override
-    public void addFilterDef(FilterDef arg0) {
-
+    public void addFilterDef(FilterDef value) {
+        // Not Implemented
     }
 
     @Override
-    public void addFilterMap(FilterMap arg0) {
-
+    public void addFilterMap(FilterMap value) {
+        // Not Implemented
     }
 
     @Override
-    public void addInstanceListener(String arg0) {
-
+    public void addInstanceListener(String value) {
+        // Not Implemented
     }
 
     @Override
-    public void addLocaleEncodingMappingParameter(String arg0, String arg1) {
-
+    public void addLocaleEncodingMappingParameter(String value, String arg1) {
+        // Not Implemented
     }
 
     @Override
-    public void addMimeMapping(String arg0, String arg1) {
-
+    public void addMimeMapping(String value, String arg1) {
+        // Not Implemented
     }
 
     @Override
-    public void addParameter(String arg0, String arg1) {
-
+    public void addParameter(String value, String arg1) {
+        // Not Implemented
     }
 
     @Override
-    public void addRoleMapping(String arg0, String arg1) {
-
+    public void addRoleMapping(String value, String arg1) {
+        // Not Implemented
     }
 
     @Override
-    public void addSecurityRole(String arg0) {
-
+    public void addSecurityRole(String value) {
+        // Not Implemented
     }
 
     @Override
-    public void addServletMapping(String arg0, String arg1) {
-
+    public void addServletMapping(String value, String arg1) {
+        // Not Implemented
     }
 
     @Override
-    public void addWatchedResource(String arg0) {
-
+    public void addWatchedResource(String value) {
+        // Not Implemented
     }
 
     @Override
-    public void addWelcomeFile(String arg0) {
-
+    public void addWelcomeFile(String value) {
+        // Not Implemented
     }
 
     @Override
-    public void addWrapperLifecycle(String arg0) {
-
+    public void addWrapperLifecycle(String value) {
+        // Not Implemented
     }
 
     @Override
-    public void addWrapperListener(String arg0) {
-
+    public void addWrapperListener(String value) {
+        // Not Implemented
     }
 
     @Override
     public Wrapper createWrapper() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public ApplicationParameter[] findApplicationParameters() {
+        // Not Implemented
         return new ApplicationParameter[0];
     }
 
     @Override
     public SecurityConstraint[] findConstraints() {
+        // Not Implemented
         return new SecurityConstraint[0];
     }
 
     @Override
-    public ErrorPage findErrorPage(int arg0) {
+    public ErrorPage findErrorPage(int value) {
+        // Not Implemented
         return null;
     }
 
     @Override
-    public ErrorPage findErrorPage(String arg0) {
+    public ErrorPage findErrorPage(String value) {
+        // Not Implemented
         return null;
     }
 
     @Override
     public ErrorPage[] findErrorPages() {
+        // Not Implemented
         return new ErrorPage[0];
     }
 
     @Override
-    public FilterDef findFilterDef(String arg0) {
+    public FilterDef findFilterDef(String value) {
+        // Not Implemented
         return null;
     }
 
     @Override
     public FilterDef[] findFilterDefs() {
+        // Not Implemented
         return new FilterDef[0];
     }
 
     @Override
     public FilterMap[] findFilterMaps() {
+        // Not Implemented
         return new FilterMap[0];
     }
 
     @Override
     public String[] findInstanceListeners() {
+        // Not Implemented
         return new String[0];
     }
 
     @Override
-    public String findMimeMapping(String arg0) {
+    public String findMimeMapping(String value) {
+        // Not Implemented
         return null;
     }
 
     @Override
     public String[] findMimeMappings() {
+        // Not Implemented
         return new String[0];
     }
 
     @Override
-    public String findParameter(String arg0) {
+    public String findParameter(String value) {
+        // Not Implemented
         return null;
     }
 
     @Override
     public String[] findParameters() {
+        // Not Implemented
         return new String[0];
     }
 
     @Override
-    public String findRoleMapping(String arg0) {
+    public String findRoleMapping(String value) {
+        // Not Implemented
         return null;
     }
 
     @Override
-    public boolean findSecurityRole(String arg0) {
+    public boolean findSecurityRole(String value) {
+        // Not Implemented
         return false;
     }
 
     @Override
     public String[] findSecurityRoles() {
+        // Not Implemented
         return new String[0];
     }
 
     @Override
-    public String findServletMapping(String arg0) {
+    public String findServletMapping(String value) {
+        // Not Implemented
         return null;
     }
 
     @Override
     public String[] findServletMappings() {
+        // Not Implemented
         return new String[0];
     }
 
     @Override
-    public String findStatusPage(int arg0) {
+    public String findStatusPage(int value) {
+        // Not Implemented
         return null;
     }
 
     @Override
     public int[] findStatusPages() {
+        // Not Implemented
         return new int[0];
     }
 
     @Override
     public String[] findWatchedResources() {
+        // Not Implemented
         return new String[0];
     }
 
     @Override
-    public boolean findWelcomeFile(String arg0) {
+    public boolean findWelcomeFile(String value) {
+        // Not Implemented
         return false;
     }
 
     @Override
     public String[] findWelcomeFiles() {
+        // Not Implemented
         return new String[0];
     }
 
     @Override
     public String[] findWrapperLifecycles() {
+        // Not Implemented
         return new String[0];
     }
 
     @Override
     public String[] findWrapperListeners() {
+        // Not Implemented
         return new String[0];
     }
 
     @Override
     public String getAltDDName() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public Object[] getApplicationEventListeners() {
+        // Not Implemented
         return new Object[0];
     }
 
     @Override
     public Object[] getApplicationLifecycleListeners() {
+        // Not Implemented
         return new Object[0];
     }
 
     @Override
     public URL getConfigFile() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public boolean getConfigured() {
+        // Not Implemented
         return false;
     }
 
     @Override
     public boolean getCookies() {
+        // Not Implemented
         return false;
     }
 
     @Override
     public boolean getCrossContext() {
+        // Not Implemented
         return false;
     }
 
     @Override
     public String getDisplayName() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public boolean getDistributable() {
+        // Not Implemented
         return false;
     }
 
     @Override
     public String getDocBase() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public String getEncodedPath() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public boolean getIgnoreAnnotations() {
+        // Not Implemented
         return false;
     }
 
     @Override
     public LoginConfig getLoginConfig() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public NamingResourcesImpl getNamingResources() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public boolean getOverride() {
+        // Not Implemented
         return false;
     }
 
+    /**
+     * Get Path Used By Waffle.
+     */
     @Override
     public String getPath() {
-        return _path;
+        return this.path;
     }
 
     @Override
     public boolean getPrivileged() {
+        // Not Implemented
         return false;
     }
 
     @Override
     public String getPublicId() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public boolean getReloadable() {
+        // Not Implemented
         return false;
     }
 
+    /**
+     * Get Servlet Context Used By Waffle.
+     */
     @Override
     public ServletContext getServletContext() {
-        return _servletContext;
+        return this.servletContext;
     }
 
     @Override
     public int getSessionTimeout() {
+        // Not Implemented
         return 0;
     }
 
     @Override
     public boolean getSwallowOutput() {
+        // Not Implemented
         return false;
     }
 
     @Override
     public boolean getTldValidation() {
+        // Not Implemented
         return false;
     }
 
     @Override
     public boolean getUseHttpOnly() {
+        // Not Implemented
         return false;
     }
 
     @Override
     public String getWrapperClass() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public boolean getXmlNamespaceAware() {
+        // Not Implemented
         return false;
     }
 
     @Override
     public boolean getXmlValidation() {
+        // Not Implemented
         return false;
     }
 
     @Override
     public void reload() {
-
+        // Not Implemented
     }
 
     @Override
-    public void removeApplicationListener(String arg0) {
-
+    public void removeApplicationListener(String value) {
+        // Not Implemented
     }
 
     @Override
-    public void removeApplicationParameter(String arg0) {
-
+    public void removeApplicationParameter(String value) {
+        // Not Implemented
     }
 
     @Override
-    public void removeConstraint(SecurityConstraint arg0) {
-
+    public void removeConstraint(SecurityConstraint value) {
+        // Not Implemented
     }
 
     @Override
-    public void removeErrorPage(ErrorPage arg0) {
-
+    public void removeErrorPage(ErrorPage value) {
+        // Not Implemented
     }
 
     @Override
-    public void removeFilterDef(FilterDef arg0) {
-
+    public void removeFilterDef(FilterDef value) {
+        // Not Implemented
     }
 
     @Override
-    public void removeFilterMap(FilterMap arg0) {
-
+    public void removeFilterMap(FilterMap value) {
+        // Not Implemented
     }
 
     @Override
-    public void removeInstanceListener(String arg0) {
-
+    public void removeInstanceListener(String value) {
+        // Not Implemented
     }
 
     @Override
-    public void removeMimeMapping(String arg0) {
-
+    public void removeMimeMapping(String value) {
+        // Not Implemented
     }
 
     @Override
-    public void removeParameter(String arg0) {
-
+    public void removeParameter(String value) {
+        // Not Implemented
     }
 
     @Override
-    public void removeRoleMapping(String arg0) {
-
+    public void removeRoleMapping(String value) {
+        // Not Implemented
     }
 
     @Override
-    public void removeSecurityRole(String arg0) {
-
+    public void removeSecurityRole(String value) {
+        // Not Implemented
     }
 
     @Override
-    public void removeServletMapping(String arg0) {
-
+    public void removeServletMapping(String value) {
+        // Not Implemented
     }
 
     @Override
-    public void removeWatchedResource(String arg0) {
-
+    public void removeWatchedResource(String value) {
+        // Not Implemented
     }
 
     @Override
-    public void removeWelcomeFile(String arg0) {
-
+    public void removeWelcomeFile(String value) {
+        // Not Implemented
     }
 
     @Override
-    public void removeWrapperLifecycle(String arg0) {
-
+    public void removeWrapperLifecycle(String value) {
+        // Not Implemented
     }
 
     @Override
-    public void removeWrapperListener(String arg0) {
-
+    public void removeWrapperListener(String value) {
+        // Not Implemented
     }
 
     @Override
-    public void setAltDDName(String arg0) {
-
+    public void setAltDDName(String value) {
+        // Not Implemented
     }
 
     @Override
-    public void setApplicationEventListeners(Object[] arg0) {
-
+    public void setApplicationEventListeners(Object[] value) {
+        // Not Implemented
     }
 
     @Override
-    public void setApplicationLifecycleListeners(Object[] arg0) {
-
+    public void setApplicationLifecycleListeners(Object[] value) {
+        // Not Implemented
     }
 
     @Override
-    public void setConfigured(boolean arg0) {
-
+    public void setConfigured(boolean value) {
+        // Not Implemented
     }
 
     @Override
-    public void setCookies(boolean arg0) {
-
+    public void setCookies(boolean value) {
+        // Not Implemented
     }
 
     @Override
-    public void setCrossContext(boolean arg0) {
-
+    public void setCrossContext(boolean value) {
+        // Not Implemented
     }
 
     @Override
-    public void setDisplayName(String arg0) {
-
+    public void setDisplayName(String value) {
+        // Not Implemented
     }
 
     @Override
-    public void setDistributable(boolean arg0) {
-
+    public void setDistributable(boolean value) {
+        // Not Implemented
     }
 
     @Override
-    public void setDocBase(String arg0) {
-
+    public void setDocBase(String value) {
+        // Not Implemented
     }
 
     @Override
-    public void setIgnoreAnnotations(boolean arg0) {
-
+    public void setIgnoreAnnotations(boolean value) {
+        // Not Implemented
     }
 
     @Override
-    public void setLoginConfig(LoginConfig arg0) {
-
+    public void setLoginConfig(LoginConfig value) {
+        // Not Implemented
     }
 
     @Override
-    public void setOverride(boolean arg0) {
+    public void setOverride(boolean value) {
+        // Not Implemented
+    }
 
+    /**
+     * Set Path Used By Waffle
+     */
+    @Override
+    public void setPath(String value) {
+        this.path = value;
     }
 
     @Override
-    public void setPath(String path) {
-        _path = path;
+    public void setPrivileged(boolean value) {
+        // Not Implemented
     }
 
     @Override
-    public void setPrivileged(boolean arg0) {
-
+    public void setPublicId(String value) {
+        // Not Implemented
     }
 
     @Override
-    public void setPublicId(String arg0) {
-
+    public void setReloadable(boolean value) {
+        // Not Implemented
     }
 
     @Override
-    public void setReloadable(boolean arg0) {
-
+    public void setSessionTimeout(int value) {
+        // Not Implemented
     }
 
     @Override
-    public void setSessionTimeout(int arg0) {
-
+    public void setSwallowOutput(boolean value) {
+        // Not Implemented
     }
 
     @Override
-    public void setSwallowOutput(boolean arg0) {
-
+    public void setTldValidation(boolean value) {
+        // Not Implemented
     }
 
     @Override
-    public void setTldValidation(boolean arg0) {
-
+    public void setUseHttpOnly(boolean value) {
+        // Not Implemented
     }
 
     @Override
-    public void setUseHttpOnly(boolean arg0) {
-
+    public void setWrapperClass(String value) {
+        // Not Implemented
     }
 
     @Override
-    public void setWrapperClass(String arg0) {
-
+    public void setXmlNamespaceAware(boolean value) {
+        // Not Implemented
     }
 
     @Override
-    public void setXmlNamespaceAware(boolean arg0) {
-
+    public void setXmlValidation(boolean value) {
+        // Not Implemented
     }
 
     @Override
-    public void setXmlValidation(boolean arg0) {
-
+    public void addChild(Container value) {
+        // Not Implemented
     }
 
     @Override
-    public void addChild(Container arg0) {
-
+    public void addContainerListener(ContainerListener value) {
+        // Not Implemented
     }
 
     @Override
-    public void addContainerListener(ContainerListener arg0) {
-
-    }
-
-    @Override
-    public void addPropertyChangeListener(PropertyChangeListener arg0) {
-
+    public void addPropertyChangeListener(PropertyChangeListener value) {
+        // Not Implemented
     }
 
     @Override
     public void backgroundProcess() {
-
+        // Not Implemented
     }
 
     @Override
-    public Container findChild(String arg0) {
+    public Container findChild(String value) {
+        // Not Implemented
         return null;
     }
 
     @Override
     public Container[] findChildren() {
+        // Not Implemented
         return new Container[0];
     }
 
     @Override
     public ContainerListener[] findContainerListeners() {
+        // Not Implemented
         return new ContainerListener[0];
     }
 
     @Override
     public int getBackgroundProcessorDelay() {
+        // Not Implemented
         return 0;
     }
 
     @Override
     public Cluster getCluster() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public Loader getLoader() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public Log getLogger() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public Manager getManager() {
+        // Not Implemented
         return null;
     }
 
+    /**
+     * Get Name Used By Waffle.
+     */
     @Override
     public String getName() {
-        return _name;
+        return this.name;
     }
 
     @Override
     public ObjectName getObjectName() {
+        // Not Implemented
         return null;
     }
 
+    /**
+     * Get Parent Used By Waffle.
+     */
     @Override
     public Container getParent() {
-        return _parent;
+        return this.parent;
     }
 
     @Override
     public ClassLoader getParentClassLoader() {
+        // Not Implemented
         return null;
     }
 
+    /**
+     * Get Pipeline Used By Waffle.
+     */
     @Override
     public Pipeline getPipeline() {
-        return _pipeline;
+        return this.pipeline;
     }
 
-    public void setPipeline(Pipeline pipeline) {
-        _pipeline = pipeline;
+    /**
+     * Set Pipeline Used By Waffle.
+     * 
+     * @param value
+     */
+    public void setPipeline(Pipeline value) {
+        this.pipeline = value;
     }
 
+    /**
+     * Get Realm Used By Waffle.
+     */
     @Override
     public Realm getRealm() {
-        return _realm;
+        return this.realm;
     }
 
     @Override
     public WebResourceRoot getResources() {
+        // Not Implemented
         return null;
     }
 
     @Override
-    public void removeChild(Container arg0) {
-
+    public void removeChild(Container value) {
+        // Not Implemented
     }
 
     @Override
-    public void removeContainerListener(ContainerListener arg0) {
-
+    public void removeContainerListener(ContainerListener value) {
+        // Not Implemented
     }
 
     @Override
-    public void removePropertyChangeListener(PropertyChangeListener arg0) {
-
+    public void removePropertyChangeListener(PropertyChangeListener value) {
+        // Not Implemented
     }
 
     @Override
-    public void setBackgroundProcessorDelay(int arg0) {
-
+    public void setBackgroundProcessorDelay(int value) {
+        // Not Implemented
     }
 
     @Override
-    public void setCluster(Cluster arg0) {
-
+    public void setCluster(Cluster value) {
+        // Not Implemented
     }
 
     @Override
-    public void setLoader(Loader arg0) {
-
+    public void setLoader(Loader value) {
+        // Not Implemented
     }
 
     @Override
-    public void setManager(Manager arg0) {
-
+    public void setManager(Manager value) {
+        // Not Implemented
     }
 
+    /**
+     * Set Name Used By Waffle.
+     */
     @Override
-    public void setName(String name) {
-        _name = name;
+    public void setName(String value) {
+        this.name = value;
     }
 
+    /**
+     * Set Parent Used By Waffle.
+     */
     @Override
     public void setParent(Container container) {
-        _parent = container;
+        this.parent = container;
     }
 
     @Override
-    public void setParentClassLoader(ClassLoader arg0) {
-
+    public void setParentClassLoader(ClassLoader value) {
+        // Not Implemented
     }
 
+    /**
+     * Set Realm Used By Waffle.
+     */
     @Override
-    public void setRealm(Realm realm) {
-        _realm = realm;
+    public void setRealm(Realm value) {
+        this.realm = value;
     }
 
     @Override
     public String getSessionCookieDomain() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public String getSessionCookieName() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public String getSessionCookiePath() {
+        // Not Implemented
         return null;
     }
 
     @Override
-    public void setSessionCookieDomain(String arg0) {
-
+    public void setSessionCookieDomain(String value) {
+        // Not Implemented
     }
 
     @Override
-    public void setSessionCookieName(String arg0) {
-
+    public void setSessionCookieName(String value) {
+        // Not Implemented
     }
 
     @Override
-    public void setSessionCookiePath(String arg0) {
-
+    public void setSessionCookiePath(String value) {
+        // Not Implemented
     }
 
     @Override
     public AccessLog getAccessLog() {
+        // Not Implemented
         return null;
     }
 
     @Override
-    public void logAccess(Request arg0, Response arg1, long arg2, boolean arg3) {
-
+    public void logAccess(Request value, Response arg1, long arg2, boolean arg3) {
+        // Not Implemented
     }
 
     @Override
-    public void fireContainerEvent(String arg0, Object arg1) {
-
+    public void fireContainerEvent(String value, Object arg1) {
+        // Not Implemented
     }
 
     @Override
-    public void addLifecycleListener(LifecycleListener arg0) {
-
+    public void addLifecycleListener(LifecycleListener value) {
+        // Not Implemented
     }
 
     @Override
     public void destroy() throws LifecycleException {
-
+        // Not Implemented
     }
 
     @Override
     public LifecycleListener[] findLifecycleListeners() {
+        // Not Implemented
         return new LifecycleListener[0];
     }
 
     @Override
     public LifecycleState getState() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public String getStateName() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public void init() throws LifecycleException {
-
+        // Not Implemented
     }
 
     @Override
-    public void removeLifecycleListener(LifecycleListener arg0) {
-
+    public void removeLifecycleListener(LifecycleListener value) {
+        // Not Implemented
     }
 
     @Override
     public void start() throws LifecycleException {
-
+        // Not Implemented
     }
 
     @Override
     public void stop() throws LifecycleException {
-
+        // Not Implemented
     }
 
     @Override
-    public void addFilterMapBefore(FilterMap arg0) {
-
+    public void addFilterMapBefore(FilterMap value) {
+        // Not Implemented
     }
 
     @Override
-    public void addServletContainerInitializer(ServletContainerInitializer arg0, Set<Class<?>> arg1) {
-
+    public void addServletContainerInitializer(ServletContainerInitializer value, Set<Class<?>> arg1) {
+        // Not Implemented
     }
 
     @Override
-    public void addServletMapping(String arg0, String arg1, boolean arg2) {
-
+    public void addServletMapping(String value, String arg1, boolean arg2) {
+        // Not Implemented
     }
 
+    /**
+     * Get Authenticator Used By Waffle.
+     */
     @Override
     public Authenticator getAuthenticator() {
-        return _authenticator;
+        return this.authenticator;
     }
 
-    public void setAuthenticator(Authenticator authenticator) {
-        _authenticator = authenticator;
+    /**
+     * Set Authenticator Used By Waffle.
+     * 
+     * @param value
+     */
+    public void setAuthenticator(Authenticator value) {
+        this.authenticator = value;
     }
 
     @Override
     public int getEffectiveMajorVersion() {
+        // Not Implemented
         return 0;
     }
 
     @Override
     public int getEffectiveMinorVersion() {
+        // Not Implemented
         return 0;
     }
 
     @Override
     public JspConfigDescriptor getJspConfigDescriptor() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public boolean getLogEffectiveWebXml() {
+        // Not Implemented
         return false;
     }
 
     @Override
     public boolean getPaused() {
+        // Not Implemented
         return false;
     }
 
     @Override
-    public String getRealPath(String arg0) {
+    public String getRealPath(String value) {
+        // Not Implemented
         return null;
     }
 
     @Override
     public boolean isServlet22() {
+        // Not Implemented
         return false;
     }
 
     @Override
-    public void setConfigFile(URL arg0) {
-
+    public void setConfigFile(URL value) {
+        // Not Implemented
     }
 
     @Override
-    public void setEffectiveMajorVersion(int arg0) {
-
+    public void setEffectiveMajorVersion(int value) {
+        // Not Implemented
     }
 
     @Override
-    public void setEffectiveMinorVersion(int arg0) {
-
+    public void setEffectiveMinorVersion(int value) {
+        // Not Implemented
     }
 
     @Override
-    public void setLogEffectiveWebXml(boolean arg0) {
-
+    public void setLogEffectiveWebXml(boolean value) {
+        // Not Implemented
     }
 
     @Override
     public int getStartStopThreads() {
+        // Not Implemented
         return 0;
     }
 
     @Override
-    public void setStartStopThreads(int arg0) {
-
+    public void setStartStopThreads(int value) {
+        // Not Implemented
     }
 
     @Override
-    public boolean fireRequestDestroyEvent(ServletRequest arg0) {
+    public boolean fireRequestDestroyEvent(ServletRequest value) {
+        // Not Implemented
         return false;
     }
 
     @Override
-    public boolean fireRequestInitEvent(ServletRequest arg0) {
+    public boolean fireRequestInitEvent(ServletRequest value) {
+        // Not Implemented
         return false;
     }
 
     @Override
     public boolean getAllowCasualMultipartParsing() {
+        // Not Implemented
         return false;
     }
 
     @Override
     public String getBaseName() {
+        // Not Implemented
         return null;
     }
 
     @Override
-    public String getCharset(Locale arg0) {
+    public String getCharset(Locale value) {
+        // Not Implemented
         return null;
     }
 
     @Override
     public boolean getFireRequestListenersOnForwards() {
+        // Not Implemented
         return false;
     }
 
     @Override
     public boolean getPreemptiveAuthentication() {
+        // Not Implemented
         return false;
     }
 
     @Override
     public String getResourceOnlyServlets() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public boolean getSendRedirectBody() {
+        // Not Implemented
         return false;
     }
 
     @Override
     public boolean getSessionCookiePathUsesTrailingSlash() {
+        // Not Implemented
         return false;
     }
 
     @Override
     public boolean getSwallowAbortedUploads() {
+        // Not Implemented
         return false;
     }
 
     @Override
     public String getWebappVersion() {
+        // Not Implemented
         return null;
     }
 
     @Override
-    public boolean isResourceOnlyServlet(String arg0) {
+    public boolean isResourceOnlyServlet(String value) {
+        // Not Implemented
         return false;
     }
 
     @Override
-    public void setAllowCasualMultipartParsing(boolean arg0) {
-
+    public void setAllowCasualMultipartParsing(boolean value) {
+        // Not Implemented
     }
 
     @Override
-    public void setFireRequestListenersOnForwards(boolean arg0) {
-
+    public void setFireRequestListenersOnForwards(boolean value) {
+        // Not Implemented
     }
 
     @Override
-    public void setPreemptiveAuthentication(boolean arg0) {
-
+    public void setPreemptiveAuthentication(boolean value) {
+        // Not Implemented
     }
 
     @Override
-    public void setResourceOnlyServlets(String arg0) {
-
+    public void setResourceOnlyServlets(String value) {
+        // Not Implemented
     }
 
     @Override
-    public void setSendRedirectBody(boolean arg0) {
-
+    public void setSendRedirectBody(boolean value) {
+        // Not Implemented
     }
 
     @Override
-    public void setSessionCookiePathUsesTrailingSlash(boolean arg0) {
-
+    public void setSessionCookiePathUsesTrailingSlash(boolean value) {
+        // Not Implemented
     }
 
     @Override
-    public void setSwallowAbortedUploads(boolean arg0) {
-
+    public void setSwallowAbortedUploads(boolean value) {
+        // Not Implemented
     }
 
     @Override
-    public void setWebappVersion(String arg0) {
-
+    public void setWebappVersion(String value) {
+        // Not Implemented
     }
 
     @Override
     public JarScanner getJarScanner() {
+        // Not Implemented
         return null;
     }
 
     @Override
-    public void setJarScanner(JarScanner arg0) {
-
+    public void setJarScanner(JarScanner value) {
+        // Not Implemented
     }
 
     @Override
     public String getDomain() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public String getMBeanKeyProperties() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public File getCatalinaBase() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public File getCatalinaHome() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public boolean getDenyUncoveredHttpMethods() {
+        // Not Implemented
         return false;
     }
 
     @Override
     public void setDenyUncoveredHttpMethods(boolean denyUncoveredHttpMethods) {
-
+        // Not Implemented
     }
 
     @Override
     public void setNamingResources(NamingResourcesImpl namingResources) {
-
+        // Not Implemented
     }
 
     @Override
     public boolean getXmlBlockExternal() {
+        // Not Implemented
         return false;
     }
 
     @Override
     public void setXmlBlockExternal(boolean xmlBlockExternal) {
-
+        // Not Implemented
     }
 
     @Override
     public InstanceManager getInstanceManager() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public void setInstanceManager(InstanceManager instanceManager) {
-
+        // Not Implemented
     }
 
     @Override
     public void setContainerSciFilter(String containerSciFilter) {
-
+        // Not Implemented
     }
 
     @Override
     public String getContainerSciFilter() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public ThreadBindingListener getThreadBindingListener() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public void setThreadBindingListener(ThreadBindingListener threadBindingListener) {
-
+        // Not Implemented
     }
 
     @Override
     public void setJspConfigDescriptor(JspConfigDescriptor descriptor) {
-
+        // Not Implemented
     }
 
     @Override
     public Set<String> addServletSecurity(Dynamic registration, ServletSecurityElement servletSecurityElement) {
+        // Not Implemented
         return null;
     }
 
     @Override
     public void setResources(WebResourceRoot resources) {
-
+        // Not Implemented
     }
 
     @Override
     public void setAddWebinfClassesResources(boolean addWebinfClassesResources) {
-
+        // Not Implemented
     }
 
     @Override
     public boolean getAddWebinfClassesResources() {
+        // Not Implemented
         return false;
     }
 
     @Override
     public void addPostConstructMethod(String clazz, String method) {
-
+        // Not Implemented
     }
 
     @Override
     public void addPreDestroyMethod(String clazz, String method) {
-
+        // Not Implemented
     }
 
     @Override
     public void removePostConstructMethod(String clazz) {
-
+        // Not Implemented
     }
 
     @Override
     public void removePreDestroyMethod(String clazz) {
-
+        // Not Implemented
     }
 
     @Override
     public String findPostConstructMethod(String clazz) {
+        // Not Implemented
         return null;
     }
 
     @Override
     public String findPreDestroyMethod(String clazz) {
+        // Not Implemented
         return null;
     }
 
     @Override
     public Map<String, String> findPostConstructMethods() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public Map<String, String> findPreDestroyMethods() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public ClassLoader bind(boolean usePrivilegedAction, ClassLoader originalClassLoader) {
+        // Not Implemented
         return null;
     }
 
     @Override
     public void unbind(boolean usePrivilegedAction, ClassLoader originalClassLoader) {
-
+        // Not Implemented
     }
 
     @Override
     public Object getNamingToken() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public void addApplicationListener(String listener) {
-
+        // Not Implemented
     }
 
     @Override
     public String[] findApplicationListeners() {
+        // Not Implemented
         return null;
     }
 }

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleEngine.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleEngine.java
@@ -32,254 +32,285 @@ import org.apache.juli.logging.Log;
 
 public class SimpleEngine implements org.apache.catalina.Engine {
 
-    private Pipeline _pipeline;
+    private Pipeline pipeline;
 
     @Override
     public Log getLogger() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public ObjectName getObjectName() {
+        // Not Implemented
         return null;
     }
 
+    /**
+     * Get Pipeline Used By Waffle.
+     */
     @Override
     public Pipeline getPipeline() {
-        return _pipeline;
+        return this.pipeline;
     }
 
-    public void setPipeline(Pipeline pipeline) {
-        _pipeline = pipeline;
+    /**
+     * Set Pipeline Used By Waffle.
+     * 
+     * @param value
+     */
+    public void setPipeline(Pipeline value) {
+        this.pipeline = value;
     }
 
     @Override
     public Cluster getCluster() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public void setCluster(Cluster cluster) {
-
+        // Not Implemented
     }
 
     @Override
     public int getBackgroundProcessorDelay() {
+        // Not Implemented
         return 0;
     }
 
     @Override
     public void setBackgroundProcessorDelay(int delay) {
-
+        // Not Implemented
     }
 
     @Override
     public String getName() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public void setName(String name) {
-
+        // Not Implemented
     }
 
     @Override
     public Container getParent() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public void setParent(Container container) {
-
+        // Not Implemented
     }
 
     @Override
     public ClassLoader getParentClassLoader() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public void setParentClassLoader(ClassLoader parent) {
-
+        // Not Implemented
     }
 
     @Override
     public Realm getRealm() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public void setRealm(Realm realm) {
-
+        // Not Implemented
     }
 
     @Override
     public void backgroundProcess() {
-
+        // Not Implemented
     }
 
     @Override
     public void addChild(Container child) {
-
+        // Not Implemented
     }
 
     @Override
     public void addContainerListener(ContainerListener listener) {
-
+        // Not Implemented
     }
 
     @Override
     public void addPropertyChangeListener(PropertyChangeListener listener) {
-
+        // Not Implemented
     }
 
     @Override
     public Container findChild(String name) {
+        // Not Implemented
         return null;
     }
 
     @Override
     public Container[] findChildren() {
+        // Not Implemented
         return new Container[0];
     }
 
     @Override
     public ContainerListener[] findContainerListeners() {
+        // Not Implemented
         return new ContainerListener[0];
     }
 
     @Override
     public void removeChild(Container child) {
-
+        // Not Implemented
     }
 
     @Override
     public void removeContainerListener(ContainerListener listener) {
-
+        // Not Implemented
     }
 
     @Override
     public void removePropertyChangeListener(PropertyChangeListener listener) {
-
+        // Not Implemented
     }
 
     @Override
     public void fireContainerEvent(String type, Object data) {
-
+        // Not Implemented
     }
 
     @Override
     public void logAccess(Request request, Response response, long time, boolean useDefault) {
-
+        // Not Implemented
     }
 
     @Override
     public AccessLog getAccessLog() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public void addLifecycleListener(LifecycleListener listener) {
-
+        // Not Implemented
     }
 
     @Override
     public LifecycleListener[] findLifecycleListeners() {
+        // Not Implemented
         return new LifecycleListener[0];
     }
 
     @Override
     public void removeLifecycleListener(LifecycleListener listener) {
-
+        // Not Implemented
     }
 
     @Override
     public void init() throws LifecycleException {
-
+        // Not Implemented
     }
 
     @Override
     public void start() throws LifecycleException {
-
+        // Not Implemented
     }
 
     @Override
     public void stop() throws LifecycleException {
-
+        // Not Implemented
     }
 
     @Override
     public void destroy() throws LifecycleException {
-
+        // Not Implemented
     }
 
     @Override
     public LifecycleState getState() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public String getStateName() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public String getDefaultHost() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public void setDefaultHost(String defaultHost) {
-
+        // Not Implemented
     }
 
     @Override
     public String getJvmRoute() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public void setJvmRoute(String jvmRouteId) {
-
+        // Not Implemented
     }
 
     @Override
     public Service getService() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public void setService(Service service) {
-
+        // Not Implemented
     }
 
     @Override
     public int getStartStopThreads() {
+        // Not Implemented
         return 0;
     }
 
     @Override
     public void setStartStopThreads(int arg0) {
-
+        // Not Implemented
     }
 
     @Override
     public String getDomain() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public String getMBeanKeyProperties() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public File getCatalinaBase() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public File getCatalinaHome() {
+        // Not Implemented
         return null;
     }
 

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleFilterChain.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleFilterChain.java
@@ -27,21 +27,20 @@ import javax.servlet.ServletResponse;
  */
 public class SimpleFilterChain implements FilterChain {
 
-    private ServletRequest  _request;
-    private ServletResponse _response;
+    private ServletRequest  request;
+    private ServletResponse response;
 
     public ServletRequest getRequest() {
-        return _request;
+        return this.request;
     }
 
     public ServletResponse getResponse() {
-        return _response;
+        return this.response;
     }
 
     @Override
     public void doFilter(ServletRequest sreq, ServletResponse srep) throws IOException, ServletException {
-
-        _request = sreq;
-        _response = srep;
+        this.request = sreq;
+        this.response = srep;
     }
 }

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleHttpRequest.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleHttpRequest.java
@@ -26,97 +26,94 @@ import org.apache.catalina.connector.Request;
  */
 public class SimpleHttpRequest extends Request {
 
-    private static int          _remotePort_s;
+    private static int          remotePortS;
 
-    private String              _requestURI;
-    private String              _queryString;
-    private String              _remoteUser;
-    private String              _method     = "GET";
-    private String              _remoteHost;
-    private String              _remoteAddr;
-    private int                 _remotePort = -1;
-    private Map<String, String> _headers    = new HashMap<String, String>();
-    private Map<String, String> _parameters = new HashMap<String, String>();
-    private byte[]              _content;
-    private HttpSession         _session    = new SimpleHttpSession();
-    private Principal           _principal;
+    private String              requestURI;
+    private String              queryString;
+    private String              remoteUser;
+    private String              method      = "GET";
+    private Map<String, String> headers     = new HashMap<String, String>();
+    private Map<String, String> parameters  = new HashMap<String, String>();
+    private byte[]              content;
+    private HttpSession         httpSession = new SimpleHttpSession();
+    private Principal           principal;
 
     public SimpleHttpRequest() {
         super();
-        _remotePort = nextRemotePort();
+        this.remotePort = nextRemotePort();
     }
 
     public synchronized static int nextRemotePort() {
-        return ++_remotePort_s;
+        return ++remotePortS;
     }
 
     public synchronized static void resetRemotePort() {
-        _remotePort_s = 0;
+        remotePortS = 0;
     }
 
     public void addHeader(String headerName, String headerValue) {
-        _headers.put(headerName, headerValue);
+        this.headers.put(headerName, headerValue);
     }
 
     @Override
     public String getHeader(String headerName) {
-        return _headers.get(headerName);
+        return this.headers.get(headerName);
     }
 
     @Override
     public String getMethod() {
-        return _method;
+        return this.method;
     }
 
     @Override
     public int getContentLength() {
-        return _content == null ? -1 : _content.length;
+        return this.content == null ? -1 : this.content.length;
     }
 
     @Override
     public int getRemotePort() {
-        return _remotePort;
+        return this.remotePort;
     }
 
-    public void setMethod(String methodName) {
-        _method = methodName;
+    public void setMethod(String value) {
+        this.method = value;
     }
 
     public void setContentLength(int length) {
-        _content = new byte[length];
+        this.content = new byte[length];
     }
 
-    public void setRemoteUser(String username) {
-        _remoteUser = username;
+    public void setRemoteUser(String value) {
+        this.remoteUser = value;
     }
 
     @Override
     public String getRemoteUser() {
-        return _remoteUser;
+        return this.remoteUser;
     }
 
     @Override
     public HttpSession getSession() {
-        return _session;
+        return this.httpSession;
     }
 
     @Override
     public HttpSession getSession(boolean create) {
-        if (_session == null && create) {
-            _session = new SimpleHttpSession();
+        if (this.httpSession == null && create) {
+            this.httpSession = new SimpleHttpSession();
         }
-        return _session;
+        return this.httpSession;
     }
 
     @Override
     public String getQueryString() {
-        return _queryString;
+        return this.queryString;
     }
 
-    public void setQueryString(String queryString) {
-        _queryString = queryString;
-        if (_queryString != null) {
-            for (String eachParameter : _queryString.split("[&]")) {
+    public void setQueryString(String queryValue) {
+        this.queryString = queryValue;
+        if (this.queryString != null) {
+            for (String eachParameter : this.queryString.split("[&]")) {
                 String[] pair = eachParameter.split("=");
                 String value = (pair.length == 2) ? pair[1] : "";
                 addParameter(pair[0], value);
@@ -124,51 +121,51 @@ public class SimpleHttpRequest extends Request {
         }
     }
 
-    public void setRequestURI(String uri) {
-        _requestURI = uri;
+    public void setRequestURI(String value) {
+        this.requestURI = value;
     }
 
     @Override
     public String getRequestURI() {
-        return _requestURI;
+        return this.requestURI;
     }
 
     @Override
     public String getParameter(String parameterName) {
-        return _parameters.get(parameterName);
+        return this.parameters.get(parameterName);
     }
 
     public void addParameter(String parameterName, String parameterValue) {
-        _parameters.put(parameterName, parameterValue);
+        this.parameters.put(parameterName, parameterValue);
     }
 
     @Override
     public String getRemoteHost() {
-        return _remoteHost;
+        return this.remoteHost;
     }
 
     @Override
-    public void setRemoteHost(String remoteHost) {
-        _remoteHost = remoteHost;
+    public void setRemoteHost(String value) {
+        this.remoteHost = value;
     }
 
     @Override
     public String getRemoteAddr() {
-        return _remoteAddr;
+        return this.remoteAddr;
     }
 
     @Override
-    public void setRemoteAddr(String remoteAddr) {
-        _remoteAddr = remoteAddr;
+    public void setRemoteAddr(String value) {
+        this.remoteAddr = value;
     }
 
     @Override
     public Principal getUserPrincipal() {
-        return _principal;
+        return this.principal;
     }
 
     @Override
-    public void setUserPrincipal(Principal principal) {
-        _principal = principal;
+    public void setUserPrincipal(Principal value) {
+        this.principal = value;
     }
 }

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleHttpResponse.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleHttpResponse.java
@@ -28,45 +28,45 @@ import org.slf4j.LoggerFactory;
  */
 public class SimpleHttpResponse extends Response {
 
-    private static final Logger       LOGGER   = LoggerFactory.getLogger(SimpleHttpResponse.class);
+    private static final Logger       LOGGER  = LoggerFactory.getLogger(SimpleHttpResponse.class);
 
-    private int                       _status  = 500;
-    private Map<String, List<String>> _headers = new HashMap<String, List<String>>();
+    private int                       status  = 500;
+    private Map<String, List<String>> headers = new HashMap<String, List<String>>();
 
     @Override
     public int getStatus() {
-        return _status;
+        return this.status;
     }
 
     @Override
     public void addHeader(String headerName, String headerValue) {
-        List<String> current = _headers.get(headerName);
+        List<String> current = this.headers.get(headerName);
         if (current == null) {
             current = new ArrayList<String>();
         }
         current.add(headerValue);
-        _headers.put(headerName, current);
+        this.headers.put(headerName, current);
     }
 
     @Override
     public void setHeader(String headerName, String headerValue) {
-        List<String> current = _headers.get(headerName);
+        List<String> current = this.headers.get(headerName);
         if (current == null) {
             current = new ArrayList<String>();
         } else {
             current.clear();
         }
         current.add(headerValue);
-        _headers.put(headerName, current);
+        this.headers.put(headerName, current);
     }
 
     @Override
     public void setStatus(int value) {
-        _status = value;
+        this.status = value;
     }
 
     public String getStatusString() {
-        if (_status == 401) {
+        if (this.status == 401) {
             return "Unauthorized";
         }
         return "Unknown";
@@ -74,22 +74,22 @@ public class SimpleHttpResponse extends Response {
 
     @Override
     public void flushBuffer() {
-        SimpleHttpResponse.LOGGER.info("{} {}", Integer.valueOf(_status), getStatusString());
-        for (String header : _headers.keySet()) {
-            for (String headerValue : _headers.get(header)) {
+        SimpleHttpResponse.LOGGER.info("{} {}", Integer.valueOf(this.status), getStatusString());
+        for (String header : this.headers.keySet()) {
+            for (String headerValue : this.headers.get(header)) {
                 SimpleHttpResponse.LOGGER.info("{}: {}", header, headerValue);
             }
         }
     }
 
     public String[] getHeaderValues(String headerName) {
-        List<String> headerValues = _headers.get(headerName);
+        List<String> headerValues = this.headers.get(headerName);
         return headerValues == null ? null : headerValues.toArray(new String[0]);
     }
 
     @Override
     public String getHeader(String headerName) {
-        List<String> headerValues = _headers.get(headerName);
+        List<String> headerValues = this.headers.get(headerName);
         if (headerValues == null) {
             return null;
         }
@@ -105,16 +105,16 @@ public class SimpleHttpResponse extends Response {
 
     @Override
     public Collection<String> getHeaderNames() {
-        return _headers.keySet();
+        return this.headers.keySet();
     }
 
     @Override
     public void sendError(int rc, String message) {
-        _status = rc;
+        this.status = rc;
     }
 
     @Override
     public void sendError(int rc) {
-        _status = rc;
+        this.status = rc;
     }
 }

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleHttpSession.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleHttpSession.java
@@ -29,11 +29,11 @@ import javax.servlet.http.HttpSessionContext;
 @SuppressWarnings("deprecation")
 public class SimpleHttpSession implements HttpSession {
 
-    private Map<String, Object> _attributes = new HashMap<String, Object>();
+    private Map<String, Object> attributes = new HashMap<String, Object>();
 
     @Override
     public Object getAttribute(String attributeName) {
-        return _attributes.get(attributeName);
+        return this.attributes.get(attributeName);
     }
 
     @Override
@@ -83,7 +83,7 @@ public class SimpleHttpSession implements HttpSession {
 
     @Override
     public void invalidate() {
-
+        // Not Implemented
     }
 
     @Override
@@ -93,25 +93,26 @@ public class SimpleHttpSession implements HttpSession {
 
     @Override
     public void putValue(String arg0, Object arg1) {
+        // Not Implemented
     }
 
     @Override
     public void removeAttribute(String attributeName) {
-        _attributes.remove(attributeName);
+        this.attributes.remove(attributeName);
     }
 
     @Override
     public void removeValue(String arg0) {
-
+        // Not Implemented
     }
 
     @Override
     public void setAttribute(String attributeName, Object attributeValue) {
-        _attributes.put(attributeName, attributeValue);
+        this.attributes.put(attributeName, attributeValue);
     }
 
     @Override
     public void setMaxInactiveInterval(int arg0) {
-
+        // Not Implemented
     }
 }

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimplePipeline.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimplePipeline.java
@@ -19,50 +19,55 @@ import org.apache.catalina.Valve;
 
 public class SimplePipeline implements Pipeline {
 
-    private Valve[] _valves = new Valve[0];
+    private Valve[] valves = new Valve[0];
 
     @Override
     public void addValve(Valve arg0) {
-
+        // Not Implemented
     }
 
     @Override
     public Valve getBasic() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public Container getContainer() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public Valve getFirst() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public Valve[] getValves() {
-        return _valves.clone();
+        return this.valves.clone();
     }
 
     @Override
     public boolean isAsyncSupported() {
+        // Not Implemented
         return false;
     }
 
     @Override
     public void removeValve(Valve arg0) {
-
+        // Not Implemented
     }
 
     @Override
     public void setBasic(Valve arg0) {
-
+        // Not Implemented
     }
 
     @Override
     public void setContainer(Container arg0) {
-
+        // Not Implemented
     }
+
 }

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleRealm.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleRealm.java
@@ -29,11 +29,13 @@ public class SimpleRealm extends RealmBase {
 
     @Override
     protected String getPassword(String arg0) {
+        // Not Implemented
         return null;
     }
 
     @Override
     protected Principal getPrincipal(String arg0) {
+        // Not Implemented
         return null;
     }
 }

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleRequestDispatcher.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleRequestDispatcher.java
@@ -26,20 +26,22 @@ import javax.servlet.http.HttpServletResponse;
  */
 public class SimpleRequestDispatcher implements RequestDispatcher {
 
-    private String _url;
+    private String url;
 
     public SimpleRequestDispatcher(String url) {
-        _url = url;
+        this.url = url;
     }
 
     @Override
     public void forward(ServletRequest request, ServletResponse response) throws ServletException, IOException {
         HttpServletResponse httpResponse = (HttpServletResponse) response;
         httpResponse.setStatus(304);
-        httpResponse.addHeader("Location", _url);
+        httpResponse.addHeader("Location", this.url);
     }
 
     @Override
     public void include(ServletRequest request, ServletResponse response) throws ServletException, IOException {
+        // Not Implemented
     }
+
 }

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleServletContext.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/catalina/SimpleServletContext.java
@@ -40,51 +40,61 @@ public class SimpleServletContext implements ServletContext {
 
     @Override
     public Object getAttribute(String arg0) {
+        // Not Implemented
         return null;
     }
 
     @Override
     public ServletContext getContext(String arg0) {
+        // Not Implemented
         return null;
     }
 
     @Override
     public String getContextPath() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public String getInitParameter(String arg0) {
+        // Not Implemented
         return null;
     }
 
     @Override
     public Enumeration<String> getInitParameterNames() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public int getMajorVersion() {
+        // Not Implemented
         return 0;
     }
 
     @Override
     public String getMimeType(String arg0) {
+        // Not Implemented
         return null;
     }
 
     @Override
     public int getMinorVersion() {
+        // Not Implemented
         return 0;
     }
 
     @Override
     public RequestDispatcher getNamedDispatcher(String name) {
+        // Not Implemented
         return null;
     }
 
     @Override
     public String getRealPath(String arg0) {
+        // Not Implemented
         return null;
     }
 
@@ -95,207 +105,242 @@ public class SimpleServletContext implements ServletContext {
 
     @Override
     public URL getResource(String arg0) throws MalformedURLException {
+        // Not Implemented
         return null;
     }
 
     @Override
     public InputStream getResourceAsStream(String arg0) {
+        // Not Implemented
         return null;
     }
 
     @Override
     public Set<String> getResourcePaths(String arg0) {
+        // Not Implemented
         return null;
     }
 
     @Override
     public String getServerInfo() {
+        // Not Implemented
         return null;
     }
 
+    @Deprecated
     @Override
     public Servlet getServlet(String arg0) throws ServletException {
+        // Not Implemented
         return null;
     }
 
     @Override
     public String getServletContextName() {
+        // Not Implemented
         return null;
     }
 
+    @Deprecated
     @Override
     public Enumeration<String> getServletNames() {
+        // Not Implemented
         return null;
     }
 
+    @Deprecated
     @Override
     public Enumeration<Servlet> getServlets() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public void log(String arg0) {
-
+        // Not Implemented
     }
 
+    @Deprecated
     @Override
     public void log(Exception arg0, String arg1) {
-
+        // Not Implemented
     }
 
     @Override
     public void log(String arg0, Throwable arg1) {
-
+        // Not Implemented
     }
 
     @Override
     public void removeAttribute(String arg0) {
-
+        // Not Implemented
     }
 
     @Override
     public void setAttribute(String arg0, Object arg1) {
-
+        // Not Implemented
     }
 
     @Override
     public Dynamic addFilter(String arg0, String arg1) {
+        // Not Implemented
         return null;
     }
 
     @Override
     public Dynamic addFilter(String arg0, Filter arg1) {
+        // Not Implemented
         return null;
     }
 
     @Override
     public Dynamic addFilter(String arg0, Class<? extends Filter> arg1) {
+        // Not Implemented
         return null;
     }
 
     @Override
     public void addListener(Class<? extends EventListener> arg0) {
-
+        // Not Implemented
     }
 
     @Override
     public void addListener(String arg0) {
-
+        // Not Implemented
     }
 
     @Override
     public <T extends EventListener> void addListener(T arg0) {
-
+        // Not Implemented
     }
 
     @Override
     public javax.servlet.ServletRegistration.Dynamic addServlet(String arg0, String arg1) {
+        // Not Implemented
         return null;
     }
 
     @Override
     public javax.servlet.ServletRegistration.Dynamic addServlet(String arg0, Servlet arg1) {
+        // Not Implemented
         return null;
     }
 
     @Override
     public javax.servlet.ServletRegistration.Dynamic addServlet(String arg0, Class<? extends Servlet> arg1) {
+        // Not Implemented
         return null;
     }
 
     @Override
     public <T extends Filter> T createFilter(Class<T> arg0) throws ServletException {
+        // Not Implemented
         return null;
     }
 
     @Override
     public <T extends EventListener> T createListener(Class<T> arg0) throws ServletException {
+        // Not Implemented
         return null;
     }
 
     @Override
     public <T extends Servlet> T createServlet(Class<T> arg0) throws ServletException {
+        // Not Implemented
         return null;
     }
 
     @Override
     public void declareRoles(String... arg0) {
-
+        // Not Implemented
     }
 
     @Override
     public ClassLoader getClassLoader() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public Set<SessionTrackingMode> getDefaultSessionTrackingModes() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public int getEffectiveMajorVersion() {
+        // Not Implemented
         return 0;
     }
 
     @Override
     public int getEffectiveMinorVersion() {
+        // Not Implemented
         return 0;
     }
 
     @Override
     public Set<SessionTrackingMode> getEffectiveSessionTrackingModes() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public FilterRegistration getFilterRegistration(String arg0) {
+        // Not Implemented
         return null;
     }
 
     @Override
     public Map<String, ? extends FilterRegistration> getFilterRegistrations() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public JspConfigDescriptor getJspConfigDescriptor() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public ServletRegistration getServletRegistration(String arg0) {
+        // Not Implemented
         return null;
     }
 
     @Override
     public Map<String, ? extends ServletRegistration> getServletRegistrations() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public SessionCookieConfig getSessionCookieConfig() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public boolean setInitParameter(String arg0, String arg1) {
+        // Not Implemented
         return false;
     }
 
     @Override
     public void setSessionTrackingModes(Set<SessionTrackingMode> arg0) throws IllegalStateException,
             IllegalArgumentException {
-
+        // Not Implemented
     }
 
     @Override
     public Enumeration<String> getAttributeNames() {
+        // Not Implemented
         return null;
     }
 
     @Override
     public String getVirtualServerName() {
+        // Not Implemented
         return null;
     }
 }


### PR DESCRIPTION
- use explicit reference such as this or static references
- use proper java variable instance naming (ie not underscores preceding
  name)
- use proper java case on static final variables such as LOGGER
- removed unnecessary definitions of remoteHost, remoteAddr, and
  remotePort shadowed from tomcat super classes under test cases.  Renamed
  session to httpSession as that shadow was separate and needed to be
  defined separately.
- updated tomcat 7 to 7.0.55
- started adding comments in tomcat 8 and will follow in others
  regarding pieces of tomcat not actually implemented within test cases in
  an effort to make it more obvious to what is being used.  Ultimately
  will like pull unimplemented items out into separate class making the
  waffle implemented portion completely obvious.
