### PR TITLE
Custom instances of GenericPrincipal in WaffleAuthenticatorBase

### DIFF
--- a/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/MixedAuthenticator.java
+++ b/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/MixedAuthenticator.java
@@ -257,7 +257,7 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
 
             final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
 
-            this.log.debug("roles: {}",  String.join(", ", genericPrincipal.getRoles()));
+            this.log.debug("roles: {}", String.join(", ", genericPrincipal.getRoles()));
             // create a session associated with this request if there's none
             final HttpSession session = request.getSession(true);
             this.log.debug("session id: {}", session == null ? "null" : session.getId());

--- a/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/MixedAuthenticator.java
+++ b/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/MixedAuthenticator.java
@@ -26,6 +26,7 @@ import javax.servlet.http.HttpSession;
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.deploy.LoginConfig;
+import org.apache.catalina.realm.GenericPrincipal;
 import org.slf4j.LoggerFactory;
 
 import waffle.util.AuthorizationHeader;
@@ -254,17 +255,15 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
         try {
             this.log.debug("successfully logged in {} ({})", username, windowsIdentity.getSidString());
 
-            final GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity,
-                    this.principalFormat, this.roleFormat);
+            final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
 
-            this.log.debug("roles: {}", windowsPrincipal.getRolesString());
-
+            this.log.debug("roles: {}",  String.join(", ", genericPrincipal.getRoles()));
             // create a session associated with this request if there's none
             final HttpSession session = request.getSession(true);
             this.log.debug("session id: {}", session == null ? "null" : session.getId());
 
-            this.register(request, response, windowsPrincipal, "FORM", windowsPrincipal.getName(), null);
-            this.log.info("successfully logged in user: {}", windowsPrincipal.getName());
+            this.register(request, response, genericPrincipal, "FORM", genericPrincipal.getName(), null);
+            this.log.info("successfully logged in user: {}", genericPrincipal.getName());
         } finally {
             windowsIdentity.dispose();
         }

--- a/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/NegotiateAuthenticator.java
+++ b/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/NegotiateAuthenticator.java
@@ -23,6 +23,7 @@ import javax.servlet.http.HttpSession;
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.deploy.LoginConfig;
+import org.apache.catalina.realm.GenericPrincipal;
 import org.slf4j.LoggerFactory;
 
 import waffle.util.AuthorizationHeader;
@@ -160,12 +161,11 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
             try {
                 this.log.debug("logged in user: {} ({})", windowsIdentity.getFqn(), windowsIdentity.getSidString());
 
-                final GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity,
-                        this.principalFormat, this.roleFormat);
+                final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
 
-                this.log.debug("roles: {}", windowsPrincipal.getRolesString());
+                this.log.debug("roles: {}",  String.join(", ", genericPrincipal.getRoles()));
 
-                principal = windowsPrincipal;
+                principal = genericPrincipal;
 
                 // create a session associated with this request if there's none
                 final HttpSession session = request.getSession(true);

--- a/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/NegotiateAuthenticator.java
+++ b/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/NegotiateAuthenticator.java
@@ -163,7 +163,7 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
 
                 final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
 
-                this.log.debug("roles: {}",  String.join(", ", genericPrincipal.getRoles()));
+                this.log.debug("roles: {}", String.join(", ", genericPrincipal.getRoles()));
 
                 principal = genericPrincipal;
 

--- a/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
+++ b/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
@@ -23,6 +23,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.catalina.authenticator.AuthenticatorBase;
 import org.apache.catalina.connector.Request;
+import org.apache.catalina.realm.GenericPrincipal;
 import org.slf4j.Logger;
 
 import waffle.windows.auth.IWindowsAuthProvider;
@@ -243,13 +244,22 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
         }
         try {
             this.log.debug("successfully logged in {} ({})", username, windowsIdentity.getSidString());
-            final GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity,
-                    this.principalFormat, this.roleFormat);
-            this.log.debug("roles: {}", windowsPrincipal.getRolesString());
-            return windowsPrincipal;
+            final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
+            this.log.debug("roles: {}",  String.join(", ", genericPrincipal.getRoles()));
+            return genericPrincipal;
         } finally {
             windowsIdentity.dispose();
         }
+    }
+
+    /**
+     * This method will create an instance of a IWindowsIdentity based GenericPrincipal.
+     * It is used for creating custom implementation within subclasses.
+     * @param windowsIdentity the windows identity to initialize the principal
+     * @return the Generic Principal
+     */
+    protected GenericPrincipal createPrincipal(final IWindowsIdentity windowsIdentity) {
+        return new GenericWindowsPrincipal(windowsIdentity, this.principalFormat, this.roleFormat);
     }
 
 }

--- a/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
+++ b/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
@@ -245,7 +245,7 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
         try {
             this.log.debug("successfully logged in {} ({})", username, windowsIdentity.getSidString());
             final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
-            this.log.debug("roles: {}",  String.join(", ", genericPrincipal.getRoles()));
+            this.log.debug("roles: {}", String.join(", ", genericPrincipal.getRoles()));
             return genericPrincipal;
         } finally {
             windowsIdentity.dispose();

--- a/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/MixedAuthenticator.java
+++ b/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/MixedAuthenticator.java
@@ -25,6 +25,7 @@ import javax.servlet.http.HttpSession;
 
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.connector.Request;
+import org.apache.catalina.realm.GenericPrincipal;
 import org.apache.tomcat.util.descriptor.web.LoginConfig;
 import org.slf4j.LoggerFactory;
 
@@ -255,17 +256,15 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
         try {
             this.log.debug("successfully logged in {} ({})", username, windowsIdentity.getSidString());
 
-            final GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity,
-                    this.principalFormat, this.roleFormat);
+            final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
 
-            this.log.debug("roles: {}", windowsPrincipal.getRolesString());
-
+            this.log.debug("roles: {}",  String.join(", ", genericPrincipal.getRoles()));
             // create a session associated with this request if there's none
             final HttpSession session = request.getSession(true);
             this.log.debug("session id: {}", session == null ? "null" : session.getId());
 
-            this.register(request, response, windowsPrincipal, "FORM", windowsPrincipal.getName(), null);
-            this.log.info("successfully logged in user: {}", windowsPrincipal.getName());
+            this.register(request, response, genericPrincipal, "FORM", genericPrincipal.getName(), null);
+            this.log.info("successfully logged in user: {}", genericPrincipal.getName());
         } finally {
             windowsIdentity.dispose();
         }

--- a/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/MixedAuthenticator.java
+++ b/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/MixedAuthenticator.java
@@ -258,7 +258,7 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
 
             final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
 
-            this.log.debug("roles: {}",  String.join(", ", genericPrincipal.getRoles()));
+            this.log.debug("roles: {}", String.join(", ", genericPrincipal.getRoles()));
             // create a session associated with this request if there's none
             final HttpSession session = request.getSession(true);
             this.log.debug("session id: {}", session == null ? "null" : session.getId());

--- a/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/NegotiateAuthenticator.java
+++ b/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/NegotiateAuthenticator.java
@@ -22,6 +22,7 @@ import javax.servlet.http.HttpSession;
 
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.connector.Request;
+import org.apache.catalina.realm.GenericPrincipal;
 import org.slf4j.LoggerFactory;
 
 import waffle.util.AuthorizationHeader;
@@ -158,12 +159,11 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
             try {
                 this.log.debug("logged in user: {} ({})", windowsIdentity.getFqn(), windowsIdentity.getSidString());
 
-                final GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity,
-                        this.principalFormat, this.roleFormat);
+                final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
 
-                this.log.debug("roles: {}", windowsPrincipal.getRolesString());
+                this.log.debug("roles: {}",  String.join(", ", genericPrincipal.getRoles()));
 
-                principal = windowsPrincipal;
+                principal = genericPrincipal;
 
                 // create a session associated with this request if there's none
                 final HttpSession session = request.getSession(true);

--- a/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/NegotiateAuthenticator.java
+++ b/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/NegotiateAuthenticator.java
@@ -161,7 +161,7 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
 
                 final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
 
-                this.log.debug("roles: {}",  String.join(", ", genericPrincipal.getRoles()));
+                this.log.debug("roles: {}", String.join(", ", genericPrincipal.getRoles()));
 
                 principal = genericPrincipal;
 

--- a/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
+++ b/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
@@ -23,6 +23,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.catalina.authenticator.AuthenticatorBase;
 import org.apache.catalina.connector.Request;
+import org.apache.catalina.realm.GenericPrincipal;
 import org.slf4j.Logger;
 
 import waffle.windows.auth.IWindowsAuthProvider;
@@ -242,13 +243,22 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
         }
         try {
             this.log.debug("successfully logged in {} ({})", username, windowsIdentity.getSidString());
-            final GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity,
-                    this.principalFormat, this.roleFormat);
-            this.log.debug("roles: {}", windowsPrincipal.getRolesString());
-            return windowsPrincipal;
+            final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
+            this.log.debug("roles: {}",  String.join(", ", genericPrincipal.getRoles()));
+            return genericPrincipal;
         } finally {
             windowsIdentity.dispose();
         }
+    }
+
+    /**
+     * This method will create an instance of a IWindowsIdentity based GenericPrincipal.
+     * It is used for creating custom implementation within subclasses.
+     * @param windowsIdentity the windows identity to initialize the principal
+     * @return the Generic Principal
+     */
+    protected GenericPrincipal createPrincipal(final IWindowsIdentity windowsIdentity) {
+        return new GenericWindowsPrincipal(windowsIdentity, this.principalFormat, this.roleFormat);
     }
 
 }

--- a/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
+++ b/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
@@ -244,7 +244,7 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
         try {
             this.log.debug("successfully logged in {} ({})", username, windowsIdentity.getSidString());
             final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
-            this.log.debug("roles: {}",  String.join(", ", genericPrincipal.getRoles()));
+            this.log.debug("roles: {}", String.join(", ", genericPrincipal.getRoles()));
             return genericPrincipal;
         } finally {
             windowsIdentity.dispose();

--- a/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/MixedAuthenticator.java
+++ b/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/MixedAuthenticator.java
@@ -25,6 +25,7 @@ import javax.servlet.http.HttpSession;
 
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.connector.Request;
+import org.apache.catalina.realm.GenericPrincipal;
 import org.apache.tomcat.util.descriptor.web.LoginConfig;
 import org.slf4j.LoggerFactory;
 
@@ -202,17 +203,16 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
 
             this.log.debug("logged in user: {} ({})", windowsIdentity.getFqn(), windowsIdentity.getSidString());
 
-            final GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity,
-                    this.principalFormat, this.roleFormat);
+            final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
 
-            this.log.debug("roles: {}", windowsPrincipal.getRolesString());
+            this.log.debug("roles: {}",  String.join(", ", genericPrincipal.getRoles()));
 
             // create a session associated with this request if there's none
             final HttpSession session = request.getSession(true);
             this.log.debug("session id: {}", session == null ? "null" : session.getId());
 
-            this.register(request, response, windowsPrincipal, securityPackage, windowsPrincipal.getName(), null);
-            this.log.info("successfully logged in user: {}", windowsPrincipal.getName());
+            this.register(request, response, genericPrincipal, securityPackage, genericPrincipal.getName(), null);
+            this.log.info("successfully logged in user: {}", genericPrincipal.getName());
 
         } finally {
             windowsIdentity.dispose();
@@ -255,17 +255,15 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
         try {
             this.log.debug("successfully logged in {} ({})", username, windowsIdentity.getSidString());
 
-            final GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity,
-                    this.principalFormat, this.roleFormat);
+            final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
 
-            this.log.debug("roles: {}", windowsPrincipal.getRolesString());
-
+            this.log.debug("roles: {}",  String.join(", ", genericPrincipal.getRoles()));
             // create a session associated with this request if there's none
             final HttpSession session = request.getSession(true);
             this.log.debug("session id: {}", session == null ? "null" : session.getId());
 
-            this.register(request, response, windowsPrincipal, "FORM", windowsPrincipal.getName(), null);
-            this.log.info("successfully logged in user: {}", windowsPrincipal.getName());
+            this.register(request, response, genericPrincipal, "FORM", genericPrincipal.getName(), null);
+            this.log.info("successfully logged in user: {}", genericPrincipal.getName());
         } finally {
             windowsIdentity.dispose();
         }

--- a/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/MixedAuthenticator.java
+++ b/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/MixedAuthenticator.java
@@ -205,7 +205,7 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
 
             final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
 
-            this.log.debug("roles: {}",  String.join(", ", genericPrincipal.getRoles()));
+            this.log.debug("roles: {}", String.join(", ", genericPrincipal.getRoles()));
 
             // create a session associated with this request if there's none
             final HttpSession session = request.getSession(true);
@@ -257,7 +257,7 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
 
             final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
 
-            this.log.debug("roles: {}",  String.join(", ", genericPrincipal.getRoles()));
+            this.log.debug("roles: {}", String.join(", ", genericPrincipal.getRoles()));
             // create a session associated with this request if there's none
             final HttpSession session = request.getSession(true);
             this.log.debug("session id: {}", session == null ? "null" : session.getId());

--- a/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/NegotiateAuthenticator.java
+++ b/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/NegotiateAuthenticator.java
@@ -11,8 +11,6 @@
  */
 package waffle.apache;
 
-import com.sun.jna.platform.win32.Win32Exception;
-
 import java.io.IOException;
 import java.security.Principal;
 import java.util.Base64;
@@ -22,7 +20,10 @@ import javax.servlet.http.HttpSession;
 
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.connector.Request;
+import org.apache.catalina.realm.GenericPrincipal;
 import org.slf4j.LoggerFactory;
+
+import com.sun.jna.platform.win32.Win32Exception;
 
 import waffle.util.AuthorizationHeader;
 import waffle.util.NtlmServletRequest;
@@ -158,12 +159,11 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
             try {
                 this.log.debug("logged in user: {} ({})", windowsIdentity.getFqn(), windowsIdentity.getSidString());
 
-                final GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity,
-                        this.principalFormat, this.roleFormat);
+                final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
 
-                this.log.debug("roles: {}", windowsPrincipal.getRolesString());
+                this.log.debug("roles: {}",  String.join(", ", genericPrincipal.getRoles()));
 
-                principal = windowsPrincipal;
+                principal = genericPrincipal;
 
                 // create a session associated with this request if there's none
                 final HttpSession session = request.getSession(true);
@@ -184,6 +184,10 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
         this.log.debug("authorization required");
         this.sendUnauthorized(response);
         return false;
+    }
+
+    protected GenericPrincipal createPrincipal(final IWindowsIdentity windowsIdentity) {
+        return new GenericWindowsPrincipal(windowsIdentity, this.principalFormat, this.roleFormat);
     }
 
     /**

--- a/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/NegotiateAuthenticator.java
+++ b/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/NegotiateAuthenticator.java
@@ -186,10 +186,6 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
         return false;
     }
 
-    protected GenericPrincipal createPrincipal(final IWindowsIdentity windowsIdentity) {
-        return new GenericWindowsPrincipal(windowsIdentity, this.principalFormat, this.roleFormat);
-    }
-
     /**
      * XXX The 'doAuthenticate' is intended to replace 'authenticate' for needs like ours. In order to support old and
      * new at this time, we will continue to have both for time being.

--- a/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/NegotiateAuthenticator.java
+++ b/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/NegotiateAuthenticator.java
@@ -161,7 +161,7 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
 
                 final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
 
-                this.log.debug("roles: {}",  String.join(", ", genericPrincipal.getRoles()));
+                this.log.debug("roles: {}", String.join(", ", genericPrincipal.getRoles()));
 
                 principal = genericPrincipal;
 

--- a/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
+++ b/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
@@ -23,6 +23,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.catalina.authenticator.AuthenticatorBase;
 import org.apache.catalina.connector.Request;
+import org.apache.catalina.realm.GenericPrincipal;
 import org.slf4j.Logger;
 
 import waffle.windows.auth.IWindowsAuthProvider;
@@ -242,13 +243,22 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
         }
         try {
             this.log.debug("successfully logged in {} ({})", username, windowsIdentity.getSidString());
-            final GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity,
-                    this.principalFormat, this.roleFormat);
-            this.log.debug("roles: {}", windowsPrincipal.getRolesString());
-            return windowsPrincipal;
+            final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
+            this.log.debug("roles: {}",  String.join(", ", genericPrincipal.getRoles()));
+            return genericPrincipal;
         } finally {
             windowsIdentity.dispose();
         }
+    }
+
+    /**
+     * This method will create an instance of a IWindowsIdentity based GenericPrincipal.
+     * It is used for creating custom implementation within subclasses.
+     * @param windowsIdentity the windows identity to initialize the principal
+     * @return the Generic Principal
+     */
+    protected GenericPrincipal createPrincipal(final IWindowsIdentity windowsIdentity) {
+        return new GenericWindowsPrincipal(windowsIdentity, this.principalFormat, this.roleFormat);
     }
 
 }

--- a/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
+++ b/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
@@ -244,7 +244,7 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
         try {
             this.log.debug("successfully logged in {} ({})", username, windowsIdentity.getSidString());
             final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
-            this.log.debug("roles: {}",  String.join(", ", genericPrincipal.getRoles()));
+            this.log.debug("roles: {}", String.join(", ", genericPrincipal.getRoles()));
             return genericPrincipal;
         } finally {
             windowsIdentity.dispose();

--- a/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/MixedAuthenticator.java
+++ b/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/MixedAuthenticator.java
@@ -25,6 +25,7 @@ import javax.servlet.http.HttpSession;
 
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.connector.Request;
+import org.apache.catalina.realm.GenericPrincipal;
 import org.apache.tomcat.util.descriptor.web.LoginConfig;
 import org.slf4j.LoggerFactory;
 
@@ -202,17 +203,16 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
 
             this.log.debug("logged in user: {} ({})", windowsIdentity.getFqn(), windowsIdentity.getSidString());
 
-            final GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity,
-                    this.principalFormat, this.roleFormat);
+            final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
 
-            this.log.debug("roles: {}", windowsPrincipal.getRolesString());
+            this.log.debug("roles: {}",  String.join(", ", genericPrincipal.getRoles()));
 
             // create a session associated with this request if there's none
             final HttpSession session = request.getSession(true);
             this.log.debug("session id: {}", session == null ? "null" : session.getId());
 
-            this.register(request, response, windowsPrincipal, securityPackage, windowsPrincipal.getName(), null);
-            this.log.info("successfully logged in user: {}", windowsPrincipal.getName());
+            this.register(request, response, genericPrincipal, securityPackage, genericPrincipal.getName(), null);
+            this.log.info("successfully logged in user: {}", genericPrincipal.getName());
 
         } finally {
             windowsIdentity.dispose();
@@ -255,17 +255,15 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
         try {
             this.log.debug("successfully logged in {} ({})", username, windowsIdentity.getSidString());
 
-            final GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity,
-                    this.principalFormat, this.roleFormat);
+            final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
 
-            this.log.debug("roles: {}", windowsPrincipal.getRolesString());
-
+            this.log.debug("roles: {}",  String.join(", ", genericPrincipal.getRoles()));
             // create a session associated with this request if there's none
             final HttpSession session = request.getSession(true);
             this.log.debug("session id: {}", session == null ? "null" : session.getId());
 
-            this.register(request, response, windowsPrincipal, "FORM", windowsPrincipal.getName(), null);
-            this.log.info("successfully logged in user: {}", windowsPrincipal.getName());
+            this.register(request, response, genericPrincipal, "FORM", genericPrincipal.getName(), null);
+            this.log.info("successfully logged in user: {}", genericPrincipal.getName());
         } finally {
             windowsIdentity.dispose();
         }

--- a/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/MixedAuthenticator.java
+++ b/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/MixedAuthenticator.java
@@ -205,7 +205,7 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
 
             final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
 
-            this.log.debug("roles: {}",  String.join(", ", genericPrincipal.getRoles()));
+            this.log.debug("roles: {}", String.join(", ", genericPrincipal.getRoles()));
 
             // create a session associated with this request if there's none
             final HttpSession session = request.getSession(true);
@@ -257,7 +257,7 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
 
             final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
 
-            this.log.debug("roles: {}",  String.join(", ", genericPrincipal.getRoles()));
+            this.log.debug("roles: {}", String.join(", ", genericPrincipal.getRoles()));
             // create a session associated with this request if there's none
             final HttpSession session = request.getSession(true);
             this.log.debug("session id: {}", session == null ? "null" : session.getId());

--- a/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/NegotiateAuthenticator.java
+++ b/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/NegotiateAuthenticator.java
@@ -162,7 +162,7 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
 
                 final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
 
-                this.log.debug("roles: {}",  String.join(", ", genericPrincipal.getRoles()));
+                this.log.debug("roles: {}", String.join(", ", genericPrincipal.getRoles()));
 
                 principal = genericPrincipal;
 

--- a/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/NegotiateAuthenticator.java
+++ b/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/NegotiateAuthenticator.java
@@ -22,6 +22,7 @@ import javax.servlet.http.HttpSession;
 
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.connector.Request;
+import org.apache.catalina.realm.GenericPrincipal;
 import org.slf4j.LoggerFactory;
 
 import waffle.util.AuthorizationHeader;
@@ -159,12 +160,11 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
             try {
                 this.log.debug("logged in user: {} ({})", windowsIdentity.getFqn(), windowsIdentity.getSidString());
 
-                final GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity,
-                        this.principalFormat, this.roleFormat);
+                final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
 
-                this.log.debug("roles: {}", windowsPrincipal.getRolesString());
+                this.log.debug("roles: {}",  String.join(", ", genericPrincipal.getRoles()));
 
-                principal = windowsPrincipal;
+                principal = genericPrincipal;
 
                 // create a session associated with this request if there's none
                 final HttpSession session = request.getSession(true);

--- a/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
+++ b/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
@@ -23,6 +23,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.catalina.authenticator.AuthenticatorBase;
 import org.apache.catalina.connector.Request;
+import org.apache.catalina.realm.GenericPrincipal;
 import org.slf4j.Logger;
 
 import waffle.windows.auth.IWindowsAuthProvider;
@@ -242,13 +243,22 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
         }
         try {
             this.log.debug("successfully logged in {} ({})", username, windowsIdentity.getSidString());
-            final GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity,
-                    this.principalFormat, this.roleFormat);
-            this.log.debug("roles: {}", windowsPrincipal.getRolesString());
-            return windowsPrincipal;
+            final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
+            this.log.debug("roles: {}",  String.join(", ", genericPrincipal.getRoles()));
+            return genericPrincipal;
         } finally {
             windowsIdentity.dispose();
         }
+    }
+
+    /**
+     * This method will create an instance of a IWindowsIdentity based GenericPrincipal.
+     * It is used for creating custom implementation within subclasses.
+     * @param windowsIdentity the windows identity to initialize the principal
+     * @return the Generic Principal
+     */
+    protected GenericPrincipal createPrincipal(final IWindowsIdentity windowsIdentity) {
+        return new GenericWindowsPrincipal(windowsIdentity, this.principalFormat, this.roleFormat);
     }
 
 }

--- a/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
+++ b/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
@@ -244,7 +244,7 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
         try {
             this.log.debug("successfully logged in {} ({})", username, windowsIdentity.getSidString());
             final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
-            this.log.debug("roles: {}",  String.join(", ", genericPrincipal.getRoles()));
+            this.log.debug("roles: {}", String.join(", ", genericPrincipal.getRoles()));
             return genericPrincipal;
         } finally {
             windowsIdentity.dispose();


### PR DESCRIPTION
refering:
https://github.com/Waffle/waffle/issues/561

my main target is it to get the roles not directly by the windows roles but by a further mechanism that gets some roles from a database query using the current windowsIdentity as a query parameter