### PR TITLE
[jdk] Stop using deprecated interface and just directly configure group and update changelog

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: java
 
 jdk:
+  - openjdk15
+  - openjdk14
   - openjdk11
   - openjdk8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,15 @@
-2.3.0 (in-progress)
+3.0.0 (in-progress)
 ===================
+* Support different cache solutions (default is caffeine cache) through service loader using '/META-INF/services/waffle.cache.CacheSupplier' pointing to your cache solution.
+* Remove use of Group interface and directly use our implementation to allow build on jdk14/15 (not confirmed JAAS works, just compiles)
+* Cleanup error prone code usage resulting in header treatment without training '\n'
+
+2.3.0 (6/19/2020)
+=================
 * Introduction of waffle-tomcat10 module
 * Introduction of waffle-jna-jakarta module for usage with jakarta package rename direct usage
 
 * [#956](https://github.com/Waffle/waffle/pull/956): Fix DelegatingNegotiateSecurityFilter [@cmolodo](https://github.com/cmolodo) - Fixes #453
-
-2.2.2 (in-progress)
-===================
-* TODO
 
 2.2.1 (1/26/2020)
 ================

--- a/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/jaas/GroupPrincipal.java
+++ b/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/jaas/GroupPrincipal.java
@@ -12,7 +12,6 @@
 package waffle.jaas;
 
 import java.security.Principal;
-import java.security.acl.Group;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -24,9 +23,7 @@ import java.util.Map;
  *
  * @author rockchip[dot]tv[at]gmail[dot]com
  */
-// TODO: Review replacement options for 'Group' as it is officially removed from jdk 14. See
-// https://bugs.openjdk.java.net/browse/JDK-8217101?attachmentOrder=desc.
-public class GroupPrincipal extends UserPrincipal implements Group {
+public class GroupPrincipal extends UserPrincipal {
 
     /** The Constant serialVersionUID. */
     private static final long serialVersionUID = 1L;
@@ -55,7 +52,6 @@ public class GroupPrincipal extends UserPrincipal implements Group {
         return this.fqn;
     }
 
-    @Override
     public boolean addMember(final Principal user) {
         final boolean isMember = this.members.containsKey(user);
         if (!isMember) {
@@ -64,14 +60,13 @@ public class GroupPrincipal extends UserPrincipal implements Group {
         return isMember;
     }
 
-    @Override
     public boolean isMember(final Principal user) {
         boolean isMember = this.members.containsKey(user);
         if (!isMember) {
             final Collection<Principal> values = this.members.values();
             for (final Principal principal : values) {
-                if (principal instanceof Group) {
-                    final Group group = (Group) principal;
+                if (principal instanceof GroupPrincipal) {
+                    final GroupPrincipal group = (GroupPrincipal) principal;
                     isMember = group.isMember(user);
                     if (isMember) {
                         break;
@@ -82,12 +77,10 @@ public class GroupPrincipal extends UserPrincipal implements Group {
         return isMember;
     }
 
-    @Override
     public Enumeration<? extends Principal> members() {
         return Collections.enumeration(this.members.values());
     }
 
-    @Override
     public boolean removeMember(final Principal user) {
         final Object prev = this.members.remove(user);
         return prev != null;

--- a/Source/JNA/waffle-jna/src/main/java/waffle/jaas/GroupPrincipal.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/jaas/GroupPrincipal.java
@@ -12,7 +12,6 @@
 package waffle.jaas;
 
 import java.security.Principal;
-import java.security.acl.Group;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -24,9 +23,7 @@ import java.util.Map;
  *
  * @author rockchip[dot]tv[at]gmail[dot]com
  */
-// TODO: Review replacement options for 'Group' as it is officially removed from jdk 14. See
-// https://bugs.openjdk.java.net/browse/JDK-8217101?attachmentOrder=desc.
-public class GroupPrincipal extends UserPrincipal implements Group {
+public class GroupPrincipal extends UserPrincipal {
 
     /** The Constant serialVersionUID. */
     private static final long serialVersionUID = 1L;
@@ -55,7 +52,6 @@ public class GroupPrincipal extends UserPrincipal implements Group {
         return this.fqn;
     }
 
-    @Override
     public boolean addMember(final Principal user) {
         final boolean isMember = this.members.containsKey(user);
         if (!isMember) {
@@ -64,14 +60,13 @@ public class GroupPrincipal extends UserPrincipal implements Group {
         return isMember;
     }
 
-    @Override
     public boolean isMember(final Principal user) {
         boolean isMember = this.members.containsKey(user);
         if (!isMember) {
             final Collection<Principal> values = this.members.values();
             for (final Principal principal : values) {
-                if (principal instanceof Group) {
-                    final Group group = (Group) principal;
+                if (principal instanceof GroupPrincipal) {
+                    final GroupPrincipal group = (GroupPrincipal) principal;
                     isMember = group.isMember(user);
                     if (isMember) {
                         break;
@@ -82,12 +77,10 @@ public class GroupPrincipal extends UserPrincipal implements Group {
         return isMember;
     }
 
-    @Override
     public Enumeration<? extends Principal> members() {
         return Collections.enumeration(this.members.values());
     }
 
-    @Override
     public boolean removeMember(final Principal user) {
         final Object prev = this.members.remove(user);
         return prev != null;


### PR DESCRIPTION
group has been deprecated for years, it's deleted from newer jdks.  Since we only use that interface but otherwise provide the implementation, simply stop using it and continue as is.  This is untested as far as jdk 14/15 goes but all tests do pass.  Additional testing will be confirmed prior to release.