### PR TITLE
Custom instances of GenericPrincipal in WaffleAuthenticatorBase (#571)

### DIFF
--- a/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/MixedAuthenticator.java
+++ b/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/MixedAuthenticator.java
@@ -16,6 +16,7 @@ import com.sun.jna.platform.win32.Win32Exception;
 
 import java.io.IOException;
 import java.security.Principal;
+import java.util.Arrays;
 
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletContext;
@@ -26,6 +27,7 @@ import javax.servlet.http.HttpSession;
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.deploy.LoginConfig;
+import org.apache.catalina.realm.GenericPrincipal;
 import org.slf4j.LoggerFactory;
 
 import waffle.util.AuthorizationHeader;
@@ -254,17 +256,15 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
         try {
             this.log.debug("successfully logged in {} ({})", username, windowsIdentity.getSidString());
 
-            final GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity,
-                    this.principalFormat, this.roleFormat);
+            final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
 
-            this.log.debug("roles: {}", windowsPrincipal.getRolesString());
-
+            this.log.debug("roles: {}", Arrays.toString(genericPrincipal.getRoles()));
             // create a session associated with this request if there's none
             final HttpSession session = request.getSession(true);
             this.log.debug("session id: {}", session == null ? "null" : session.getId());
 
-            this.register(request, response, windowsPrincipal, "FORM", windowsPrincipal.getName(), null);
-            this.log.info("successfully logged in user: {}", windowsPrincipal.getName());
+            this.register(request, response, genericPrincipal, "FORM", genericPrincipal.getName(), null);
+            this.log.info("successfully logged in user: {}", genericPrincipal.getName());
         } finally {
             windowsIdentity.dispose();
         }

--- a/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/NegotiateAuthenticator.java
+++ b/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/NegotiateAuthenticator.java
@@ -16,6 +16,7 @@ import com.sun.jna.platform.win32.Win32Exception;
 
 import java.io.IOException;
 import java.security.Principal;
+import java.util.Arrays;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
@@ -23,6 +24,7 @@ import javax.servlet.http.HttpSession;
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.deploy.LoginConfig;
+import org.apache.catalina.realm.GenericPrincipal;
 import org.slf4j.LoggerFactory;
 
 import waffle.util.AuthorizationHeader;
@@ -160,12 +162,11 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
             try {
                 this.log.debug("logged in user: {} ({})", windowsIdentity.getFqn(), windowsIdentity.getSidString());
 
-                final GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity,
-                        this.principalFormat, this.roleFormat);
+                final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
 
-                this.log.debug("roles: {}", windowsPrincipal.getRolesString());
+                this.log.debug("roles: {}", Arrays.toString(genericPrincipal.getRoles()));
 
-                principal = windowsPrincipal;
+                principal = genericPrincipal;
 
                 // create a session associated with this request if there's none
                 final HttpSession session = request.getSession(true);

--- a/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
+++ b/Source/JNA/waffle-tomcat7/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
@@ -1,7 +1,7 @@
 /**
  * Waffle (https://github.com/Waffle/waffle)
  *
- * Copyright (c) 2010-2016 Application Security, Inc.
+ * Copyright (c) 2010-2017 Application Security, Inc.
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at
@@ -24,6 +24,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.authenticator.AuthenticatorBase;
 import org.apache.catalina.connector.Request;
+import org.apache.catalina.realm.GenericPrincipal;
 import org.slf4j.Logger;
 
 import waffle.windows.auth.IWindowsAuthProvider;
@@ -263,10 +264,9 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
         }
         try {
             this.log.debug("successfully logged in {} ({})", username, windowsIdentity.getSidString());
-            final GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity,
-                    this.principalFormat, this.roleFormat);
-            this.log.debug("roles: {}", windowsPrincipal.getRolesString());
-            return windowsPrincipal;
+            final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
+            this.log.debug("roles: {}", Arrays.toString(genericPrincipal.getRoles()));
+            return genericPrincipal;
         } finally {
             windowsIdentity.dispose();
         }
@@ -282,6 +282,16 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
                 this.continueContextsTimeout);
         this.auth = new WindowsAuthProviderImpl(this.continueContextsTimeout);
         super.startInternal();
+    }
+
+    /**
+     * This method will create an instance of a IWindowsIdentity based GenericPrincipal.
+     * It is used for creating custom implementation within subclasses.
+     * @param windowsIdentity the windows identity to initialize the principal
+     * @return the Generic Principal
+     */
+    protected GenericPrincipal createPrincipal(final IWindowsIdentity windowsIdentity) {
+        return new GenericWindowsPrincipal(windowsIdentity, this.principalFormat, this.roleFormat);
     }
 
 }

--- a/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/MixedAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat7/src/test/java/waffle/apache/MixedAuthenticatorTests.java
@@ -15,6 +15,9 @@ import com.google.common.io.BaseEncoding;
 import com.sun.jna.platform.win32.Sspi;
 import com.sun.jna.platform.win32.Sspi.SecBufferDesc;
 
+import java.io.IOException;
+import java.util.ArrayList;
+
 import javax.servlet.ServletException;
 
 import mockit.Expectations;
@@ -24,6 +27,7 @@ import org.apache.catalina.Context;
 import org.apache.catalina.Engine;
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.deploy.LoginConfig;
+import org.apache.catalina.realm.GenericPrincipal;
 import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Assert;
@@ -362,5 +366,35 @@ public class MixedAuthenticatorTests {
         request.addParameter("j_password", "");
         final SimpleHttpResponse response = new SimpleHttpResponse();
         Assert.assertTrue(this.authenticator.authenticate(request, response, loginConfig));
+    }
+
+    @Test
+    public void testCustomPrincipal() throws LifecycleException, IOException {
+        final GenericPrincipal genericPrincipal = new GenericPrincipal("my-principal", "my-password",
+                new ArrayList<String>());
+        final MixedAuthenticator customAuthenticator = new MixedAuthenticator() {
+            @Override
+            protected GenericPrincipal createPrincipal(IWindowsIdentity windowsIdentity) {
+                return genericPrincipal;
+            }
+        };
+        try {
+            customAuthenticator.setContainer(this.context);
+            customAuthenticator.setAlwaysUseSession(true);
+            customAuthenticator.start();
+
+            customAuthenticator.setAuth(new MockWindowsAuthProvider());
+            final SimpleHttpRequest request = new SimpleHttpRequest();
+            request.addParameter("j_security_check", "");
+            request.addParameter("j_username", WindowsAccountImpl.getCurrentUsername());
+            request.addParameter("j_password", "");
+            final SimpleHttpResponse response = new SimpleHttpResponse();
+            Assert.assertTrue(customAuthenticator.authenticate(request, response));
+
+            Assert.assertEquals(genericPrincipal, request.getUserPrincipal());
+        } finally {
+            customAuthenticator.stop();
+        }
+
     }
 }

--- a/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/MixedAuthenticator.java
+++ b/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/MixedAuthenticator.java
@@ -16,6 +16,7 @@ import com.sun.jna.platform.win32.Win32Exception;
 
 import java.io.IOException;
 import java.security.Principal;
+import java.util.Arrays;
 
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletContext;
@@ -25,6 +26,7 @@ import javax.servlet.http.HttpSession;
 
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.connector.Request;
+import org.apache.catalina.realm.GenericPrincipal;
 import org.apache.tomcat.util.descriptor.web.LoginConfig;
 import org.slf4j.LoggerFactory;
 
@@ -255,17 +257,15 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
         try {
             this.log.debug("successfully logged in {} ({})", username, windowsIdentity.getSidString());
 
-            final GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity,
-                    this.principalFormat, this.roleFormat);
+            final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
 
-            this.log.debug("roles: {}", windowsPrincipal.getRolesString());
-
+            this.log.debug("roles: {}", Arrays.toString(genericPrincipal.getRoles()));
             // create a session associated with this request if there's none
             final HttpSession session = request.getSession(true);
             this.log.debug("session id: {}", session == null ? "null" : session.getId());
 
-            this.register(request, response, windowsPrincipal, "FORM", windowsPrincipal.getName(), null);
-            this.log.info("successfully logged in user: {}", windowsPrincipal.getName());
+            this.register(request, response, genericPrincipal, "FORM", genericPrincipal.getName(), null);
+            this.log.info("successfully logged in user: {}", genericPrincipal.getName());
         } finally {
             windowsIdentity.dispose();
         }

--- a/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/NegotiateAuthenticator.java
+++ b/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/NegotiateAuthenticator.java
@@ -16,12 +16,14 @@ import com.sun.jna.platform.win32.Win32Exception;
 
 import java.io.IOException;
 import java.security.Principal;
+import java.util.Arrays;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.connector.Request;
+import org.apache.catalina.realm.GenericPrincipal;
 import org.slf4j.LoggerFactory;
 
 import waffle.util.AuthorizationHeader;
@@ -158,12 +160,11 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
             try {
                 this.log.debug("logged in user: {} ({})", windowsIdentity.getFqn(), windowsIdentity.getSidString());
 
-                final GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity,
-                        this.principalFormat, this.roleFormat);
+                final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
 
-                this.log.debug("roles: {}", windowsPrincipal.getRolesString());
+                this.log.debug("roles: {}", Arrays.toString(genericPrincipal.getRoles()));
 
-                principal = windowsPrincipal;
+                principal = genericPrincipal;
 
                 // create a session associated with this request if there's none
                 final HttpSession session = request.getSession(true);

--- a/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
+++ b/Source/JNA/waffle-tomcat8/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
@@ -1,7 +1,7 @@
 /**
  * Waffle (https://github.com/Waffle/waffle)
  *
- * Copyright (c) 2010-2016 Application Security, Inc.
+ * Copyright (c) 2010-2017 Application Security, Inc.
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at
@@ -24,6 +24,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.authenticator.AuthenticatorBase;
 import org.apache.catalina.connector.Request;
+import org.apache.catalina.realm.GenericPrincipal;
 import org.slf4j.Logger;
 
 import waffle.windows.auth.IWindowsAuthProvider;
@@ -262,10 +263,9 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
         }
         try {
             this.log.debug("successfully logged in {} ({})", username, windowsIdentity.getSidString());
-            final GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity,
-                    this.principalFormat, this.roleFormat);
-            this.log.debug("roles: {}", windowsPrincipal.getRolesString());
-            return windowsPrincipal;
+            final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
+            this.log.debug("roles: {}", Arrays.toString(genericPrincipal.getRoles()));
+            return genericPrincipal;
         } finally {
             windowsIdentity.dispose();
         }
@@ -282,4 +282,15 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
         this.auth = new WindowsAuthProviderImpl(this.continueContextsTimeout);
         super.startInternal();
     }
+
+    /**
+     * This method will create an instance of a IWindowsIdentity based GenericPrincipal.
+     * It is used for creating custom implementation within subclasses.
+     * @param windowsIdentity the windows identity to initialize the principal
+     * @return the Generic Principal
+     */
+    protected GenericPrincipal createPrincipal(final IWindowsIdentity windowsIdentity) {
+        return new GenericWindowsPrincipal(windowsIdentity, this.principalFormat, this.roleFormat);
+    }
+
 }

--- a/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/MixedAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat8/src/test/java/waffle/apache/MixedAuthenticatorTests.java
@@ -15,6 +15,8 @@ import com.google.common.io.BaseEncoding;
 import com.sun.jna.platform.win32.Sspi;
 import com.sun.jna.platform.win32.Sspi.SecBufferDesc;
 
+import java.util.ArrayList;
+
 import javax.servlet.ServletException;
 
 import mockit.Expectations;
@@ -23,6 +25,7 @@ import mockit.Mocked;
 import org.apache.catalina.Context;
 import org.apache.catalina.Engine;
 import org.apache.catalina.LifecycleException;
+import org.apache.catalina.realm.GenericPrincipal;
 import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Assert;
@@ -347,5 +350,35 @@ public class MixedAuthenticatorTests {
         request.addParameter("j_password", "");
         final SimpleHttpResponse response = new SimpleHttpResponse();
         Assert.assertTrue(this.authenticator.authenticate(request, response));
+    }
+
+    @Test
+    public void testCustomPrincipal() throws LifecycleException {
+        final GenericPrincipal genericPrincipal = new GenericPrincipal("my-principal", "my-password",
+                new ArrayList<String>());
+        final MixedAuthenticator customAuthenticator = new MixedAuthenticator() {
+            @Override
+            protected GenericPrincipal createPrincipal(IWindowsIdentity windowsIdentity) {
+                return genericPrincipal;
+            }
+        };
+        try {
+            customAuthenticator.setContainer(this.context);
+            customAuthenticator.setAlwaysUseSession(true);
+            customAuthenticator.start();
+
+            customAuthenticator.setAuth(new MockWindowsAuthProvider());
+            final SimpleHttpRequest request = new SimpleHttpRequest();
+            request.addParameter("j_security_check", "");
+            request.addParameter("j_username", WindowsAccountImpl.getCurrentUsername());
+            request.addParameter("j_password", "");
+            final SimpleHttpResponse response = new SimpleHttpResponse();
+            Assert.assertTrue(customAuthenticator.authenticate(request, response));
+
+            Assert.assertEquals(genericPrincipal, request.getUserPrincipal());
+        } finally {
+            customAuthenticator.stop();
+        }
+
     }
 }

--- a/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/MixedAuthenticator.java
+++ b/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/MixedAuthenticator.java
@@ -16,6 +16,7 @@ import com.sun.jna.platform.win32.Win32Exception;
 
 import java.io.IOException;
 import java.security.Principal;
+import java.util.Arrays;
 
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletContext;
@@ -25,6 +26,7 @@ import javax.servlet.http.HttpSession;
 
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.connector.Request;
+import org.apache.catalina.realm.GenericPrincipal;
 import org.apache.tomcat.util.descriptor.web.LoginConfig;
 import org.slf4j.LoggerFactory;
 
@@ -202,17 +204,16 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
 
             this.log.debug("logged in user: {} ({})", windowsIdentity.getFqn(), windowsIdentity.getSidString());
 
-            final GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity,
-                    this.principalFormat, this.roleFormat);
+            final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
 
-            this.log.debug("roles: {}", windowsPrincipal.getRolesString());
+            this.log.debug("roles: {}", Arrays.toString(genericPrincipal.getRoles()));
 
             // create a session associated with this request if there's none
             final HttpSession session = request.getSession(true);
             this.log.debug("session id: {}", session == null ? "null" : session.getId());
 
-            this.register(request, response, windowsPrincipal, securityPackage, windowsPrincipal.getName(), null);
-            this.log.info("successfully logged in user: {}", windowsPrincipal.getName());
+            this.register(request, response, genericPrincipal, securityPackage, genericPrincipal.getName(), null);
+            this.log.info("successfully logged in user: {}", genericPrincipal.getName());
 
         } finally {
             windowsIdentity.dispose();
@@ -255,17 +256,15 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
         try {
             this.log.debug("successfully logged in {} ({})", username, windowsIdentity.getSidString());
 
-            final GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity,
-                    this.principalFormat, this.roleFormat);
+            final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
 
-            this.log.debug("roles: {}", windowsPrincipal.getRolesString());
-
+            this.log.debug("roles: {}", Arrays.toString(genericPrincipal.getRoles()));
             // create a session associated with this request if there's none
             final HttpSession session = request.getSession(true);
             this.log.debug("session id: {}", session == null ? "null" : session.getId());
 
-            this.register(request, response, windowsPrincipal, "FORM", windowsPrincipal.getName(), null);
-            this.log.info("successfully logged in user: {}", windowsPrincipal.getName());
+            this.register(request, response, genericPrincipal, "FORM", genericPrincipal.getName(), null);
+            this.log.info("successfully logged in user: {}", genericPrincipal.getName());
         } finally {
             windowsIdentity.dispose();
         }

--- a/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/NegotiateAuthenticator.java
+++ b/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/NegotiateAuthenticator.java
@@ -16,12 +16,14 @@ import com.sun.jna.platform.win32.Win32Exception;
 
 import java.io.IOException;
 import java.security.Principal;
+import java.util.Arrays;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.connector.Request;
+import org.apache.catalina.realm.GenericPrincipal;
 import org.slf4j.LoggerFactory;
 
 import waffle.util.AuthorizationHeader;
@@ -158,12 +160,11 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
             try {
                 this.log.debug("logged in user: {} ({})", windowsIdentity.getFqn(), windowsIdentity.getSidString());
 
-                final GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity,
-                        this.principalFormat, this.roleFormat);
+                final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
 
-                this.log.debug("roles: {}", windowsPrincipal.getRolesString());
+                this.log.debug("roles: {}", Arrays.toString(genericPrincipal.getRoles()));
 
-                principal = windowsPrincipal;
+                principal = genericPrincipal;
 
                 // create a session associated with this request if there's none
                 final HttpSession session = request.getSession(true);

--- a/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
+++ b/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
@@ -1,7 +1,7 @@
 /**
  * Waffle (https://github.com/Waffle/waffle)
  *
- * Copyright (c) 2010-2016 Application Security, Inc.
+ * Copyright (c) 2010-2017 Application Security, Inc.
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at
@@ -24,6 +24,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.authenticator.AuthenticatorBase;
 import org.apache.catalina.connector.Request;
+import org.apache.catalina.realm.GenericPrincipal;
 import org.slf4j.Logger;
 
 import waffle.windows.auth.IWindowsAuthProvider;
@@ -274,13 +275,22 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
         }
         try {
             this.log.debug("successfully logged in {} ({})", username, windowsIdentity.getSidString());
-            final GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity,
-                    this.principalFormat, this.roleFormat);
-            this.log.debug("roles: {}", windowsPrincipal.getRolesString());
-            return windowsPrincipal;
+            final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
+            this.log.debug("roles: {}", Arrays.toString(genericPrincipal.getRoles()));
+            return genericPrincipal;
         } finally {
             windowsIdentity.dispose();
         }
+    }
+
+    /**
+     * This method will create an instance of a IWindowsIdentity based GenericPrincipal.
+     * It is used for creating custom implementation within subclasses.
+     * @param windowsIdentity the windows identity to initialize the principal
+     * @return the Generic Principal
+     */
+    protected GenericPrincipal createPrincipal(final IWindowsIdentity windowsIdentity) {
+        return new GenericWindowsPrincipal(windowsIdentity, this.principalFormat, this.roleFormat);
     }
 
 }

--- a/Source/JNA/waffle-tomcat85/src/test/java/waffle/apache/MixedAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat85/src/test/java/waffle/apache/MixedAuthenticatorTests.java
@@ -15,6 +15,8 @@ import com.google.common.io.BaseEncoding;
 import com.sun.jna.platform.win32.Sspi;
 import com.sun.jna.platform.win32.Sspi.SecBufferDesc;
 
+import java.util.ArrayList;
+
 import javax.servlet.ServletException;
 
 import mockit.Expectations;
@@ -23,6 +25,7 @@ import mockit.Mocked;
 import org.apache.catalina.Context;
 import org.apache.catalina.Engine;
 import org.apache.catalina.LifecycleException;
+import org.apache.catalina.realm.GenericPrincipal;
 import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Assert;
@@ -347,5 +350,35 @@ public class MixedAuthenticatorTests {
         request.addParameter("j_password", "");
         final SimpleHttpResponse response = new SimpleHttpResponse();
         Assert.assertTrue(this.authenticator.authenticate(request, response));
+    }
+
+    @Test
+    public void testCustomPrincipal() throws LifecycleException {
+        final GenericPrincipal genericPrincipal = new GenericPrincipal("my-principal", "my-password",
+                new ArrayList<String>());
+        final MixedAuthenticator customAuthenticator = new MixedAuthenticator() {
+            @Override
+            protected GenericPrincipal createPrincipal(IWindowsIdentity windowsIdentity) {
+                return genericPrincipal;
+            }
+        };
+        try {
+            customAuthenticator.setContainer(this.context);
+            customAuthenticator.setAlwaysUseSession(true);
+            customAuthenticator.start();
+
+            customAuthenticator.setAuth(new MockWindowsAuthProvider());
+            final SimpleHttpRequest request = new SimpleHttpRequest();
+            request.addParameter("j_security_check", "");
+            request.addParameter("j_username", WindowsAccountImpl.getCurrentUsername());
+            request.addParameter("j_password", "");
+            final SimpleHttpResponse response = new SimpleHttpResponse();
+            Assert.assertTrue(customAuthenticator.authenticate(request, response));
+
+            Assert.assertEquals(genericPrincipal, request.getUserPrincipal());
+        } finally {
+            customAuthenticator.stop();
+        }
+
     }
 }

--- a/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/MixedAuthenticator.java
+++ b/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/MixedAuthenticator.java
@@ -25,6 +25,7 @@ import javax.servlet.http.HttpSession;
 
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.connector.Request;
+import org.apache.catalina.realm.GenericPrincipal;
 import org.apache.tomcat.util.descriptor.web.LoginConfig;
 import org.slf4j.LoggerFactory;
 
@@ -202,17 +203,16 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
 
             this.log.debug("logged in user: {} ({})", windowsIdentity.getFqn(), windowsIdentity.getSidString());
 
-            final GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity,
-                    this.principalFormat, this.roleFormat);
+            final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
 
-            this.log.debug("roles: {}", windowsPrincipal.getRolesString());
+            this.log.debug("roles: {}", String.join(", ", genericPrincipal.getRoles()));
 
             // create a session associated with this request if there's none
             final HttpSession session = request.getSession(true);
             this.log.debug("session id: {}", session == null ? "null" : session.getId());
 
-            this.register(request, response, windowsPrincipal, securityPackage, windowsPrincipal.getName(), null);
-            this.log.info("successfully logged in user: {}", windowsPrincipal.getName());
+            this.register(request, response, genericPrincipal, securityPackage, genericPrincipal.getName(), null);
+            this.log.info("successfully logged in user: {}", genericPrincipal.getName());
 
         } finally {
             windowsIdentity.dispose();
@@ -255,17 +255,15 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
         try {
             this.log.debug("successfully logged in {} ({})", username, windowsIdentity.getSidString());
 
-            final GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity,
-                    this.principalFormat, this.roleFormat);
+            final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
 
-            this.log.debug("roles: {}", windowsPrincipal.getRolesString());
-
+            this.log.debug("roles: {}", String.join(", ", genericPrincipal.getRoles()));
             // create a session associated with this request if there's none
             final HttpSession session = request.getSession(true);
             this.log.debug("session id: {}", session == null ? "null" : session.getId());
 
-            this.register(request, response, windowsPrincipal, "FORM", windowsPrincipal.getName(), null);
-            this.log.info("successfully logged in user: {}", windowsPrincipal.getName());
+            this.register(request, response, genericPrincipal, "FORM", genericPrincipal.getName(), null);
+            this.log.info("successfully logged in user: {}", genericPrincipal.getName());
         } finally {
             windowsIdentity.dispose();
         }

--- a/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/NegotiateAuthenticator.java
+++ b/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/NegotiateAuthenticator.java
@@ -22,6 +22,7 @@ import javax.servlet.http.HttpSession;
 
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.connector.Request;
+import org.apache.catalina.realm.GenericPrincipal;
 import org.slf4j.LoggerFactory;
 
 import waffle.util.AuthorizationHeader;
@@ -159,12 +160,11 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
             try {
                 this.log.debug("logged in user: {} ({})", windowsIdentity.getFqn(), windowsIdentity.getSidString());
 
-                final GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity,
-                        this.principalFormat, this.roleFormat);
+                final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
 
-                this.log.debug("roles: {}", windowsPrincipal.getRolesString());
+                this.log.debug("roles: {}", String.join(", ", genericPrincipal.getRoles()));
 
-                principal = windowsPrincipal;
+                principal = genericPrincipal;
 
                 // create a session associated with this request if there's none
                 final HttpSession session = request.getSession(true);

--- a/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
+++ b/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
@@ -1,7 +1,7 @@
 /**
  * Waffle (https://github.com/Waffle/waffle)
  *
- * Copyright (c) 2010-2016 Application Security, Inc.
+ * Copyright (c) 2010-2017 Application Security, Inc.
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at
@@ -24,6 +24,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.authenticator.AuthenticatorBase;
 import org.apache.catalina.connector.Request;
+import org.apache.catalina.realm.GenericPrincipal;
 import org.slf4j.Logger;
 
 import waffle.windows.auth.IWindowsAuthProvider;
@@ -274,13 +275,22 @@ abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
         }
         try {
             this.log.debug("successfully logged in {} ({})", username, windowsIdentity.getSidString());
-            final GenericWindowsPrincipal windowsPrincipal = new GenericWindowsPrincipal(windowsIdentity,
-                    this.principalFormat, this.roleFormat);
-            this.log.debug("roles: {}", windowsPrincipal.getRolesString());
-            return windowsPrincipal;
+            final GenericPrincipal genericPrincipal = createPrincipal(windowsIdentity);
+            this.log.debug("roles: {}", String.join(", ", genericPrincipal.getRoles()));
+            return genericPrincipal;
         } finally {
             windowsIdentity.dispose();
         }
+    }
+
+    /**
+     * This method will create an instance of a IWindowsIdentity based GenericPrincipal.
+     * It is used for creating custom implementation within subclasses.
+     * @param windowsIdentity the windows identity to initialize the principal
+     * @return the Generic Principal
+     */
+    protected GenericPrincipal createPrincipal(final IWindowsIdentity windowsIdentity) {
+        return new GenericWindowsPrincipal(windowsIdentity, this.principalFormat, this.roleFormat);
     }
 
 }

--- a/Source/JNA/waffle-tomcat9/src/test/java/waffle/apache/MixedAuthenticatorTests.java
+++ b/Source/JNA/waffle-tomcat9/src/test/java/waffle/apache/MixedAuthenticatorTests.java
@@ -15,6 +15,7 @@ import com.sun.jna.platform.win32.Sspi;
 import com.sun.jna.platform.win32.Sspi.SecBufferDesc;
 
 import java.util.Base64;
+import java.util.Collections;
 
 import javax.servlet.ServletException;
 
@@ -24,6 +25,7 @@ import mockit.Mocked;
 import org.apache.catalina.Context;
 import org.apache.catalina.Engine;
 import org.apache.catalina.LifecycleException;
+import org.apache.catalina.realm.GenericPrincipal;
 import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Assert;
@@ -348,5 +350,35 @@ public class MixedAuthenticatorTests {
         request.addParameter("j_password", "");
         final SimpleHttpResponse response = new SimpleHttpResponse();
         Assert.assertTrue(this.authenticator.authenticate(request, response));
+    }
+
+    @Test
+    public void testCustomPrincipal() throws LifecycleException {
+        final GenericPrincipal genericPrincipal = new GenericPrincipal("my-principal", "my-password",
+                Collections.emptyList());
+        final MixedAuthenticator customAuthenticator = new MixedAuthenticator() {
+            @Override
+            protected GenericPrincipal createPrincipal(IWindowsIdentity windowsIdentity) {
+                return genericPrincipal;
+            }
+        };
+        try {
+            customAuthenticator.setContainer(this.context);
+            customAuthenticator.setAlwaysUseSession(true);
+            customAuthenticator.start();
+
+            customAuthenticator.setAuth(new MockWindowsAuthProvider());
+            final SimpleHttpRequest request = new SimpleHttpRequest();
+            request.addParameter("j_security_check", "");
+            request.addParameter("j_username", WindowsAccountImpl.getCurrentUsername());
+            request.addParameter("j_password", "");
+            final SimpleHttpResponse response = new SimpleHttpResponse();
+            Assert.assertTrue(customAuthenticator.authenticate(request, response));
+
+            Assert.assertEquals(genericPrincipal, request.getUserPrincipal());
+        } finally {
+            customAuthenticator.stop();
+        }
+
     }
 }


### PR DESCRIPTION
backport to 1.8.x branch as-is with fixes for java 7 usage.  Will do more later as pieces are missing from tomcat 7 and 8 in general and we need to back port for 6.