### PR TITLE
Fix WindowsLoginModule.java to be JAAS and therefore Tomcat compatible

### DIFF
--- a/Source/JNA/waffle-jna/src/main/java/waffle/jaas/WindowsLoginModule.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/jaas/WindowsLoginModule.java
@@ -166,6 +166,7 @@ public class WindowsLoginModule implements LoginModule {
                 // create the group principal and add roles as members of the group
                 final GroupPrincipal groupList = new GroupPrincipal("Roles");
                 for (final IWindowsAccount group : windowsIdentity.getGroups()) {
+                    this.principals.addAll(getRolePrincipals(group, this.roleFormat));
                     for (final Principal role : WindowsLoginModule.getRolePrincipals(group, this.roleFormat)) {
                         WindowsLoginModule.LOGGER.debug(" group: {}", role.getName());
                         groupList.addMember(new RolePrincipal(role.getName()));

--- a/Source/JNA/waffle-jna/src/test/java/waffle/jaas/WindowsLoginModuleTest.java
+++ b/Source/JNA/waffle-jna/src/test/java/waffle/jaas/WindowsLoginModuleTest.java
@@ -153,7 +153,9 @@ public class WindowsLoginModuleTest {
         final Set<Principal> principals = new LinkedHashSet<>();
         principals.add(new UserPrincipal("FQN"));
         final GroupPrincipal group = new GroupPrincipal("Roles");
-        group.addMember(new RolePrincipal("WindowsGroup"));
+        final RolePrincipal role = new RolePrincipal("WindowsGroup");
+        group.addMember(role);
+        principals.add(role);
         principals.add(group);
         Whitebox.setInternalState(this.loginModule, principals);
         this.loginModule.initialize(this.subject, this.callbackHandler, null, this.options);


### PR DESCRIPTION
The modifications made to this class on 16 October 2016 broke JAAS compliance and Tomcat cannot resolve the roles (from Windows groups) from the non-compliant subject.
I have re-introduced the line to add all roles as principles, but I have not removed the non-standard hack that was introduced, as I do not know who is actually reliant on this hack.
Therefore the roles will be listed as RolePrinciples, whilst there will also be a GroupPrinciple named "Roles" with a list of the RolePrinciples.
Refer to issue #1114.