### PR TITLE
Update docs / Add logback to the demos

### DIFF
--- a/Docs/MavenReleaseGuide.md
+++ b/Docs/MavenReleaseGuide.md
@@ -6,7 +6,7 @@ This is a guide for WAFFLE developers hoping to publish a release to Maven Centr
 Building with Maven
 -------------------
 
-In order to build with [Maven][], you'll need Java 7+ and [Maven][] 3.3.9+.  Download and install them, and then run `mvn --version` to check that it's working.  If you don't already have it, also get Git and a clone of the WAFFLE repository.  Once you have this, run `mvn package` in the `Source/JNA/waffle-parent` directory.  This command compiles, unit tests, and JARs all of the WAFFLE components that are currently Maven-enabled.
+In order to build with [Maven][], you'll need Java 8+ and [Maven][] 3.6.3+.  Download and install them, and then run `mvn --version` to check that it's working.  If you don't already have it, also get Git and a clone of the WAFFLE repository.  Once you have this, run `mvn package` in the `Source/JNA/waffle-parent` directory.  This command compiles, unit tests, and JARs all of the WAFFLE components that are currently Maven-enabled.
 
 If you don't want to run the unit tests (which can be useful if you're trying to compile on a non-Windows platform), use `mvn package -DskipTests=true` instead.  This isn't recommended for release builds.
 

--- a/Docs/ServletSingleSignOnSecurityFilter.md
+++ b/Docs/ServletSingleSignOnSecurityFilter.md
@@ -10,9 +10,9 @@ Configuring Web Servers
 
 The following steps are required to configure a web server with the Waffle Servlet Security Filter. These instructions work for Tomcat, Jetty, WebSphere and possibly others.
 
-Package Waffle JARs (1.8.4), including `waffle-jna-1.8.4.jar`, `guava-20.0.jar`, `jna-4.3.0.jar`, `jna-platform-4.3.0.jar` and `slf4j-1.7.22.jar` in the application's `lib` directory or copy them to your web server's lib. 
+Package Waffle JARs (1.8.4), including `waffle-jna-2.1.1.jar`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar` and `slf4j-2.0.0-alpha1.jar` in the application's `lib` directory or copy them to your web server's lib. 
 
-- For latest snapshot instead use `waffle-jna-1.9.0-SNAPSHOT`, `caffeine-2.3.5.jar`, `jna-4.3.0.jar`, `jna-platform-4.3.0.jar` and `slf4j-1.7.22.jar`.
+- For latest snapshot instead use `waffle-jna-2.1.2-SNAPSHOT`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar` and `slf4j-2.0.0-alpha1.jar`.
 
 Add a security filter to `WEB-INF\web.xml` of your application. 
 

--- a/Docs/spring/DelegatingSpringSecuritySingleSignOnFilter.md
+++ b/Docs/spring/DelegatingSpringSecuritySingleSignOnFilter.md
@@ -1,7 +1,7 @@
 Delegating Spring Security Single-SignOn Filter
 ====================================
 
-The Waffle Delegating Spring-Security Filter extends the [Spring Security Single-SignOn Filter](https://github.com/dblock/waffle/blob/master/Docs/spring/SpringSecuritySingleSignOnFilter.md) by allowing the application using the filter to inject an additional authenticationmanager to provide authorization to a principal
+The Waffle Delegating Spring-Security Filter extends the [Spring Security Single-SignOn Filter](https://github.com/dblock/waffle/blob/master/Docs/spring/SpringSecuritySingleSignOnFilter.md) by allowing the application using the filter to inject an additional authentication manager to provide authorization to a principal
 that is authenticated in towards the active directory in the single sign-on process.
 
 Configuring Spring Security

--- a/Docs/spring/SpringSecurityAuthenticationProvider.md
+++ b/Docs/spring/SpringSecurityAuthenticationProvider.md
@@ -28,9 +28,9 @@ We'll assume that Spring-Security is configured via `web.xml` with a filter chai
 </listener>
 ```
 
-Copy Waffle JARs, including `waffle-jna-2.1.0.jar`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar`, `slf4j-api-2.0.0-alpha1.jar` and `waffle-spring-security4-2.1.0.jar` in the application's `lib` directory along with Spring and Spring-Security JARs. Or, if you use Maven, add the following to your `pom.xml`:
+Copy Waffle JARs, including `waffle-jna-2.1.1.jar`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar`, `slf4j-api-2.0.0-alpha1.jar` and `waffle-spring-security4-2.1.1.jar` in the application's `lib` directory along with Spring and Spring-Security JARs. Or, if you use Maven, add the following to your `pom.xml`:
 
-- For latest snapshot instead use `waffle-jna-2.1.1-SNAPSHOT`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar`, `slf4j-api-2.0.0-alpha1.jar` and `waffle-spring-security4-2.1.1-SNAPSHOT.jar`
+- For latest snapshot instead use `waffle-jna-2.1.2-SNAPSHOT`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar`, `slf4j-api-2.0.0-alpha1.jar` and `waffle-spring-security4-2.1.2-SNAPSHOT.jar`
 
 ``` xml
 <dependency>

--- a/Docs/spring/SpringSecuritySingleSignOnFilter.md
+++ b/Docs/spring/SpringSecuritySingleSignOnFilter.md
@@ -28,9 +28,9 @@ We'll assume that Spring-Security is configured via `web.xml` with a filter chai
 </listener>
 ```
 
-Copy Waffle JARs, including `waffle-jna-2.1.0.jar`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar`, `slf4j-api-2.0.0-alpha1.jar` and `waffle-spring-security4-2.1.0.jar` in the application's `lib` directory along with Spring and Spring-Security JARs. Or, if you use Maven, add the following to your `pom.xml`:
+Copy Waffle JARs, including `waffle-jna-2.1.1.jar`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar`, `slf4j-api-2.0.0-alpha1.jar` and `waffle-spring-security4-2.1.1.jar` in the application's `lib` directory along with Spring and Spring-Security JARs. Or, if you use Maven, add the following to your `pom.xml`:
 
-- For latest snapshot instead use `waffle-jna-2.1.1-SNAPSHOT`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar`, `slf4j-api-2.0.0-alpha1.jar` and `waffle-spring-security4-2.1.1-SNAPSHOT.jar`
+- For latest snapshot instead use `waffle-jna-2.1.2-SNAPSHOT`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar`, `slf4j-api-2.0.0-alpha1.jar` and `waffle-spring-security4-2.1.2-SNAPSHOT.jar`
 
 ``` xml
 <dependency>

--- a/Docs/tomcat/TomcatMixedSingleSignOnAndFormAuthenticatorValve.md
+++ b/Docs/tomcat/TomcatMixedSingleSignOnAndFormAuthenticatorValve.md
@@ -8,9 +8,9 @@ Configuring Tomcat
 
 The following steps are required to configure Tomcat with Waffle Mixed Authenticator. 
 
-Place  `waffle-jna-2.1.0.jar`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar`, `slf4j-api-2.0.0-alpha1.jar` and `waffle-tomcat[tomcat version]-2.1.0.jar` into your Tomcat's `lib` directory. It is *not* possible to place these files in `WEB-INF\lib`!
+Place  `waffle-jna-2.1.1.jar`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar`, `slf4j-api-2.0.0-alpha1.jar` and `waffle-tomcat[tomcat version]-2.1.1.jar` into your Tomcat's `lib` directory. It is *not* possible to place these files in `WEB-INF\lib`!
 
-- For latest snapshot instead use `waffle-jna-2.1.1-SNAPSHOT`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar`, `slf4j-api-2.0.0-alpha1.jar` and `waffle-tomcat[tomcat version]-2.1.1-SNAPSHOT.jar`
+- For latest snapshot instead use `waffle-jna-2.1.2-SNAPSHOT`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar`, `slf4j-api-2.0.0-alpha1.jar` and `waffle-tomcat[tomcat version]-2.1.2-SNAPSHOT.jar`
 
 If you are using Eclipse, you can see which files tomcat is importing by going to Java Recources: `src / Libraries / Apache Tomcat vx.x`. If you've placed it in the tomcat directory and still don't see it, restart Eclipse.
 

--- a/Docs/tomcat/TomcatSingleSignOnValve.md
+++ b/Docs/tomcat/TomcatSingleSignOnValve.md
@@ -8,9 +8,9 @@ Configuring Tomcat
 
 The following steps are required to configure Tomcat with Waffle authenticator. 
 
-Package Waffle JARs, including `waffle-jna-2.1.0.jar`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar`, `slf4j-api-2.0.0-alpha1.jar` and `waffle-tomcat[tomcat version]-2.1.0.jar` in the application's lib directory or copy them to Tomcat's lib.
+Package Waffle JARs, including `waffle-jna-2.1.1.jar`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar`, `slf4j-api-2.0.0-alpha1.jar` and `waffle-tomcat[tomcat version]-2.1.1.jar` in the application's lib directory or copy them to Tomcat's lib.
 
-- For latest snapshot instead use `waffle-jna-2.1.1-SNAPSHOT`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar`, `slf4j-api-2.0.0-alpha1.jar` and `waffle-tomcat[tomcat version]-2.1.1-SNAPSHOT.jar`
+- For latest snapshot instead use `waffle-jna-2.1.2-SNAPSHOT`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar`, `slf4j-api-2.0.0-alpha1.jar` and `waffle-tomcat[tomcat version]-2.1.2-SNAPSHOT.jar`
 
 Add a valve and a realm to the application context. For an application, modify `META-INF\context.xml`.
 

--- a/Docs/tomcat/TomcatWindowsLoginJAASAuthenticator.md
+++ b/Docs/tomcat/TomcatWindowsLoginJAASAuthenticator.md
@@ -8,9 +8,9 @@ Configuring Tomcat
 
 The following steps are required to configure Tomcat with Waffle authenticator. 
 
-Package Waffle JARs, including `waffle-jna-2.1.0.jar`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar`, and `slf4j-api-2.0.0-alpha1.jar` in the application's lib directory or copy them to Tomcat's lib.
+Package Waffle JARs, including `waffle-jna-2.1.1.jar`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar`, and `slf4j-api-2.0.0-alpha1.jar` in the application's lib directory or copy them to Tomcat's lib.
 
-- For latest snapshot instead use `waffle-jna-2.1.1-SNAPSHOT`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar` and `slf4j-api-2.0.0-alpha1.jar`.
+- For latest snapshot instead use `waffle-jna-2.1.2-SNAPSHOT`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar` and `slf4j-api-2.0.0-alpha1.jar`.
 
 Add a JAAS realm to the application context. Modify `META-INF\context.xml`.
  

--- a/Docs/wildfly/WildFlySecurityDomain.md
+++ b/Docs/wildfly/WildFlySecurityDomain.md
@@ -8,9 +8,9 @@ Configuring WildFly
 
 The following steps are required to configure WildFly with Waffle authenticator.
 
-Include the Waffle JARs, `waffle-jna-2.1.0.jar`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar`, and `slf4j-api-2.0.0-alpha1.jar` in your war's `WEB-INF\lib` directory. Alternatively you may place them in the `standalone/lib/ext` folder within the wildfly installation.
+Include the Waffle JARs, `waffle-jna-2.1.1.jar`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar`, and `slf4j-api-2.0.0-alpha1.jar` in your war's `WEB-INF\lib` directory. Alternatively you may place them in the `standalone/lib/ext` folder within the wildfly installation.
 
-- For latest snapshot instead use `waffle-jna-2.1.1-SNAPSHOT`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar` and `slf4j-api-2.0.0-alpha1.jar`.
+- For latest snapshot instead use `waffle-jna-2.1.2-SNAPSHOT`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar` and `slf4j-api-2.0.0-alpha1.jar`.
 
 Create a security domain using the Waffle `WindowsLoginModule`. It is recommended you keep the principal and role formats to `fqn`. 
 ```xml

--- a/Source/JNA/waffle-demo/pom.xml
+++ b/Source/JNA/waffle-demo/pom.xml
@@ -81,6 +81,16 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>${logback.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.sun.mail</groupId>
+                    <artifactId>javax.mail</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>edu.washington.cs.types.checker</groupId>
+                    <artifactId>checker-framework</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/Source/JNA/waffle-demo/pom.xml
+++ b/Source/JNA/waffle-demo/pom.xml
@@ -51,6 +51,7 @@
     </scm>
 
     <properties>
+        <logback.version>1.3.0-alpha5</logback.version>
         <servlet.version>4.0.3</servlet.version>
     </properties>
 
@@ -74,6 +75,12 @@
             <artifactId>jakarta.servlet-api</artifactId>
             <version>${servlet.version}</version>
             <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
         </dependency>
     </dependencies>
 

--- a/Source/JNA/waffle-demo/waffle-spring-boot-filter/pom.xml
+++ b/Source/JNA/waffle-demo/waffle-spring-boot-filter/pom.xml
@@ -37,6 +37,7 @@
 
     <properties>
         <jna.version>5.5.0</jna.version>
+        <logback.version>1.2.3</logback.version>
         <spring-boot.version>1.5.22.RELEASE</spring-boot.version>
     </properties>
 

--- a/Source/JNA/waffle-demo/waffle-spring-boot-filter2/pom.xml
+++ b/Source/JNA/waffle-demo/waffle-spring-boot-filter2/pom.xml
@@ -37,6 +37,7 @@
 
     <properties>
         <jna.version>5.5.0</jna.version>
+        <logback.version>1.2.3</logback.version>
         <spring-boot.version>2.1.11.RELEASE</spring-boot.version>
     </properties>
 


### PR DESCRIPTION
demos have logback configuration but don't necessarily have logback added.  This also makes it more clear as to what version is used with springboot as we now firmly define the older logback releases.