### PR TITLE
Interim/windows login module

### DIFF
--- a/Source/JNA/waffle-jna/src/main/java/waffle/jaas/GroupPrincipal.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/jaas/GroupPrincipal.java
@@ -34,7 +34,11 @@ import java.util.Map;
  * Group principal.
  *
  * @author rockchip[dot]tv[at]gmail[dot]com
+ * @deprecated This class is deprecated as hiding a principal inside
+ * another principal is not JAAS compliant.  Use the Principals in the
+ * Subject to directly enrol groups or roles by name.
  */
+@Deprecated
 public class GroupPrincipal extends UserPrincipal {
 
     /** The Constant serialVersionUID. */

--- a/Source/JNA/waffle-jna/src/main/java/waffle/jaas/WindowsLoginModule.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/jaas/WindowsLoginModule.java
@@ -166,6 +166,7 @@ public class WindowsLoginModule implements LoginModule {
                 // create the group principal and add roles as members of the group
                 final GroupPrincipal groupList = new GroupPrincipal("Roles");
                 for (final IWindowsAccount group : windowsIdentity.getGroups()) {
+                    this.principals.addAll(getRolePrincipals(group, this.roleFormat));
                     for (final Principal role : WindowsLoginModule.getRolePrincipals(group, this.roleFormat)) {
                         WindowsLoginModule.LOGGER.debug(" group: {}", role.getName());
                         groupList.addMember(new RolePrincipal(role.getName()));

--- a/Source/JNA/waffle-jna/src/test/java/waffle/jaas/WindowsLoginModuleTest.java
+++ b/Source/JNA/waffle-jna/src/test/java/waffle/jaas/WindowsLoginModuleTest.java
@@ -153,7 +153,9 @@ public class WindowsLoginModuleTest {
         final Set<Principal> principals = new LinkedHashSet<>();
         principals.add(new UserPrincipal("FQN"));
         final GroupPrincipal group = new GroupPrincipal("Roles");
-        group.addMember(new RolePrincipal("WindowsGroup"));
+        final RolePrincipal role = new RolePrincipal("WindowsGroup");
+        group.addMember(role);
+        principals.add(role);
         principals.add(group);
         Whitebox.setInternalState(this.loginModule, principals);
         this.loginModule.initialize(this.subject, this.callbackHandler, null, this.options);

--- a/Source/JNA/waffle-tests/src/test/java/waffle/jaas/WindowsLoginModuleTests.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/jaas/WindowsLoginModuleTests.java
@@ -242,15 +242,15 @@ public class WindowsLoginModuleTests {
         Assertions.assertTrue(this.loginModule.commit());
 
         Assertions.assertTrue(subject.getPrincipals().size() >= 3);
+        Assertions.assertTrue(
+                subject.getPrincipals().contains(new UserPrincipal(WindowsAccountImpl.getCurrentUsername())));
         int size = 0;
         for (final Principal principal : subject.getPrincipals()) {
             if (principal instanceof RolePrincipal) {
                 if (principal.getName().startsWith("S-")) {
                     size++;
                 }
-            } else if (principal instanceof UserPrincipal) {
-                Assertions.assertTrue(principal.getName().equals(WindowsAccountImpl.getCurrentUsername()));
-            }
+            } 
         }
         Assertions.assertEquals(2, size);
     }

--- a/Source/JNA/waffle-tests/src/test/java/waffle/jaas/WindowsLoginModuleTests.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/jaas/WindowsLoginModuleTests.java
@@ -275,7 +275,7 @@ public class WindowsLoginModuleTests {
         Assertions.assertTrue(this.loginModule.login());
         Assertions.assertTrue(this.loginModule.commit());
 
-        Assertions.assertTrue(4, subject.getPrincipals().size() >= 4);
+        Assertions.assertTrue(subject.getPrincipals().size() >= 4);
         Assertions.assertTrue(subject.getPrincipals().contains(new RolePrincipal("Everyone")));
         Assertions.assertTrue(subject.getPrincipals().contains(new RolePrincipal("Users")));
         Assertions.assertTrue(subject.getPrincipals().contains(new RolePrincipal("Group 1")));

--- a/Source/JNA/waffle-tests/src/test/java/waffle/jaas/WindowsLoginModuleTests.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/jaas/WindowsLoginModuleTests.java
@@ -104,14 +104,8 @@ public class WindowsLoginModuleTests {
         Assertions.assertTrue(this.loginModule.login());
         Assertions.assertEquals(0, subject.getPrincipals().size());
         Assertions.assertTrue(this.loginModule.commit());
-        Assertions.assertEquals(2, subject.getPrincipals().size());
-        Assertions.assertTrue(subject.getPrincipals().contains(new GroupPrincipal("Roles")));
-        for (final Principal principal : subject.getPrincipals()) {
-            if (principal instanceof GroupPrincipal) {
-                Assertions.assertTrue(((GroupPrincipal) principal).isMember(new RolePrincipal("Everyone")));
-                Assertions.assertTrue(((GroupPrincipal) principal).isMember(new RolePrincipal("Users")));
-            }
-        }
+        Assertions.assertTrue(subject.getPrincipals().contains(new RolePrincipal("Everyone")));
+        Assertions.assertTrue(subject.getPrincipals().contains(new RolePrincipal("Users")));
         Assertions.assertTrue(
                 subject.getPrincipals().contains(new UserPrincipal(WindowsAccountImpl.getCurrentUsername())));
         Assertions.assertTrue(this.loginModule.logout());
@@ -191,26 +185,21 @@ public class WindowsLoginModuleTests {
         Assertions.assertTrue(this.loginModule.login());
         Assertions.assertTrue(this.loginModule.commit());
 
-        Assertions.assertEquals(2, subject.getPrincipals().size());
-        Assertions.assertTrue(subject.getPrincipals().contains(new GroupPrincipal("Roles")));
+        Assertions.assertTrue(subject.getPrincipals().size() >= 5);
+        Assertions.assertTrue(subject.getPrincipals().contains(new RolePrincipal("Everyone")));
+        Assertions.assertTrue(subject.getPrincipals().contains(new RolePrincipal("Users")));
+        int roleSize = 0;
+        int roleSidSize = 0;
         for (final Principal principal : subject.getPrincipals()) {
-            if (principal instanceof GroupPrincipal) {
-                int size = 0;
-                int sidSize = 0;
-                final List<? extends Principal> groupPrincipals = Collections
-                        .list(((GroupPrincipal) principal).members());
-                for (Principal groupPrincipal : groupPrincipals) {
-                    if (groupPrincipal.getName().startsWith("S-")) {
-                        sidSize++;
-                    }
-                    size++;
+            if (principal instanceof RolePrincipal) {
+                if (principal.getName().startsWith("S-")) {
+                    roleSidSize++;
                 }
-                Assertions.assertEquals(4, size);
-                Assertions.assertTrue(((GroupPrincipal) principal).isMember(new RolePrincipal("Everyone")));
-                Assertions.assertTrue(((GroupPrincipal) principal).isMember(new RolePrincipal("Users")));
-                Assertions.assertEquals(2, sidSize);
+                roleSize++;
             }
         }
+        Assertions.assertEquals(4, roleSize);
+        Assertions.assertEquals(2, roleSidSize);
     }
 
     /**
@@ -252,23 +241,18 @@ public class WindowsLoginModuleTests {
         Assertions.assertTrue(this.loginModule.login());
         Assertions.assertTrue(this.loginModule.commit());
 
-        Assertions.assertEquals(2, subject.getPrincipals().size());
-        Assertions.assertTrue(subject.getPrincipals().contains(new GroupPrincipal("Roles")));
+        Assertions.assertTrue(subject.getPrincipals().size() >= 3);
+        int size = 0;
         for (final Principal principal : subject.getPrincipals()) {
-            if (principal instanceof GroupPrincipal) {
-                int size = 0;
-                final List<? extends Principal> groupPrincipals = Collections
-                        .list(((GroupPrincipal) principal).members());
-                for (Principal groupPrincipal : groupPrincipals) {
-                    if (groupPrincipal.getName().startsWith("S-")) {
-                        size++;
-                    }
+            if (principal instanceof RolePrincipal) {
+                if (principal.getName().startsWith("S-")) {
+                    size++;
                 }
-                Assertions.assertEquals(2, size);
-            } else {
+            } else if (principal instanceof UserPrincipal) {
                 Assertions.assertTrue(principal.getName().equals(WindowsAccountImpl.getCurrentUsername()));
             }
         }
+        Assertions.assertEquals(2, size);
     }
 
     /**
@@ -291,17 +275,10 @@ public class WindowsLoginModuleTests {
         Assertions.assertTrue(this.loginModule.login());
         Assertions.assertTrue(this.loginModule.commit());
 
-        Assertions.assertEquals(2, subject.getPrincipals().size());
-        Assertions.assertTrue(subject.getPrincipals().contains(new GroupPrincipal("Roles")));
-        for (final Principal principal : subject.getPrincipals()) {
-            if (principal instanceof GroupPrincipal) {
-                int size = Collections.list(((GroupPrincipal) principal).members()).size();
-                Assertions.assertEquals(3, size);
-                Assertions.assertTrue(((GroupPrincipal) principal).isMember(new RolePrincipal("Everyone")));
-                Assertions.assertTrue(((GroupPrincipal) principal).isMember(new RolePrincipal("Users")));
-                Assertions.assertTrue(((GroupPrincipal) principal).isMember(new RolePrincipal("Group 1")));
-            }
-        }
+        Assertions.assertTrue(4, subject.getPrincipals().size() >= 4);
+        Assertions.assertTrue(subject.getPrincipals().contains(new RolePrincipal("Everyone")));
+        Assertions.assertTrue(subject.getPrincipals().contains(new RolePrincipal("Users")));
+        Assertions.assertTrue(subject.getPrincipals().contains(new RolePrincipal("Group 1")));
     }
 
     /**
@@ -322,14 +299,9 @@ public class WindowsLoginModuleTests {
         Assertions.assertTrue(this.loginModule.login());
         Assertions.assertEquals(0, subject.getPrincipals().size());
         Assertions.assertTrue(this.loginModule.commit());
-        Assertions.assertEquals(2, subject.getPrincipals().size());
-        Assertions.assertTrue(subject.getPrincipals().contains(new GroupPrincipal("Roles")));
-        for (final Principal principal : subject.getPrincipals()) {
-            if (principal instanceof GroupPrincipal) {
-                Assertions.assertTrue(((GroupPrincipal) principal).isMember(new RolePrincipal("Everyone")));
-                Assertions.assertTrue(((GroupPrincipal) principal).isMember(new RolePrincipal("Users")));
-            }
-        }
+        Assertions.assertTrue(subject.getPrincipals().size() >= 3);
+        Assertions.assertTrue(subject.getPrincipals().contains(new RolePrincipal("Everyone")));
+        Assertions.assertTrue(subject.getPrincipals().contains(new RolePrincipal("Users")));
         this.loginModule.setAllowGuestLogin(false);
         final Throwable exception = Assertions.assertThrows(LoginException.class, () -> {
             Assertions.assertTrue(this.loginModule.login());


### PR DESCRIPTION
This is interim code which fixes the problem with the WindowsLoginModule not being compatible with JAAS or Tomcat, but does not remove the incorrect modification (for WildFly up to version 10), which broke the compatibility with JAAS and Tomcat.