### PR TITLE
Jna Moved to Dependency Management, spring updates, spring boot 1 overrides

### DIFF
--- a/Source/JNA/waffle-demo/waffle-spring-boot-filter/pom.xml
+++ b/Source/JNA/waffle-demo/waffle-spring-boot-filter/pom.xml
@@ -37,9 +37,13 @@
 
     <properties>
         <!-- Dependencies -->
+        <jackson.version>2.8.11.4</jackson.version>
         <jna.version>5.5.0</jna.version>
-        <logback.version>1.2.3</logback.version>
+        <logback.version>1.1.11</logback.version>
+        <slf4j.version>1.7.26</slf4j.version>
+        <spring.version>4.3.26.RELEASE</spring.version>
         <spring-boot.version>1.5.22.RELEASE</spring-boot.version>
+        <tomcat.version>8.5.50</tomcat.version>
 
         <!-- Automatic Module Name for JPMS -->
         <module.name>waffle.spring.boot.filter.demo</module.name>
@@ -47,6 +51,11 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
             <!-- Resolve conflict between WAFFLE and Spring Boot dependency version by forcing jna version -->
             <dependency>
                 <groupId>net.java.dev.jna</groupId>
@@ -57,6 +66,61 @@
                 <groupId>net.java.dev.jna</groupId>
                 <artifactId>jna-platform</artifactId>
                 <version>${jna.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-aop</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-beans</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-core</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-context</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-expression</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-web</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-webmvc</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat</groupId>
+                <artifactId>tomcat-annotations-api</artifactId>
+                <version>${tomcat.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>${tomcat.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-el</artifactId>
+                <version>${tomcat.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-websocket</artifactId>
+                <version>${tomcat.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>

--- a/Source/JNA/waffle-demo/waffle-spring-boot-filter2/pom.xml
+++ b/Source/JNA/waffle-demo/waffle-spring-boot-filter2/pom.xml
@@ -55,7 +55,7 @@
             </dependency>
             <dependency>
                 <groupId>net.java.dev.jna</groupId>
-                <artifactId>jna</artifactId>
+                <artifactId>jna-platform</artifactId>
                 <version>${jna.version}</version>
             </dependency>
             <dependency>

--- a/Source/JNA/waffle-demo/waffle-spring-boot-filter2/pom.xml
+++ b/Source/JNA/waffle-demo/waffle-spring-boot-filter2/pom.xml
@@ -39,7 +39,7 @@
         <!-- Dependencies -->
         <jna.version>5.5.0</jna.version>
         <logback.version>1.2.3</logback.version>
-        <spring-boot.version>2.2.2.RELEASE</spring-boot.version>
+        <spring-boot.version>2.2.4.RELEASE</spring-boot.version>
 
         <!-- Automatic Module Name for JPMS -->
         <module.name>waffle.spring.boot.filter2.demo</module.name>

--- a/Source/JNA/waffle-jna/pom.xml
+++ b/Source/JNA/waffle-jna/pom.xml
@@ -47,16 +47,30 @@
         <module.name>waffle.jna</module.name>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- Due to critical nature of WAFFLE jna usage, set to dependency management to help influence usage -->
+            <dependency>
+                <groupId>net.java.dev.jna</groupId>
+                <artifactId>jna</artifactId>
+                <version>${jna.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.java.dev.jna</groupId>
+                <artifactId>jna-platform</artifactId>
+                <version>${jna.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna</artifactId>
-            <version>${jna.version}</version>
         </dependency>
         <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna-platform</artifactId>
-            <version>${jna.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.servlet</groupId>

--- a/Source/JNA/waffle-spring-boot/pom.xml
+++ b/Source/JNA/waffle-spring-boot/pom.xml
@@ -39,6 +39,7 @@
     <properties>
         <!-- Dependencies -->
         <jna.version>5.5.0</jna.version>
+        <slf4j.version>1.7.26</slf4j.version>
         <spring-boot.version>1.5.22.RELEASE</spring-boot.version>
 
         <!-- Automatic Module Name for JPMS -->

--- a/Source/JNA/waffle-spring-boot/pom.xml
+++ b/Source/JNA/waffle-spring-boot/pom.xml
@@ -40,6 +40,7 @@
         <!-- Dependencies -->
         <jna.version>5.5.0</jna.version>
         <slf4j.version>1.7.26</slf4j.version>
+        <spring.version>4.3.26.RELEASE</spring.version>
         <spring-boot.version>1.5.22.RELEASE</spring-boot.version>
 
         <!-- Automatic Module Name for JPMS -->
@@ -63,6 +64,36 @@
                 <groupId>net.java.dev.jna</groupId>
                 <artifactId>jna-platform</artifactId>
                 <version>${jna.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-aop</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-beans</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-core</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-context</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-expression</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-web</artifactId>
+                <version>${spring.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>

--- a/Source/JNA/waffle-spring-boot/pom.xml
+++ b/Source/JNA/waffle-spring-boot/pom.xml
@@ -60,7 +60,7 @@
             </dependency>
             <dependency>
                 <groupId>net.java.dev.jna</groupId>
-                <artifactId>jna</artifactId>
+                <artifactId>jna-platform</artifactId>
                 <version>${jna.version}</version>
             </dependency>
             <dependency>

--- a/Source/JNA/waffle-spring-boot2/pom.xml
+++ b/Source/JNA/waffle-spring-boot2/pom.xml
@@ -39,6 +39,7 @@
     <properties>
         <!-- Dependencies -->
         <jna.version>5.5.0</jna.version>
+        <slf4j.version>1.7.30</slf4j.version>
         <spring-boot.version>2.2.4.RELEASE</spring-boot.version>
 
         <!-- Automatic Module Name for JPMS -->

--- a/Source/JNA/waffle-spring-boot2/pom.xml
+++ b/Source/JNA/waffle-spring-boot2/pom.xml
@@ -60,7 +60,7 @@
             </dependency>
             <dependency>
                 <groupId>net.java.dev.jna</groupId>
-                <artifactId>jna</artifactId>
+                <artifactId>jna-platform</artifactId>
                 <version>${jna.version}</version>
             </dependency>
             <dependency>

--- a/Source/JNA/waffle-spring-boot2/pom.xml
+++ b/Source/JNA/waffle-spring-boot2/pom.xml
@@ -39,7 +39,7 @@
     <properties>
         <!-- Dependencies -->
         <jna.version>5.5.0</jna.version>
-        <spring-boot.version>2.2.2.RELEASE</spring-boot.version>
+        <spring-boot.version>2.2.4.RELEASE</spring-boot.version>
 
         <!-- Automatic Module Name for JPMS -->
         <module.name>waffle.spring.boot2</module.name>

--- a/Source/JNA/waffle-spring-security4/pom.xml
+++ b/Source/JNA/waffle-spring-security4/pom.xml
@@ -39,7 +39,7 @@
     <properties>
         <!-- Dependencies -->
         <servlet.version>4.0.3</servlet.version>
-        <spring.version>4.3.25.RELEASE</spring.version>
+        <spring.version>4.3.26.RELEASE</spring.version>
         <spring.security.version>4.2.13.RELEASE</spring.security.version>
 
         <!-- Automatic Module Name for JPMS -->

--- a/Source/JNA/waffle-spring-security5/pom.xml
+++ b/Source/JNA/waffle-spring-security5/pom.xml
@@ -39,7 +39,7 @@
     <properties>
         <!-- Dependencies -->
         <servlet.version>4.0.3</servlet.version>
-        <spring.version>5.2.2.RELEASE</spring.version>
+        <spring.version>5.2.3.RELEASE</spring.version>
         <spring.security.version>5.2.1.RELEASE</spring.security.version>
 
         <!-- Automatic Module Name for JPMS -->


### PR DESCRIPTION
Jna is too critical for waffle to not be in dependency management.  Moved there overall.  Update spring modules.  Start controlling versions on now unsupported spring boot 1 since spring 4 is still going to be supported until end of 2020.  We will continue to support it as well for legacy usage.  Ensure vulnerability free versions showing up in the build in that case.