### PR TITLE
[spring] Re-throw Win32Exception as AuthenticationServiceException - Fixes #408

### DIFF
--- a/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/WindowsAuthenticationProvider.java
+++ b/Source/JNA/waffle-spring-security3/src/main/java/waffle/spring/WindowsAuthenticationProvider.java
@@ -13,9 +13,11 @@ package waffle.spring;
 
 import java.util.Locale;
 
+import com.sun.jna.platform.win32.Win32Exception;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -70,8 +72,12 @@ public class WindowsAuthenticationProvider implements AuthenticationProvider {
     @Override
     public Authentication authenticate(final Authentication authentication) {
         final UsernamePasswordAuthenticationToken auth = (UsernamePasswordAuthenticationToken) authentication;
-        final IWindowsIdentity windowsIdentity = this.authProvider.logonUser(auth.getName(), auth.getCredentials()
-                .toString());
+        IWindowsIdentity windowsIdentity;
+        try {
+            windowsIdentity = this.authProvider.logonUser(auth.getName(), auth.getCredentials().toString());
+        } catch (Win32Exception e) {
+            throw new AuthenticationServiceException(e.getMessage(), e);
+        }
         WindowsAuthenticationProvider.LOGGER.debug("logged in user: {} ({})", windowsIdentity.getFqn(),
                 windowsIdentity.getSidString());
 

--- a/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/WindowsAuthenticationProvider.java
+++ b/Source/JNA/waffle-spring-security4/src/main/java/waffle/spring/WindowsAuthenticationProvider.java
@@ -13,9 +13,11 @@ package waffle.spring;
 
 import java.util.Locale;
 
+import com.sun.jna.platform.win32.Win32Exception;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -70,8 +72,12 @@ public class WindowsAuthenticationProvider implements AuthenticationProvider {
     @Override
     public Authentication authenticate(final Authentication authentication) {
         final UsernamePasswordAuthenticationToken auth = (UsernamePasswordAuthenticationToken) authentication;
-        final IWindowsIdentity windowsIdentity = this.authProvider.logonUser(auth.getName(), auth.getCredentials()
-                .toString());
+        IWindowsIdentity windowsIdentity;
+        try {
+            windowsIdentity = this.authProvider.logonUser(auth.getName(), auth.getCredentials().toString());
+        } catch (Win32Exception e) {
+            throw new AuthenticationServiceException(e.getMessage(), e);
+        }
         WindowsAuthenticationProvider.LOGGER.debug("logged in user: {} ({})", windowsIdentity.getFqn(),
                 windowsIdentity.getSidString());
 


### PR DESCRIPTION
Fixes Waffle/waffle#408

The try/catch/re-throw was removed here:

https://github.com/Waffle/waffle/commit/c9c01a306833b589008b86022156b12b18e1b024#diff-150290ffe737db29594cc307562faeceL76

@hazendaz Can you comment on why this was removed?