### PR TITLE
[release] pom changes for 1.8-SNAPSHOT

### DIFF
--- a/Source/JNA/waffle-demo/waffle-demo-parent/pom.xml
+++ b/Source/JNA/waffle-demo/waffle-demo-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.dblock.waffle</groupId>
         <artifactId>waffle-parent</artifactId>
-        <version>1.7</version>
+        <version>1.8-SNAPSHOT</version>
         <relativePath>../../waffle-parent</relativePath>
     </parent>
     <groupId>com.github.dblock.waffle.demo</groupId>
@@ -12,7 +12,9 @@
     <version>1.8-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>waffle-demo-parent</name>
-    <!-- Due to maven release plugin temporarily comment modules
+    <description>Parent POM for Waffle Demo</description>
+    <url>http://dblock.github.com/waffle/</url>
+    <!-- Due to maven release plugin temporarily comment modules when releasing -->
     <modules>
         <module>../waffle-filter</module>
         <module>../waffle-form</module>
@@ -23,7 +25,6 @@
         <module>../waffle-spring-filter</module>
         <module>../waffle-spring-form</module>
     </modules>
-    -->
     <properties>
         <format.relative.loc>../..</format.relative.loc>
         <git.relative.loc>../../../..</git.relative.loc>
@@ -39,7 +40,7 @@
             <dependency>
                 <groupId>com.github.dblock.waffle</groupId>
                 <artifactId>waffle-jna</artifactId>
-                <version>1.7</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.github.dblock.waffle</groupId>

--- a/Source/JNA/waffle-demo/waffle-filter/pom.xml
+++ b/Source/JNA/waffle-demo/waffle-filter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.dblock.waffle.demo</groupId>
         <artifactId>waffle-demo-parent</artifactId>
-        <version>1.7</version>
+        <version>1.8-SNAPSHOT</version>
         <relativePath>../waffle-demo-parent</relativePath>
     </parent>
     <artifactId>waffle-filter</artifactId>
@@ -12,6 +12,10 @@
     <packaging>war</packaging>
     <name>waffle-filter</name>
     <description>Filter Demo for WAFFLE</description>
+    <url>http://dblock.github.com/waffle/</url>
+    <properties>
+        <servlet.version>2.5</servlet.version>
+    </properties>
     <scm>
         <connection>scm:git:ssh://git@github.com/dblock/waffle.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/dblock/waffle.git</developerConnection>
@@ -27,7 +31,7 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>
-            <version>2.5</version>
+            <version>${servlet.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/Source/JNA/waffle-demo/waffle-form/pom.xml
+++ b/Source/JNA/waffle-demo/waffle-form/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.dblock.waffle.demo</groupId>
         <artifactId>waffle-demo-parent</artifactId>
-        <version>1.7</version>
+        <version>1.8-SNAPSHOT</version>
         <relativePath>../waffle-demo-parent</relativePath>
     </parent>
     <artifactId>waffle-form</artifactId>
@@ -12,6 +12,7 @@
     <packaging>war</packaging>
     <name>waffle-form</name>
     <description>Form Demo for WAFFLE</description>
+    <url>http://dblock.github.com/waffle/</url>
     <properties>
         <servlet.version>2.5</servlet.version>
     </properties>

--- a/Source/JNA/waffle-demo/waffle-jaas/pom.xml
+++ b/Source/JNA/waffle-demo/waffle-jaas/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.dblock.waffle.demo</groupId>
         <artifactId>waffle-demo-parent</artifactId>
-        <version>1.7</version>
+        <version>1.8-SNAPSHOT</version>
         <relativePath>../waffle-demo-parent</relativePath>
     </parent>
     <artifactId>waffle-jaas</artifactId>
@@ -12,6 +12,7 @@
     <packaging>war</packaging>
     <name>waffle-jaas</name>
     <description>Jaas Demo for WAFFLE</description>
+    <url>http://dblock.github.com/waffle/</url>
     <properties>
         <servlet.version>2.5</servlet.version>
     </properties>

--- a/Source/JNA/waffle-demo/waffle-mixed-post/pom.xml
+++ b/Source/JNA/waffle-demo/waffle-mixed-post/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.dblock.waffle.demo</groupId>
         <artifactId>waffle-demo-parent</artifactId>
-        <version>1.7</version>
+        <version>1.8-SNAPSHOT</version>
         <relativePath>../waffle-demo-parent</relativePath>
     </parent>
     <artifactId>waffle-mixed-post</artifactId>
@@ -12,6 +12,7 @@
     <packaging>war</packaging>
     <name>waffle-mixed-post</name>
     <description>Mixed Post Demo for WAFFLE</description>
+    <url>http://dblock.github.com/waffle/</url>
     <properties>
         <servlet.version>2.5</servlet.version>
     </properties>

--- a/Source/JNA/waffle-demo/waffle-mixed/pom.xml
+++ b/Source/JNA/waffle-demo/waffle-mixed/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.dblock.waffle.demo</groupId>
         <artifactId>waffle-demo-parent</artifactId>
-        <version>1.7</version>
+        <version>1.8-SNAPSHOT</version>
         <relativePath>../waffle-demo-parent</relativePath>
     </parent>
     <artifactId>waffle-mixed</artifactId>
@@ -12,6 +12,7 @@
     <packaging>war</packaging>
     <name>waffle-mixed</name>
     <description>Mixed Demo for WAFFLE</description>
+    <url>http://dblock.github.com/waffle/</url>
     <properties>
         <servlet.version>2.5</servlet.version>
     </properties>

--- a/Source/JNA/waffle-demo/waffle-negotiate/pom.xml
+++ b/Source/JNA/waffle-demo/waffle-negotiate/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.dblock.waffle.demo</groupId>
         <artifactId>waffle-demo-parent</artifactId>
-        <version>1.7</version>
+        <version>1.8-SNAPSHOT</version>
         <relativePath>../waffle-demo-parent</relativePath>
     </parent>
     <artifactId>waffle-negotiate</artifactId>
@@ -12,6 +12,7 @@
     <packaging>war</packaging>
     <name>waffle-negotiate</name>
     <description>Negotiate Demo for WAFFLE</description>
+    <url>http://dblock.github.com/waffle/</url>
     <properties>
         <servlet.version>2.5</servlet.version>
     </properties>

--- a/Source/JNA/waffle-demo/waffle-spring-filter/pom.xml
+++ b/Source/JNA/waffle-demo/waffle-spring-filter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.dblock.waffle.demo</groupId>
         <artifactId>waffle-demo-parent</artifactId>
-        <version>1.7</version>
+        <version>1.8-SNAPSHOT</version>
         <relativePath>../waffle-demo-parent</relativePath>
     </parent>
     <artifactId>waffle-spring-filter</artifactId>
@@ -12,6 +12,7 @@
     <packaging>war</packaging>
     <name>waffle-spring-filter</name>
     <description>Spring Filter Demo for WAFFLE</description>
+    <url>http://dblock.github.com/waffle/</url>
     <properties>
         <servlet.version>2.5</servlet.version>
     </properties>
@@ -31,7 +32,7 @@
         <dependency>
             <groupId>com.github.dblock.waffle</groupId>
             <artifactId>waffle-spring-security3</artifactId>
-            <version>1.7</version>
+            <version>1.8-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/Source/JNA/waffle-demo/waffle-spring-form/pom.xml
+++ b/Source/JNA/waffle-demo/waffle-spring-form/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.dblock.waffle.demo</groupId>
         <artifactId>waffle-demo-parent</artifactId>
-        <version>1.7</version>
+        <version>1.8-SNAPSHOT</version>
         <relativePath>../waffle-demo-parent</relativePath>
     </parent>
     <artifactId>waffle-spring-form</artifactId>
@@ -12,6 +12,7 @@
     <packaging>war</packaging>
     <name>waffle-spring-form</name>
     <description>Spring Form Demo for WAFFLE</description>
+    <url>http://dblock.github.com/waffle/</url>
     <properties>
         <servlet.version>2.5</servlet.version>
     </properties>
@@ -31,7 +32,7 @@
         <dependency>
             <groupId>com.github.dblock.waffle</groupId>
             <artifactId>waffle-spring-security3</artifactId>
-            <version>1.7</version>
+            <version>1.8-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/Source/JNA/waffle-distro/pom.xml
+++ b/Source/JNA/waffle-distro/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.dblock.waffle</groupId>
         <artifactId>waffle-parent</artifactId>
-        <version>1.7</version>
+        <version>1.8-SNAPSHOT</version>
         <relativePath>../waffle-parent</relativePath>
     </parent>
     <artifactId>waffle-distro</artifactId>
@@ -12,6 +12,10 @@
     <packaging>pom</packaging>
     <name>waffle-distro</name>
     <description>Distribution for WAFFLE</description>
+    <url>http://dblock.github.com/waffle/</url>
+    <properties>
+        <logback.version>1.1.2</logback.version>
+    </properties>
     <scm>
         <connection>scm:git:ssh://git@github.com/dblock/waffle.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/dblock/waffle.git</developerConnection>
@@ -22,135 +26,135 @@
         <dependency>
             <groupId>com.github.dblock.waffle</groupId>
             <artifactId>waffle-jetty</artifactId>
-            <version>1.7</version>
+            <version>1.8-SNAPSHOT</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>com.github.dblock.waffle</groupId>
             <artifactId>waffle-jna</artifactId>
-            <version>1.7</version>
+            <version>1.8-SNAPSHOT</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>com.github.dblock.waffle</groupId>
             <artifactId>waffle-shiro</artifactId>
-            <version>1.7</version>
+            <version>1.8-SNAPSHOT</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>com.github.dblock.waffle</groupId>
             <artifactId>waffle-spring-security2</artifactId>
-            <version>1.7</version>
+            <version>1.8-SNAPSHOT</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>com.github.dblock.waffle</groupId>
             <artifactId>waffle-spring-security3</artifactId>
-            <version>1.7</version>
+            <version>1.8-SNAPSHOT</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>com.github.dblock.waffle</groupId>
             <artifactId>waffle-spring-security4</artifactId>
-            <version>1.7</version>
+            <version>1.8-SNAPSHOT</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>com.github.dblock.waffle</groupId>
             <artifactId>waffle-tests</artifactId>
-            <version>1.7</version>
+            <version>1.8-SNAPSHOT</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>com.github.dblock.waffle</groupId>
             <artifactId>waffle-tomcat5</artifactId>
-            <version>1.7</version>
+            <version>1.8-SNAPSHOT</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>com.github.dblock.waffle</groupId>
             <artifactId>waffle-tomcat6</artifactId>
-            <version>1.7</version>
+            <version>1.8-SNAPSHOT</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>com.github.dblock.waffle</groupId>
             <artifactId>waffle-tomcat7</artifactId>
-            <version>1.7</version>
+            <version>1.8-SNAPSHOT</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>com.github.dblock.waffle</groupId>
             <artifactId>waffle-tomcat8</artifactId>
-            <version>1.7</version>
+            <version>1.8-SNAPSHOT</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>com.github.dblock.waffle.demo</groupId>
             <artifactId>waffle-filter</artifactId>
-            <version>1.7</version>
+            <version>1.8-SNAPSHOT</version>
             <scope>runtime</scope>
             <type>war</type>
         </dependency>
         <dependency>
             <groupId>com.github.dblock.waffle.demo</groupId>
             <artifactId>waffle-form</artifactId>
-            <version>1.7</version>
+            <version>1.8-SNAPSHOT</version>
             <scope>runtime</scope>
             <type>war</type>
         </dependency>
         <dependency>
             <groupId>com.github.dblock.waffle.demo</groupId>
             <artifactId>waffle-jaas</artifactId>
-            <version>1.7</version>
+            <version>1.8-SNAPSHOT</version>
             <scope>runtime</scope>
             <type>war</type>
         </dependency>
         <dependency>
             <groupId>com.github.dblock.waffle.demo</groupId>
             <artifactId>waffle-mixed</artifactId>
-            <version>1.7</version>
+            <version>1.8-SNAPSHOT</version>
             <scope>runtime</scope>
             <type>war</type>
         </dependency>
         <dependency>
             <groupId>com.github.dblock.waffle.demo</groupId>
             <artifactId>waffle-mixed-post</artifactId>
-            <version>1.7</version>
+            <version>1.8-SNAPSHOT</version>
             <scope>runtime</scope>
             <type>war</type>
         </dependency>
         <dependency>
             <groupId>com.github.dblock.waffle.demo</groupId>
             <artifactId>waffle-negotiate</artifactId>
-            <version>1.7</version>
+            <version>1.8-SNAPSHOT</version>
             <scope>runtime</scope>
             <type>war</type>
         </dependency>
         <dependency>
             <groupId>com.github.dblock.waffle.demo</groupId>
             <artifactId>waffle-spring-filter</artifactId>
-            <version>1.7</version>
+            <version>1.8-SNAPSHOT</version>
             <scope>runtime</scope>
             <type>war</type>
         </dependency>
         <dependency>
             <groupId>com.github.dblock.waffle.demo</groupId>
             <artifactId>waffle-spring-form</artifactId>
-            <version>1.7</version>
+            <version>1.8-SNAPSHOT</version>
             <scope>runtime</scope>
             <type>war</type>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.1.2</version>
+            <version>${logback.version}</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.1.2</version>
+            <version>${logback.version}</version>
             <scope>runtime</scope>
         </dependency>
     </dependencies>

--- a/Source/JNA/waffle-jetty/pom.xml
+++ b/Source/JNA/waffle-jetty/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.dblock.waffle</groupId>
         <artifactId>waffle-parent</artifactId>
-        <version>1.7</version>
+        <version>1.8-SNAPSHOT</version>
         <relativePath>../waffle-parent</relativePath>
     </parent>
     <artifactId>waffle-jetty</artifactId>
@@ -12,11 +12,21 @@
     <packaging>jar</packaging>
     <name>waffle-jetty</name>
     <description>Jetty integration for WAFFLE</description>
+    <url>http://dblock.github.com/waffle/</url>
     <properties>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
+
+        <!-- Skipping because there is no source to prevent it failing -->
         <maven.javadoc.skip>true</maven.javadoc.skip>
+
+        <el.version>3.0.1-b05</el.version>
+        <el-api.version>3.0.1-b04</el-api.version>
         <jetty.version>9.2.3.v20140905</jetty.version>
+        <jdt.version>4.4</jdt.version>
+        <jsp.version>2.3.3-b02</jsp.version>
+        <jsp-api.version>2.3.2-b01</jsp-api.version>
+        <jstl.version>1.2.3</jstl.version>
         <slf4j.version>1.7.7</slf4j.version>
     </properties>
     <scm>
@@ -24,12 +34,12 @@
         <developerConnection>scm:git:ssh://git@github.com/dblock/waffle.git</developerConnection>
         <url>https://github.com/dblock/waffle</url>
         <tag>HEAD</tag>
-  </scm>
+    </scm>
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>waffle-jna</artifactId>
-            <version>1.7</version>
+            <version>1.8-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -39,39 +49,39 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.jetty.orbit</groupId>
-            <artifactId>org.eclipse.jdt.core</artifactId>
-            <version>3.8.2.v20130121</version>
+            <groupId>org.eclipse.jdt.core.compiler</groupId>
+            <artifactId>ecj</artifactId>
+            <version>${jdt.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>javax.el</groupId>
             <artifactId>javax.el-api</artifactId>
-            <version>3.0.1-b04</version>
+            <version>${el-api.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>javax.servlet.jsp</groupId>
             <artifactId>javax.servlet.jsp-api</artifactId>
-            <version>2.3.2-b01</version>
+            <version>${jsp-api.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>javax.el</artifactId>
-            <version>3.0.1-b05</version>
+            <version>${el.version}</version>
             <scope>provided</scope>
         </dependency>
          <dependency>
             <groupId>org.glassfish.web</groupId>
             <artifactId>javax.servlet.jsp</artifactId>
-            <version>2.3.3-b02</version>
+            <version>${jsp.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish.web</groupId>
             <artifactId>javax.servlet.jsp.jstl</artifactId>
-            <version>1.2.3</version>
+            <version>${jstl.version}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/Source/JNA/waffle-jna/pom.xml
+++ b/Source/JNA/waffle-jna/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.dblock.waffle</groupId>
         <artifactId>waffle-parent</artifactId>
-        <version>1.7</version>
+        <version>1.8-SNAPSHOT</version>
         <relativePath>../waffle-parent</relativePath>
     </parent>
     <artifactId>waffle-jna</artifactId>
@@ -12,6 +12,7 @@
     <packaging>jar</packaging>
     <name>waffle-jna</name>
     <description>WAFFLE JNA implementation</description>
+    <url>http://dblock.github.com/waffle/</url>
     <properties>
         <guava.version>18.0</guava.version>
         <jna.version>4.1.0</jna.version>
@@ -23,7 +24,7 @@
         <developerConnection>scm:git:ssh://git@github.com/dblock/waffle.git</developerConnection>
         <url>https://github.com/dblock/waffle</url>
         <tag>HEAD</tag>
-  </scm>
+    </scm>
     <dependencies>
         <dependency>
             <groupId>net.java.dev.jna</groupId>

--- a/Source/JNA/waffle-parent/pom.xml
+++ b/Source/JNA/waffle-parent/pom.xml
@@ -61,9 +61,9 @@
         </contributor>
     </contributors>
     <prerequisites>
-        <maven>3.0.5</maven>
+        <maven>3.2.1</maven>
     </prerequisites>
-    <!-- Due to maven release plugin temporarily comment modules
+    <!-- Due to maven release plugin temporarily comment modules when releasing -->
     <modules>
         <module>../waffle-demo/waffle-demo-parent</module>
         <module>../waffle-distro</module>
@@ -79,7 +79,6 @@
         <module>../waffle-tomcat7</module>
         <module>../waffle-tomcat8</module>
     </modules>
-    -->
     <scm>
         <connection>scm:git:ssh://git@github.com/dblock/waffle.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/dblock/waffle.git</developerConnection>
@@ -100,7 +99,7 @@
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss</maven.build.timestamp.format>
         <maven.compiler.source>1.6</maven.compiler.source>
         <maven.compiler.target>1.6</maven.compiler.target>
-        <maven.min-version>3.0.5</maven.min-version>
+        <maven.min-version>3.2.1</maven.min-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -214,6 +213,7 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
                     <version>3.4</version>
+                    <!-- For reporting only of versions -->
                     <dependencies>
                         <dependency>
                             <groupId>org.apache.maven.skins</groupId>
@@ -444,12 +444,12 @@
                         <dependency>
                             <groupId>org.eclipse.jgit</groupId>
                             <artifactId>org.eclipse.jgit</artifactId>
-                            <version>3.4.1.201406201815-r</version>
+                            <version>3.5.0.201409260305-r</version>
                         </dependency>
                         <dependency>
                             <groupId>org.codehaus.plexus</groupId>
                             <artifactId>plexus-utils</artifactId>
-                            <version>3.0.17</version>
+                            <version>3.0.18</version>
                         </dependency>
                     </dependencies>
                 </plugin>

--- a/Source/JNA/waffle-shiro/pom.xml
+++ b/Source/JNA/waffle-shiro/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.dblock.waffle</groupId>
         <artifactId>waffle-parent</artifactId>
-        <version>1.7</version>
+        <version>1.8-SNAPSHOT</version>
         <relativePath>../waffle-parent</relativePath>
     </parent>
     <artifactId>waffle-shiro</artifactId>
@@ -12,6 +12,7 @@
     <packaging>jar</packaging>
     <name>waffle-shiro</name>
     <description>Shiro integration for WAFFLE</description>
+    <url>http://dblock.github.com/waffle/</url>
     <properties>
         <servlet.version>2.5</servlet.version>
         <shiro.version>1.2.3</shiro.version>
@@ -21,18 +22,18 @@
         <developerConnection>scm:git:ssh://git@github.com/dblock/waffle.git</developerConnection>
         <url>https://github.com/dblock/waffle</url>
         <tag>HEAD</tag>
-  </scm>
+    </scm>
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>waffle-jna</artifactId>
-            <version>1.7</version>
+            <version>1.8-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>waffle-tests</artifactId>
-            <version>1.7</version>
+            <version>1.8-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/Source/JNA/waffle-spring-security2/pom.xml
+++ b/Source/JNA/waffle-spring-security2/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.dblock.waffle</groupId>
         <artifactId>waffle-parent</artifactId>
-        <version>1.7</version>
+        <version>1.8-SNAPSHOT</version>
         <relativePath>../waffle-parent</relativePath>
     </parent>
     <artifactId>waffle-spring-security2</artifactId>
@@ -12,6 +12,7 @@
     <packaging>jar</packaging>
     <name>waffle-spring-security2</name>
     <description>Spring Security 2 integration for WAFFLE</description>
+    <url>http://dblock.github.com/waffle/</url>
     <properties>
         <servlet.version>2.5</servlet.version>
         <spring.version>2.5.6.SEC03</spring.version>
@@ -22,18 +23,18 @@
         <developerConnection>scm:git:ssh://git@github.com/dblock/waffle.git</developerConnection>
         <url>https://github.com/dblock/waffle</url>
         <tag>HEAD</tag>
-  </scm>
+    </scm>
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>waffle-jna</artifactId>
-            <version>1.7</version>
+            <version>1.8-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>waffle-tests</artifactId>
-            <version>1.7</version>
+            <version>1.8-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/Source/JNA/waffle-spring-security3/pom.xml
+++ b/Source/JNA/waffle-spring-security3/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.dblock.waffle</groupId>
         <artifactId>waffle-parent</artifactId>
-        <version>1.7</version>
+        <version>1.8-SNAPSHOT</version>
         <relativePath>../waffle-parent</relativePath>
     </parent>
     <artifactId>waffle-spring-security3</artifactId>
@@ -12,7 +12,9 @@
     <packaging>jar</packaging>
     <name>waffle-spring-security3</name>
     <description>Spring Security 3 integration for WAFFLE</description>
+    <url>http://dblock.github.com/waffle/</url>
     <properties>
+        <servlet.version>3.0.1</servlet.version>
         <spring.version>3.2.11.RELEASE</spring.version>
         <spring.security.version>3.2.5.RELEASE</spring.security.version>
     </properties>
@@ -21,24 +23,24 @@
         <developerConnection>scm:git:ssh://git@github.com/dblock/waffle.git</developerConnection>
         <url>https://github.com/dblock/waffle</url>
         <tag>HEAD</tag>
-  </scm>
+    </scm>
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>waffle-jna</artifactId>
-            <version>1.7</version>
+            <version>1.8-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>waffle-tests</artifactId>
-            <version>1.7</version>
+            <version>1.8-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <version>3.0.1</version>
+            <version>${servlet.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/Source/JNA/waffle-spring-security4/pom.xml
+++ b/Source/JNA/waffle-spring-security4/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.dblock.waffle</groupId>
         <artifactId>waffle-parent</artifactId>
-        <version>1.7</version>
+        <version>1.8-SNAPSHOT</version>
         <relativePath>../waffle-parent</relativePath>
     </parent>
     <artifactId>waffle-spring-security4</artifactId>
@@ -12,12 +12,14 @@
     <packaging>jar</packaging>
     <name>waffle-spring-security4</name>
     <description>Spring Security 4 integration for WAFFLE</description>
+    <url>http://dblock.github.com/waffle/</url>
     <properties>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
 
         <thirdparty.dir>${project.basedir}/../../ThirdParty</thirdparty.dir>
 
+        <servlet.version>3.1.0</servlet.version>
         <spring.version>4.1.0.RELEASE</spring.version>
         <spring.security.version>4.0.0.M2</spring.security.version>
     </properties>
@@ -26,24 +28,24 @@
         <developerConnection>scm:git:ssh://git@github.com/dblock/waffle.git</developerConnection>
         <url>https://github.com/dblock/waffle</url>
         <tag>HEAD</tag>
-  </scm>
+    </scm>
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>waffle-jna</artifactId>
-            <version>1.7</version>
+            <version>1.8-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>waffle-tests</artifactId>
-            <version>1.7</version>
+            <version>1.8-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
+            <version>${servlet.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/Source/JNA/waffle-tests/pom.xml
+++ b/Source/JNA/waffle-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.dblock.waffle</groupId>
         <artifactId>waffle-parent</artifactId>
-        <version>1.7</version>
+        <version>1.8-SNAPSHOT</version>
         <relativePath>../waffle-parent</relativePath>
     </parent>
     <artifactId>waffle-tests</artifactId>
@@ -12,6 +12,7 @@
     <packaging>jar</packaging>
     <name>waffle-tests</name>
     <description>Tests for WAFFLE</description>
+    <url>http://dblock.github.com/waffle/</url>
     <properties>
         <servlet.version>2.5</servlet.version>
         <mockito.version>1.9.5</mockito.version>
@@ -21,12 +22,12 @@
         <developerConnection>scm:git:ssh://git@github.com/dblock/waffle.git</developerConnection>
         <url>https://github.com/dblock/waffle</url>
         <tag>HEAD</tag>
-  </scm>
+    </scm>
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>waffle-jna</artifactId>
-            <version>1.7</version>
+            <version>1.8-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/Source/JNA/waffle-tomcat5/pom.xml
+++ b/Source/JNA/waffle-tomcat5/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.dblock.waffle</groupId>
         <artifactId>waffle-parent</artifactId>
-        <version>1.7</version>
+        <version>1.8-SNAPSHOT</version>
         <relativePath>../waffle-parent</relativePath>
     </parent>
     <artifactId>waffle-tomcat5</artifactId>
@@ -12,6 +12,7 @@
     <packaging>jar</packaging>
     <name>waffle-tomcat5</name>
     <description>Tomcat 5 integration for WAFFLE</description>
+    <url>http://dblock.github.com/waffle/</url>
     <properties>
         <thirdparty.dir>${project.basedir}/../../ThirdParty</thirdparty.dir>
         <slf4j.version>1.7.7</slf4j.version>
@@ -22,18 +23,18 @@
         <developerConnection>scm:git:ssh://git@github.com/dblock/waffle.git</developerConnection>
         <url>https://github.com/dblock/waffle</url>
         <tag>HEAD</tag>
-  </scm>
+    </scm>
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>waffle-jna</artifactId>
-            <version>1.7</version>
+            <version>1.8-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>waffle-tests</artifactId>
-            <version>1.7</version>
+            <version>1.8-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/Source/JNA/waffle-tomcat6/pom.xml
+++ b/Source/JNA/waffle-tomcat6/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.dblock.waffle</groupId>
         <artifactId>waffle-parent</artifactId>
-        <version>1.7</version>
+        <version>1.8-SNAPSHOT</version>
         <relativePath>../waffle-parent</relativePath>
     </parent>
     <artifactId>waffle-tomcat6</artifactId>
@@ -12,6 +12,7 @@
     <packaging>jar</packaging>
     <name>waffle-tomcat6</name>
     <description>Tomcat 6 integration for WAFFLE</description>
+    <url>http://dblock.github.com/waffle/</url>
     <properties>
         <tomcat.version>6.0.41</tomcat.version>
     </properties>
@@ -20,18 +21,18 @@
         <developerConnection>scm:git:ssh://git@github.com/dblock/waffle.git</developerConnection>
         <url>https://github.com/dblock/waffle</url>
         <tag>HEAD</tag>
-  </scm>
+    </scm>
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>waffle-jna</artifactId>
-            <version>1.7</version>
+            <version>1.8-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>waffle-tests</artifactId>
-            <version>1.7</version>
+            <version>1.8-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/Source/JNA/waffle-tomcat7/pom.xml
+++ b/Source/JNA/waffle-tomcat7/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.dblock.waffle</groupId>
         <artifactId>waffle-parent</artifactId>
-        <version>1.7</version>
+        <version>1.8-SNAPSHOT</version>
         <relativePath>../waffle-parent</relativePath>
     </parent>
     <artifactId>waffle-tomcat7</artifactId>
@@ -12,6 +12,7 @@
     <packaging>jar</packaging>
     <name>waffle-tomcat7</name>
     <description>Tomcat 7 integration for WAFFLE</description>
+    <url>http://dblock.github.com/waffle/</url>
     <properties>
         <tomcat.version>7.0.55</tomcat.version>
     </properties>
@@ -20,18 +21,18 @@
         <developerConnection>scm:git:ssh://git@github.com/dblock/waffle.git</developerConnection>
         <url>https://github.com/dblock/waffle</url>
         <tag>HEAD</tag>
-  </scm>
+    </scm>
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>waffle-jna</artifactId>
-            <version>1.7</version>
+            <version>1.8-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>waffle-tests</artifactId>
-            <version>1.7</version>
+            <version>1.8-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/Source/JNA/waffle-tomcat8/pom.xml
+++ b/Source/JNA/waffle-tomcat8/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.dblock.waffle</groupId>
         <artifactId>waffle-parent</artifactId>
-        <version>1.7</version>
+        <version>1.8-SNAPSHOT</version>
         <relativePath>../waffle-parent</relativePath>
     </parent>
     <artifactId>waffle-tomcat8</artifactId>
@@ -12,6 +12,7 @@
     <packaging>jar</packaging>
     <name>waffle-tomcat8</name>
     <description>Tomcat 8 integration for WAFFLE</description>
+    <url>http://dblock.github.com/waffle/</url>
     <properties>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
@@ -22,18 +23,18 @@
         <developerConnection>scm:git:ssh://git@github.com/dblock/waffle.git</developerConnection>
         <url>https://github.com/dblock/waffle</url>
         <tag>HEAD</tag>
-  </scm>
+    </scm>
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>waffle-jna</artifactId>
-            <version>1.7</version>
+            <version>1.8-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>waffle-tests</artifactId>
-            <version>1.7</version>
+            <version>1.8-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
- Enforce maven 3.2.1 at least.  No reason to say on the old when the
  old isn't used.  Version 3.2.1 is being shipped with eclipse 4.4
  versions.  It isn't quite the latest but allowed good fallback.  Maven
  is discussing getting here soon as a base.
- Removed temporary comments for multi module build
- Ensure 1.8-SNAPSHOT marked everywhere.  No point is trying to be smart
  here as maven release will just change values later so noting version
  directly.
- Add url on all projects as there is only one site and not noting it
  causes it to list incorrect site by project level.
- Make properties out of more versions
- switch jetty to use latest ecj
- updated jgit and plexus utils
