### PR TITLE
Added troubleshooting story to disable debug log

### DIFF
--- a/Docs/FAQ.md
+++ b/Docs/FAQ.md
@@ -41,6 +41,7 @@ Troubleshooting Stories
 * [Issues with servlet filter on multiple Tomcat 7 Instances Sharing WAFFLE binaries](https://groups.google.com/forum/?fromgroups#!topic/waffle-users/4_K_O7BCn-c): solved by putting filter-mapping in the application's web.xml, also answered by [Tomcat bug 51754](https://issues.apache.org/bugzilla/show_bug.cgi?id=51754#c1).
 * [Waffle returns outdated nonexistent user name after the user name was changed on domain](faq/ClearLSACacheToAvoidOutdatedPrincipalNames.md): solved by clearing the server LSA cache through the Windows registry according to MS Kbase article.
 * [Status 401 (error code 80090308) when using .NET client and HTTP 1.0 protocol](https://groups.google.com/d/msg/waffle-users/Nisu-m19_nI/HLgaNhfBEw4J): solved by using default protocol version in .NET HttpWebRequest
+* [Disable waffle debug log information in Tomcat server] (https://github.com/Waffle/waffle/issues/548) : solved by placing the logback configuration file in tomcat server library folder where waffle jar files are available.
 
 
 Troubleshooting Help


### PR DESCRIPTION
Added Troubleshooting story where I struggled to control the waffle debug information logs while running it in windows with Tomcat server. The log level was controlled to error or exception level after placing the logback configuration file under tomcat lib folder. The configuration file should be placed where waffle jar files are available.

This was night mare issue when debug log information makes your log file size in #GB and it shouts down the tomcat server after running for longer period.