### PR TITLE
Dispose of guest WindowsIdentity when guest login is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Drop JAAS wildfly 10 support as previously deprecated and proper solution in place for newer wildflys.
 * Drop Spring Boot 1 support as end of life for long time and underlying spring 4 now also end of life.
 * Drop Spring Security 4 support as end of life
+* Dispose of guest WindowsIdentity in NegotiateSecurityFilter for Spring Security when guest login is disabled to avoid leaking the object
 
 3.0.0 (12/28/2020)
 ==================

--- a/Source/JNA/waffle-spring-security5/src/main/java/waffle/spring/NegotiateSecurityFilter.java
+++ b/Source/JNA/waffle-spring-security5/src/main/java/waffle/spring/NegotiateSecurityFilter.java
@@ -118,14 +118,14 @@ public class NegotiateSecurityFilter extends GenericFilterBean {
                 return;
             }
 
-            if (!this.allowGuestLogin && windowsIdentity.isGuest()) {
-                NegotiateSecurityFilter.LOGGER.warn("guest login disabled: {}", windowsIdentity.getFqn());
-                this.sendUnauthorized(response, true);
-                return;
-            }
-
             IWindowsImpersonationContext ctx = null;
             try {
+                if (!this.allowGuestLogin && windowsIdentity.isGuest()) {
+                    NegotiateSecurityFilter.LOGGER.warn("guest login disabled: {}", windowsIdentity.getFqn());
+                    this.sendUnauthorized(response, true);
+                    return;
+                }
+
                 NegotiateSecurityFilter.LOGGER.debug("logged in user: {} ({})", windowsIdentity.getFqn(),
                         windowsIdentity.getSidString());
 


### PR DESCRIPTION
The same fix was done for `waffle.servlet.NegotiateSecurityFilter` and `waffle.jaas.WindowsLoginModule` in commit 8339251e.