### PR TITLE
Added continueContextsTimeout property to WaffleAuthenticatorBase for tomcat 6,7,8.

### DIFF
--- a/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/MixedAuthenticator.java
+++ b/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/MixedAuthenticator.java
@@ -22,6 +22,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
+import org.apache.catalina.LifecycleException;
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.connector.Response;
 import org.apache.catalina.deploy.LoginConfig;
@@ -55,16 +56,18 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
      * @see org.apache.catalina.authenticator.AuthenticatorBase#start()
      */
     @Override
-    public void start() {
+    public void start() throws LifecycleException {
         this.log.info("[waffle.apache.MixedAuthenticator] started");
+        super.start();
     }
 
     /* (non-Javadoc)
      * @see org.apache.catalina.authenticator.AuthenticatorBase#stop()
      */
     @Override
-    public void stop() {
+    public void stop() throws LifecycleException {
         this.log.info("[waffle.apache.MixedAuthenticator] stopped");
+        super.stop();
     }
 
     /* (non-Javadoc)

--- a/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/NegotiateAuthenticator.java
+++ b/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/NegotiateAuthenticator.java
@@ -19,6 +19,7 @@ import java.security.Principal;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
+import org.apache.catalina.LifecycleException;
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.connector.Response;
 import org.apache.catalina.deploy.LoginConfig;
@@ -52,16 +53,18 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
      * @see org.apache.catalina.authenticator.AuthenticatorBase#start()
      */
     @Override
-    public void start() {
-        this.log.info("[waffle.apache.NegotiateAuthenticator] started");
+    public void start() throws LifecycleException {
+        this.log.info("[waffle.apache.MixedAuthenticator] started");
+        super.start();
     }
 
     /* (non-Javadoc)
      * @see org.apache.catalina.authenticator.AuthenticatorBase#stop()
      */
     @Override
-    public void stop() {
-        this.log.info("[waffle.apache.NegotiateAuthenticator] stopped");
+    public void stop() throws LifecycleException {
+        this.log.info("[waffle.apache.MixedAuthenticator] stopped");
+        super.stop();
     }
 
     /* (non-Javadoc)

--- a/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
+++ b/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
@@ -65,6 +65,22 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
     protected IWindowsAuthProvider   auth                = null;
 
     /**
+     * Gets the continue context time out configuration
+     * @return
+     */
+    public int getContinueContextsTimeout() {
+        return continueContextsTimeout;
+    }
+
+    /**
+     * Sets the continue context time out configuration
+     * @param continueContextsTimeout
+     */
+    public void setContinueContextsTimeout(int continueContextsTimeout) {
+        this.continueContextsTimeout = continueContextsTimeout;
+    }
+
+    /**
      * Windows authentication provider.
      * 
      * @return IWindowsAuthProvider.

--- a/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
+++ b/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
@@ -20,6 +20,7 @@ import java.util.Set;
 
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.catalina.LifecycleException;
 import org.apache.catalina.authenticator.AuthenticatorBase;
 import org.apache.catalina.connector.Response;
 import org.slf4j.Logger;
@@ -57,8 +58,11 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
     /** The protocols. */
     protected Set<String>            protocols           = SUPPORTED_PROTOCOLS;
 
+    /** The auth continueContextTimeout configuration */
+    protected int                    continueContextsTimeout = 30;
+
     /** The auth. */
-    protected IWindowsAuthProvider   auth                = new WindowsAuthProviderImpl();
+    protected IWindowsAuthProvider   auth                = null;
 
     /**
      * Windows authentication provider.
@@ -205,5 +209,16 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
             this.log.trace("{}", e);
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * Hook to the start and to set up the dependencies.
+     * @throws LifecycleException
+     */
+    @Override
+    public void start() throws LifecycleException {
+        this.log.debug("Creating a windows authentication provider with continueContextTimeout property set to: {}", this.continueContextsTimeout);
+        this.auth = new WindowsAuthProviderImpl(this.continueContextsTimeout);
+        super.start();
     }
 }

--- a/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
+++ b/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.catalina.LifecycleException;
 import org.apache.catalina.authenticator.AuthenticatorBase;
 import org.apache.catalina.connector.Request;
 import org.slf4j.Logger;
@@ -60,8 +61,11 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
     /** The protocols. */
     protected Set<String>            protocols           = SUPPORTED_PROTOCOLS;
 
+    /** The auth continueContextTimeout configuration */
+    protected int                    continueContextsTimeout = 30;
+
     /** The auth. */
-    protected IWindowsAuthProvider   auth                = new WindowsAuthProviderImpl();
+    protected IWindowsAuthProvider   auth                = null;
 
     /**
      * Windows authentication provider.
@@ -247,6 +251,17 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
         } finally {
             windowsIdentity.dispose();
         }
+    }
+
+    /**
+     * Hook to the start and to set up the dependencies.
+     * @throws LifecycleException
+     */
+    @Override
+    protected synchronized void startInternal() throws LifecycleException {
+        this.log.debug("Creating a windows authentication provider with continueContextTimeout property set to: {}", this.continueContextsTimeout);
+        this.auth = new WindowsAuthProviderImpl(this.continueContextsTimeout);
+        super.startInternal();
     }
 
 }

--- a/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
+++ b/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
@@ -68,6 +68,22 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
     protected IWindowsAuthProvider   auth                = null;
 
     /**
+     * Gets the continue context time out configuration
+     * @return
+     */
+    public int getContinueContextsTimeout() {
+        return continueContextsTimeout;
+    }
+
+    /**
+     * Sets the continue context time out configuration
+     * @param continueContextsTimeout
+     */
+    public void setContinueContextsTimeout(int continueContextsTimeout) {
+        this.continueContextsTimeout = continueContextsTimeout;
+    }
+
+    /**
      * Windows authentication provider.
      * 
      * @return IWindowsAuthProvider.

--- a/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
+++ b/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.catalina.LifecycleException;
 import org.apache.catalina.authenticator.AuthenticatorBase;
 import org.apache.catalina.connector.Request;
 import org.slf4j.Logger;
@@ -60,8 +61,11 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
     /** The protocols. */
     protected Set<String>            protocols           = SUPPORTED_PROTOCOLS;
 
+    /** The auth continueContextTimeout configuration */
+    protected int                    continueContextsTimeout = 30;
+
     /** The auth. */
-    protected IWindowsAuthProvider   auth                = new WindowsAuthProviderImpl();
+    protected IWindowsAuthProvider   auth                = null;
 
     /**
      * Windows authentication provider.
@@ -250,4 +254,14 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
         }
     }
 
+    /**
+     * Hook to the start and to set up the dependencies.
+     * @throws LifecycleException
+     */
+    @Override
+    protected synchronized void startInternal() throws LifecycleException {
+        this.log.debug("Creating a windows authentication provider with continueContextTimeout property set to: {}", this.continueContextsTimeout);
+        this.auth = new WindowsAuthProviderImpl(this.continueContextsTimeout);
+        super.startInternal();
+    }
 }

--- a/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
+++ b/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
@@ -68,6 +68,22 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
     protected IWindowsAuthProvider   auth                = null;
 
     /**
+     * Gets the continue context time out configuration
+     * @return
+     */
+    public int getContinueContextsTimeout() {
+        return continueContextsTimeout;
+    }
+
+    /**
+     * Sets the continue context time out configuration
+     * @param continueContextsTimeout
+     */
+    public void setContinueContextsTimeout(int continueContextsTimeout) {
+        this.continueContextsTimeout = continueContextsTimeout;
+    }
+
+    /**
      * Windows authentication provider.
      * 
      * @return IWindowsAuthProvider.


### PR DESCRIPTION
I have added support for external configuration of the continueContextTimeout property required by the WindowsAuthProvider. All WaffleAuthenticatorBase classes now override the start method in order to create an instance of the WindowsAuthProviderImpl.
I have checked all inherited classes to call their base and all unit tests passes.
