### PR TITLE
Javadoc Issue Resolved - Jetty Dummy Class

### DIFF
--- a/Source/JNA/waffle-jetty/pom.xml
+++ b/Source/JNA/waffle-jetty/pom.xml
@@ -17,9 +17,6 @@
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
 
-        <!-- Skipping because there is no source to prevent it failing -->
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-
         <src.relative.loc>..</src.relative.loc>
         <git.relative.loc>../../..</git.relative.loc>
 

--- a/Source/JNA/waffle-jetty/src/main/java/waffle/jetty/DummyClass.java
+++ b/Source/JNA/waffle-jetty/src/main/java/waffle/jetty/DummyClass.java
@@ -1,0 +1,20 @@
+/**
+ * Waffle (https://github.com/dblock/waffle)
+ *
+ * Copyright (c) 2010 - 2014 Application Security, Inc.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Application Security, Inc.
+ */
+package waffle.jetty;
+
+public class DummyClass {
+
+    // Dummy class to prevent javadoc build issues.  Eventually there will be jetty code.  This ensures no empty javadoc.
+
+}


### PR DESCRIPTION
Removed skip javadoc in jetty pom.  It was breaking others.  Javadocs no
longer create empty javadocs thus the reason that was there.  That in
turn caused multi module build to break at various points due to
threading.  In order to resolve this and not get empty javadoc, added
dummy class which allows us to get everything else we want.
