### PR TITLE
added Waffle.nuspec

### DIFF
--- a/Waffle.nuspec
+++ b/Waffle.nuspec
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>Waffle</id>
+    <version>1.8.4</version>
+    <authors>Daniel Doubrovkine &amp; Jeremy Landis</authors>
+    <owners>Daniel Doubrovkine</owners>
+    <licenseUrl>https://github.com/Waffle/waffle/blob/master/LICENSE</licenseUrl>
+    <projectUrl>http://dblock.github.io/waffle/</projectUrl>
+    <iconUrl>https://github.com/Waffle/waffle/blob/master/waffle.jpg</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Enable drop-in Windows Single Sign On for popular Java web servers.</description>
+    <releaseNotes>Add nuget package</releaseNotes>
+    <copyright>Copyright (c) Application Security Inc.2010-2017 and Contributors.</copyright>
+    <tags>sspi kerberos negotiate ntlm authentication</tags>
+    <dependencies>
+      <dependency id="NUnit" version="3.5.0" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="target\Release\Waffle\Bin\*.dll" target="lib\Waffle.Windows.AuthProvider.dll" />
+  </files>
+</package>


### PR DESCRIPTION
Pull request related to #267 to add Waffle as nuget package, please check the values set in Waffle.nuspec as may not be correct including version number.  Also ensure the file source node is correct, I ran a local build and pointed it at the directory where dll is built.

The following steps are required to publish on Nuget gallery.  Instructions taken from [here](https://docs.microsoft.com/en-us/nuget/quickstart/create-and-publish-a-package)

   
- nuget  pack Waffle.nuspec

- Create account at [nuget](https://www.nuget.org/users/account/LogOn?returnUrl=%2F) and generate nuget api key here 

- nuget push  Waffle.1.8.4.nupkg **<Generated api key here>** -Source https://www.nuget.org/api/v2/package

To test create a local project and install Waffle package from nuget, if you want to test a local nuget install before publishing follow steps suggested [here](https://blogs.endjin.com/2014/07/how-to-test-nuget-packages-locally/).

Thanks
Simon