### PR TITLE
Upgrade to Java 8 - using caffeine

### DIFF
--- a/Source/JNA/pom.xml
+++ b/Source/JNA/pom.xml
@@ -124,10 +124,10 @@
         <copyright>2015</copyright>
         <jacoco.minimum.coverage>0.0</jacoco.minimum.coverage>
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss</maven.build.timestamp.format>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
-        <maven.compiler.testSource>1.7</maven.compiler.testSource>
-        <maven.compiler.testTarget>1.7</maven.compiler.testTarget>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.testSource>1.8</maven.compiler.testSource>
+        <maven.compiler.testTarget>1.8</maven.compiler.testTarget>
         <maven.min-version>3.3.9</maven.min-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
@@ -140,7 +140,7 @@
         <junit.version>4.12</junit.version>
         <slf4j.version>1.7.22</slf4j.version>
 
-        <signature.artifact>java17</signature.artifact>
+        <signature.artifact>java18</signature.artifact>
         <signature.version>1.0</signature.version>
     </properties>
 

--- a/Source/JNA/waffle-jna/pom.xml
+++ b/Source/JNA/waffle-jna/pom.xml
@@ -37,6 +37,7 @@
     </scm>
 
     <properties>
+        <caffeine.version>2.3.5</caffeine.version>
         <guava.version>20.0</guava.version>
         <jna.version>4.3.0</jna.version>
         <servlet.version>3.1.0</servlet.version>
@@ -80,6 +81,11 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>${caffeine.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsAuthProviderImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsAuthProviderImpl.java
@@ -17,8 +17,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.sun.jna.platform.win32.Advapi32;
 import com.sun.jna.platform.win32.Kernel32;
 import com.sun.jna.platform.win32.Netapi32Util;
@@ -89,7 +89,7 @@ public class WindowsAuthProviderImpl implements IWindowsAuthProvider {
      *            Timeout for security contexts in seconds.
      */
     public WindowsAuthProviderImpl(final int continueContextsTimeout) {
-        this.continueContexts = CacheBuilder.newBuilder().expireAfterWrite(continueContextsTimeout, TimeUnit.SECONDS)
+        this.continueContexts = Caffeine.newBuilder().expireAfterWrite(continueContextsTimeout, TimeUnit.SECONDS)
                 .build();
     }
 


### PR DESCRIPTION
Set the compiler to 1.8 (defaults to 1.5). This does not change code patterns, as still valid and style is a team choice. Switched from Guava's cache to Caffeine as requested.