### PR TITLE
[tests] Cleanup tests that no longer require try / catch logic

### DIFF
--- a/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat6/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
@@ -17,8 +17,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.common.io.BaseEncoding;
 import com.sun.jna.platform.win32.Sspi;
@@ -40,9 +38,6 @@ import waffle.windows.auth.impl.WindowsSecurityContextImpl;
  * @author dblock[at]dblock[dot]org
  */
 public class NegotiateAuthenticatorTests {
-
-    /** The Constant LOGGER. */
-    private static final Logger    LOGGER = LoggerFactory.getLogger(NegotiateAuthenticatorTests.class);
 
     /** The authenticator. */
     private NegotiateAuthenticator authenticator;
@@ -241,12 +236,7 @@ public class NegotiateAuthenticatorTests {
                 request.addHeader("Authorization", securityPackage + " " + clientToken);
 
                 response = new SimpleHttpResponse();
-                try {
-                    authenticated = this.authenticator.authenticate(request, response, null);
-                } catch (final Exception e) {
-                    NegotiateAuthenticatorTests.LOGGER.error("", e);
-                    return;
-                }
+                authenticated = this.authenticator.authenticate(request, response, null);
 
                 if (authenticated) {
                     Assertions.assertThat(response.getHeaderNames().length).isGreaterThanOrEqualTo(0);

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
@@ -19,9 +19,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.google.common.io.BaseEncoding;
 import com.sun.jna.platform.win32.Sspi;
 import com.sun.jna.platform.win32.Sspi.SecBufferDesc;
@@ -43,9 +40,6 @@ import waffle.windows.auth.impl.WindowsSecurityContextImpl;
  * @author dblock[at]dblock[dot]org
  */
 public class NegotiateAuthenticatorTests {
-
-    /** The Constant LOGGER. */
-    private static final Logger    LOGGER = LoggerFactory.getLogger(NegotiateAuthenticatorTests.class);
 
     /** The authenticator. */
     private NegotiateAuthenticator authenticator;
@@ -263,12 +257,7 @@ public class NegotiateAuthenticatorTests {
                 request.addHeader("Authorization", securityPackage + " " + clientToken);
 
                 response = new SimpleHttpResponse();
-                try {
-                    authenticated = this.authenticator.authenticate(request, response, null);
-                } catch (final Exception e) {
-                    NegotiateAuthenticatorTests.LOGGER.error("", e);
-                    return;
-                }
+                authenticated = this.authenticator.authenticate(request, response, null);
 
                 if (authenticated) {
                     Assertions.assertThat(response.getHeaderNames().size()).isGreaterThanOrEqualTo(0);

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
@@ -19,8 +19,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.common.io.BaseEncoding;
 import com.sun.jna.platform.win32.Sspi;
@@ -43,9 +41,6 @@ import waffle.windows.auth.impl.WindowsSecurityContextImpl;
  * @author dblock[at]dblock[dot]org
  */
 public class NegotiateAuthenticatorTests {
-
-    /** The Constant LOGGER. */
-    private static final Logger    LOGGER = LoggerFactory.getLogger(NegotiateAuthenticatorTests.class);
 
     /** The authenticator. */
     private NegotiateAuthenticator authenticator;
@@ -261,12 +256,7 @@ public class NegotiateAuthenticatorTests {
                 request.addHeader("Authorization", securityPackage + " " + clientToken);
 
                 response = new SimpleHttpResponse();
-                try {
-                    authenticated = this.authenticator.authenticate(request, response);
-                } catch (final Exception e) {
-                    NegotiateAuthenticatorTests.LOGGER.error("", e);
-                    return;
-                }
+                authenticated = this.authenticator.authenticate(request, response);
 
                 if (authenticated) {
                     Assertions.assertThat(response.getHeaderNames().size()).isGreaterThanOrEqualTo(0);

--- a/Source/JNA/waffle-tomcat85/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat85/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
@@ -19,8 +19,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.common.io.BaseEncoding;
 import com.sun.jna.platform.win32.Sspi;
@@ -43,9 +41,6 @@ import waffle.windows.auth.impl.WindowsSecurityContextImpl;
  * @author dblock[at]dblock[dot]org
  */
 public class NegotiateAuthenticatorTests {
-
-    /** The Constant LOGGER. */
-    private static final Logger    LOGGER = LoggerFactory.getLogger(NegotiateAuthenticatorTests.class);
 
     /** The authenticator. */
     private NegotiateAuthenticator authenticator;
@@ -261,12 +256,7 @@ public class NegotiateAuthenticatorTests {
                 request.addHeader("Authorization", securityPackage + " " + clientToken);
 
                 response = new SimpleHttpResponse();
-                try {
-                    authenticated = this.authenticator.authenticate(request, response);
-                } catch (final Exception e) {
-                    NegotiateAuthenticatorTests.LOGGER.error("", e);
-                    return;
-                }
+                authenticated = this.authenticator.authenticate(request, response);
 
                 if (authenticated) {
                     Assertions.assertThat(response.getHeaderNames().size()).isGreaterThanOrEqualTo(0);

--- a/Source/JNA/waffle-tomcat9/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat9/src/test/java/waffle/apache/NegotiateAuthenticatorTests.java
@@ -21,8 +21,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.sun.jna.platform.win32.Sspi;
 import com.sun.jna.platform.win32.Sspi.SecBufferDesc;
@@ -44,9 +42,6 @@ import waffle.windows.auth.impl.WindowsSecurityContextImpl;
  * @author dblock[at]dblock[dot]org
  */
 public class NegotiateAuthenticatorTests {
-
-    /** The Constant LOGGER. */
-    private static final Logger    LOGGER = LoggerFactory.getLogger(NegotiateAuthenticatorTests.class);
 
     /** The authenticator. */
     private NegotiateAuthenticator authenticator;
@@ -262,12 +257,7 @@ public class NegotiateAuthenticatorTests {
                 request.addHeader("Authorization", securityPackage + " " + clientToken);
 
                 response = new SimpleHttpResponse();
-                try {
-                    authenticated = this.authenticator.authenticate(request, response);
-                } catch (final Exception e) {
-                    NegotiateAuthenticatorTests.LOGGER.error("", e);
-                    return;
-                }
+                authenticated = this.authenticator.authenticate(request, response);
 
                 if (authenticated) {
                     Assertions.assertThat(response.getHeaderNames().size()).isGreaterThanOrEqualTo(0);


### PR DESCRIPTION
tomcat code was corrected so bug that was seen in test cases no longer
is present.  Removing unnecessary try/catch so we don't re-introduct
issues later.