### PR TITLE
docs(Troubleshooting): setspn machine/virtual-host

### DIFF
--- a/Docs/Troubleshooting.md
+++ b/Docs/Troubleshooting.md
@@ -17,7 +17,7 @@ Troubleshooting Kerberos
 Typical configurations to check are:
 
 1. The `application` is running as a `service`
-1. The `service` is running as a `user` on the same domain as the `machine`
+1. The `service` is running as a `user` on the same domain as the `machine` accessible via webserver as `virtual-host`
 1. The `user` has privileges for Kerberos delegation
 
 To check the current privileges, run:
@@ -28,6 +28,7 @@ setspn -L username
 To add privileges for the current user, run
 ```
 setspn -A PROTOCOL/machine:port username
+setspn -A PROTOCOL/virtual-host:port username
 ```
 
 Useful Troubleshooting Resources:


### PR DESCRIPTION
`setspn` needs to be invoked for the machine name as well as the virtual-host configured in the webserver.

Ref: https://support.microsoft.com/en-gb/help/929650/how-to-use-spns-when-you-configure-web-applications-that-are-hosted-on