### PR TITLE
Pr/196 - Externally configure continueContextsTimeout for tomcat(s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
+1.8.4 (12/24/2017)
+==================
+* More backporting from 1.9.x master
+* [#579](https://github.com/Waffle/waffle/pull/579): Applied PR #196 continueContextsTimeout for tomcats. [@hazendaz](https://github.com/hazendaz).
+* [#196](https://github.com/Waffle/waffle/pull/196): Added continueContextsTimeout property to WaffleAuthenticatorBase for tomcat(s). [@alanlavintman](https://github.com/alanlavintman).
+
 1.8.3 (2/6/2017)
 ================
+**** Mainly backporting from 1.9.x branch and this release specifically was to add third party licenses ****
+
 * Documentation updates
 * Version Updates
 * Sonar / Coverity Cleanup

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsAuthProviderImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsAuthProviderImpl.java
@@ -48,6 +48,9 @@ import waffle.windows.auth.IWindowsSecurityContext;
  */
 public class WindowsAuthProviderImpl implements IWindowsAuthProvider {
 
+    /** The Continue Context Timeout. */
+    public static final int CONTINUE_CONTEXT_TIMEOUT = 30;
+
     /**
      * The Class ContinueContext.
      */
@@ -79,7 +82,7 @@ public class WindowsAuthProviderImpl implements IWindowsAuthProvider {
      * Instantiates a new windows auth provider impl.
      */
     public WindowsAuthProviderImpl() {
-        this(30);
+        this(WindowsAuthProviderImpl.CONTINUE_CONTEXT_TIMEOUT);
     }
 
     /**

--- a/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/MixedAuthenticator.java
+++ b/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/MixedAuthenticator.java
@@ -57,6 +57,7 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
     @Override
     public void start() {
         this.log.info("[waffle.apache.MixedAuthenticator] started");
+        super.start();
     }
 
     /*
@@ -66,6 +67,7 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
     @Override
     public void stop() {
         this.log.info("[waffle.apache.MixedAuthenticator] stopped");
+        // Do not call tomcat 6 super.stop() as we never have and it doesn't seem to work.
     }
 
     /*

--- a/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/NegotiateAuthenticator.java
+++ b/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/NegotiateAuthenticator.java
@@ -54,6 +54,7 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
     @Override
     public void start() {
         this.log.info("[waffle.apache.NegotiateAuthenticator] started");
+        super.start();
     }
 
     /*
@@ -63,6 +64,7 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
     @Override
     public void stop() {
         this.log.info("[waffle.apache.NegotiateAuthenticator] stopped");
+        // Do not call tomcat 6 super.stop() as we never have and it doesn't seem to work.
     }
 
     /*

--- a/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
+++ b/Source/JNA/waffle-tomcat6/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
@@ -35,7 +35,7 @@ import waffle.windows.auth.impl.WindowsAuthProviderImpl;
 abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
 
     /** The Constant SUPPORTED_PROTOCOLS. */
-    private static final Set<String> SUPPORTED_PROTOCOLS = new LinkedHashSet<>(Arrays.asList("Negotiate", "NTLM"));
+    private static final Set<String> SUPPORTED_PROTOCOLS     = new LinkedHashSet<>(Arrays.asList("Negotiate", "NTLM"));
 
     /** The info. */
     @SuppressWarnings("hiding")
@@ -45,19 +45,38 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
     protected Logger                 log;
 
     /** The principal format. */
-    protected PrincipalFormat        principalFormat     = PrincipalFormat.FQN;
+    protected PrincipalFormat        principalFormat         = PrincipalFormat.FQN;
 
     /** The role format. */
-    protected PrincipalFormat        roleFormat          = PrincipalFormat.FQN;
+    protected PrincipalFormat        roleFormat              = PrincipalFormat.FQN;
 
     /** The allow guest login. */
-    protected boolean                allowGuestLogin     = true;
+    protected boolean                allowGuestLogin         = true;
 
     /** The protocols. */
-    protected Set<String>            protocols           = WaffleAuthenticatorBase.SUPPORTED_PROTOCOLS;
+    protected Set<String>            protocols               = WaffleAuthenticatorBase.SUPPORTED_PROTOCOLS;
+
+    /** The auth continueContextsTimeout configuration */
+    protected int                    continueContextsTimeout = WindowsAuthProviderImpl.CONTINUE_CONTEXT_TIMEOUT;
 
     /** The auth. */
-    protected IWindowsAuthProvider   auth                = new WindowsAuthProviderImpl();
+    protected IWindowsAuthProvider   auth;
+
+    /**
+     * Gets the continue context time out configuration
+     * @return
+     */
+    public int getContinueContextsTimeout() {
+        return continueContextsTimeout;
+    }
+
+    /**
+     * Sets the continue context time out configuration
+     * @param continueContextsTimeout
+     */
+    public void setContinueContextsTimeout(int continueContextsTimeout) {
+        this.continueContextsTimeout = continueContextsTimeout;
+    }
 
     /**
      * Windows authentication provider.
@@ -205,5 +224,16 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
             this.log.trace("", e);
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * Hook to the start and to set up the dependencies.
+     */
+    @Override
+    public void start() {
+        this.log.debug("Creating a windows authentication provider with continueContextsTimeout property set to: {}",
+                this.continueContextsTimeout);
+        this.auth = new WindowsAuthProviderImpl(this.continueContextsTimeout);
+        // Do not call tomcat 6 super.start() as we never have and it doesn't seem to work.
     }
 }

--- a/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
+++ b/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.catalina.LifecycleException;
 import org.apache.catalina.authenticator.AuthenticatorBase;
 import org.apache.catalina.connector.Request;
 import org.slf4j.Logger;
@@ -38,7 +39,7 @@ import waffle.windows.auth.impl.WindowsAuthProviderImpl;
 abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
 
     /** The Constant SUPPORTED_PROTOCOLS. */
-    private static final Set<String> SUPPORTED_PROTOCOLS = new LinkedHashSet<>(Arrays.asList("Negotiate", "NTLM"));
+    private static final Set<String> SUPPORTED_PROTOCOLS     = new LinkedHashSet<>(Arrays.asList("Negotiate", "NTLM"));
 
     /** The info. */
     @SuppressWarnings("hiding")
@@ -48,19 +49,38 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
     protected Logger                 log;
 
     /** The principal format. */
-    protected PrincipalFormat        principalFormat     = PrincipalFormat.FQN;
+    protected PrincipalFormat        principalFormat         = PrincipalFormat.FQN;
 
     /** The role format. */
-    protected PrincipalFormat        roleFormat          = PrincipalFormat.FQN;
+    protected PrincipalFormat        roleFormat              = PrincipalFormat.FQN;
 
     /** The allow guest login. */
-    protected boolean                allowGuestLogin     = true;
+    protected boolean                allowGuestLogin         = true;
 
     /** The protocols. */
-    protected Set<String>            protocols           = WaffleAuthenticatorBase.SUPPORTED_PROTOCOLS;
+    protected Set<String>            protocols               = WaffleAuthenticatorBase.SUPPORTED_PROTOCOLS;
+
+    /** The auth continueContextsTimeout configuration */
+    protected int                    continueContextsTimeout = WindowsAuthProviderImpl.CONTINUE_CONTEXT_TIMEOUT;
 
     /** The auth. */
-    protected IWindowsAuthProvider   auth                = new WindowsAuthProviderImpl();
+    protected IWindowsAuthProvider   auth;
+
+    /**
+     * Gets the continue context time out configuration
+     * @return
+     */
+    public int getContinueContextsTimeout() {
+        return continueContextsTimeout;
+    }
+
+    /**
+     * Sets the continue context time out configuration
+     * @param continueContextsTimeout
+     */
+    public void setContinueContextsTimeout(int continueContextsTimeout) {
+        this.continueContextsTimeout = continueContextsTimeout;
+    }
 
     /**
      * Windows authentication provider.
@@ -250,6 +270,18 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
         } finally {
             windowsIdentity.dispose();
         }
+    }
+
+    /**
+     * Hook to the start and to set up the dependencies.
+     * @throws LifecycleException
+     */
+    @Override
+    protected synchronized void startInternal() throws LifecycleException {
+        this.log.debug("Creating a windows authentication provider with continueContextsTimeout property set to: {}",
+                this.continueContextsTimeout);
+        this.auth = new WindowsAuthProviderImpl(this.continueContextsTimeout);
+        super.startInternal();
     }
 
 }

--- a/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
+++ b/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.catalina.LifecycleException;
 import org.apache.catalina.authenticator.AuthenticatorBase;
 import org.apache.catalina.connector.Request;
 import org.slf4j.Logger;
@@ -38,7 +39,7 @@ import waffle.windows.auth.impl.WindowsAuthProviderImpl;
 abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
 
     /** The Constant SUPPORTED_PROTOCOLS. */
-    private static final Set<String> SUPPORTED_PROTOCOLS = new LinkedHashSet<>(Arrays.asList("Negotiate", "NTLM"));
+    private static final Set<String> SUPPORTED_PROTOCOLS     = new LinkedHashSet<>(Arrays.asList("Negotiate", "NTLM"));
 
     /** The info. */
     protected String                 info;
@@ -47,19 +48,38 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
     protected Logger                 log;
 
     /** The principal format. */
-    protected PrincipalFormat        principalFormat     = PrincipalFormat.FQN;
+    protected PrincipalFormat        principalFormat         = PrincipalFormat.FQN;
 
     /** The role format. */
-    protected PrincipalFormat        roleFormat          = PrincipalFormat.FQN;
+    protected PrincipalFormat        roleFormat              = PrincipalFormat.FQN;
 
     /** The allow guest login. */
-    protected boolean                allowGuestLogin     = true;
+    protected boolean                allowGuestLogin         = true;
 
     /** The protocols. */
-    protected Set<String>            protocols           = WaffleAuthenticatorBase.SUPPORTED_PROTOCOLS;
+    protected Set<String>            protocols               = WaffleAuthenticatorBase.SUPPORTED_PROTOCOLS;
+
+    /** The auth continueContextsTimeout configuration */
+    protected int                    continueContextsTimeout = WindowsAuthProviderImpl.CONTINUE_CONTEXT_TIMEOUT;
 
     /** The auth. */
-    protected IWindowsAuthProvider   auth                = new WindowsAuthProviderImpl();
+    protected IWindowsAuthProvider   auth;
+
+    /**
+     * Gets the continue context time out configuration
+     * @return
+     */
+    public int getContinueContextsTimeout() {
+        return continueContextsTimeout;
+    }
+
+    /**
+     * Sets the continue context time out configuration
+     * @param continueContextsTimeout
+     */
+    public void setContinueContextsTimeout(int continueContextsTimeout) {
+        this.continueContextsTimeout = continueContextsTimeout;
+    }
 
     /**
      * Windows authentication provider.
@@ -251,4 +271,15 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
         }
     }
 
+    /**
+     * Hook to the start and to set up the dependencies.
+     * @throws LifecycleException
+     */
+    @Override
+    protected synchronized void startInternal() throws LifecycleException {
+        this.log.debug("Creating a windows authentication provider with continueContextsTimeout property set to: {}",
+                this.continueContextsTimeout);
+        this.auth = new WindowsAuthProviderImpl(this.continueContextsTimeout);
+        super.startInternal();
+    }
 }

--- a/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
+++ b/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.catalina.LifecycleException;
 import org.apache.catalina.authenticator.AuthenticatorBase;
 import org.apache.catalina.connector.Request;
 import org.slf4j.Logger;
@@ -38,7 +39,7 @@ import waffle.windows.auth.impl.WindowsAuthProviderImpl;
 abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
 
     /** The Constant SUPPORTED_PROTOCOLS. */
-    private static final Set<String> SUPPORTED_PROTOCOLS = new LinkedHashSet<>(Arrays.asList("Negotiate", "NTLM"));
+    private static final Set<String> SUPPORTED_PROTOCOLS     = new LinkedHashSet<>(Arrays.asList("Negotiate", "NTLM"));
 
     /** The info. */
     protected String                 info;
@@ -47,19 +48,38 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
     protected Logger                 log;
 
     /** The principal format. */
-    protected PrincipalFormat        principalFormat     = PrincipalFormat.FQN;
+    protected PrincipalFormat        principalFormat         = PrincipalFormat.FQN;
 
     /** The role format. */
-    protected PrincipalFormat        roleFormat          = PrincipalFormat.FQN;
+    protected PrincipalFormat        roleFormat              = PrincipalFormat.FQN;
 
     /** The allow guest login. */
-    protected boolean                allowGuestLogin     = true;
+    protected boolean                allowGuestLogin         = true;
+
+    /** The auth continueContextsTimeout configuration */
+    protected int                    continueContextsTimeout = WindowsAuthProviderImpl.CONTINUE_CONTEXT_TIMEOUT;
 
     /** The protocols. */
-    protected Set<String>            protocols           = WaffleAuthenticatorBase.SUPPORTED_PROTOCOLS;
+    protected Set<String>            protocols               = WaffleAuthenticatorBase.SUPPORTED_PROTOCOLS;
 
     /** The auth. */
-    protected IWindowsAuthProvider   auth                = new WindowsAuthProviderImpl();
+    protected IWindowsAuthProvider   auth;
+
+    /**
+     * Gets the continue context time out configuration
+     * @return
+     */
+    public int getContinueContextsTimeout() {
+        return continueContextsTimeout;
+    }
+
+    /**
+     * Sets the continue context time out configuration
+     * @param continueContextsTimeout
+     */
+    public void setContinueContextsTimeout(int continueContextsTimeout) {
+        this.continueContextsTimeout = continueContextsTimeout;
+    }
 
     /**
      * Windows authentication provider.
@@ -207,6 +227,18 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
             this.log.trace("", e);
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * Hook to the start and to set up the dependencies.
+     * @throws LifecycleException
+     */
+    @Override
+    public void startInternal() throws LifecycleException {
+        this.log.debug("Creating a windows authentication provider with continueContextsTimeout property set to: {}",
+                this.continueContextsTimeout);
+        this.auth = new WindowsAuthProviderImpl(this.continueContextsTimeout);
+        super.startInternal();
     }
 
     /*

--- a/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
+++ b/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.catalina.LifecycleException;
 import org.apache.catalina.authenticator.AuthenticatorBase;
 import org.apache.catalina.connector.Request;
 import org.slf4j.Logger;
@@ -38,7 +39,7 @@ import waffle.windows.auth.impl.WindowsAuthProviderImpl;
 abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
 
     /** The Constant SUPPORTED_PROTOCOLS. */
-    private static final Set<String> SUPPORTED_PROTOCOLS = new LinkedHashSet<>(Arrays.asList("Negotiate", "NTLM"));
+    private static final Set<String> SUPPORTED_PROTOCOLS     = new LinkedHashSet<>(Arrays.asList("Negotiate", "NTLM"));
 
     /** The info. */
     protected String                 info;
@@ -47,19 +48,38 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
     protected Logger                 log;
 
     /** The principal format. */
-    protected PrincipalFormat        principalFormat     = PrincipalFormat.FQN;
+    protected PrincipalFormat        principalFormat         = PrincipalFormat.FQN;
 
     /** The role format. */
-    protected PrincipalFormat        roleFormat          = PrincipalFormat.FQN;
+    protected PrincipalFormat        roleFormat              = PrincipalFormat.FQN;
 
     /** The allow guest login. */
-    protected boolean                allowGuestLogin     = true;
+    protected boolean                allowGuestLogin         = true;
+
+    /** The auth continueContextsTimeout configuration */
+    protected int                    continueContextsTimeout = WindowsAuthProviderImpl.CONTINUE_CONTEXT_TIMEOUT;
 
     /** The protocols. */
-    protected Set<String>            protocols           = WaffleAuthenticatorBase.SUPPORTED_PROTOCOLS;
+    protected Set<String>            protocols               = WaffleAuthenticatorBase.SUPPORTED_PROTOCOLS;
 
     /** The auth. */
-    protected IWindowsAuthProvider   auth                = new WindowsAuthProviderImpl();
+    protected IWindowsAuthProvider   auth;
+
+    /**
+     * Gets the continue context time out configuration
+     * @return
+     */
+    public int getContinueContextsTimeout() {
+        return continueContextsTimeout;
+    }
+
+    /**
+     * Sets the continue context time out configuration
+     * @param continueContextsTimeout
+     */
+    public void setContinueContextsTimeout(int continueContextsTimeout) {
+        this.continueContextsTimeout = continueContextsTimeout;
+    }
 
     /**
      * Windows authentication provider.
@@ -207,6 +227,18 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
             this.log.trace("", e);
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * Hook to the start and to set up the dependencies.
+     * @throws LifecycleException
+     */
+    @Override
+    public void startInternal() throws LifecycleException {
+        this.log.debug("Creating a windows authentication provider with continueContextsTimeout property set to: {}",
+                this.continueContextsTimeout);
+        this.auth = new WindowsAuthProviderImpl(this.continueContextsTimeout);
+        super.startInternal();
     }
 
     /*


### PR DESCRIPTION
Fixes issue #194 and resolves pull request #196 for all tomcats.  This is mostly the same as original but I called out JNA to a static as we did internally set the time to 30 seconds then I used that throughout so we were not repeating ourselves.  Also in tomcat6, we never called tomcats lifecycle.  I'm sure there was reason for this.  The tests locked when doing that.  I'm sure they eventually came back but because this PR does nothing to address that original design, I opted to not apply that and added comments instead.  The end result is a lot less code changes.

Formatting on how we allign properties is a mess when new items are added which is something I learned over the past few years.  I plan to address that on master in near future.