### PR TITLE
waffle-spring-filter: spring security 4 compatibility

### DIFF
--- a/Source/JNA/waffle-demo/waffle-spring-filter/src/main/webapp/WEB-INF/waffle-filter.xml
+++ b/Source/JNA/waffle-demo/waffle-spring-filter/src/main/webapp/WEB-INF/waffle-filter.xml
@@ -52,7 +52,7 @@
 
     <!-- spring filter entry point -->
     <sec:http entry-point-ref="negotiateSecurityFilterEntryPoint">
-        <sec:intercept-url pattern="/**" access="IS_AUTHENTICATED_FULLY" />
+        <sec:intercept-url pattern="/**" access="fullyAuthenticated" />
         <sec:custom-filter ref="waffleNegotiateSecurityFilter" position="BASIC_AUTH_FILTER" />
     </sec:http>
 


### PR DESCRIPTION
When starting the sample application, the following error message appeared: java.lang.IllegalArgumentException: Failed to evaluate expression 'IS_AUTHENTICATED_FULLY'

The problem is caused by the fact that Spring Security 4 is using the expression syntax by default. Thus in the waffle-filter.xml configuration "IS_AUTHENTICATED_FULLY" needs to be replaced by "fullyAuthenticated".