### PR TITLE
[assembly] Adjustments for distro on springboot

### DIFF
--- a/Source/JNA/waffle-distro/src/assembly/assembly.xml
+++ b/Source/JNA/waffle-distro/src/assembly/assembly.xml
@@ -3,7 +3,7 @@
 
     Waffle (https://github.com/Waffle/waffle)
 
-    Copyright (c) 2010-2017 Application Security, Inc.
+    Copyright (c) 2010-2019 Application Security, Inc.
 
     All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
     Public License v1.0 which accompanies this distribution, and is available at
@@ -33,6 +33,10 @@
             <includes>
                 <include>*:jar</include>
             </includes>
+            <excludes>
+                <exclude>com.github.waffle.demo:waffle-spring-boot-filter:jar</exclude>
+                <exclude>com.github.waffle.demo:waffle-spring-boot-filter2:jar</exclude>
+            </excludes>
         </dependencySet>
         <dependencySet>
             <unpack>false</unpack>
@@ -41,6 +45,8 @@
             <useTransitiveDependencies>true</useTransitiveDependencies>
             <includes>
                 <include>*:war</include>
+                <include>com.github.waffle.demo:waffle-spring-boot-filter:jar</include>
+                <include>com.github.waffle.demo:waffle-spring-boot-filter2:jar</include>
             </includes>
         </dependencySet>
     </dependencySets>


### PR DESCRIPTION
previously we split war vs jar.  Since spring boot are jars, we need extra logic to ensure it drops to correct folder.