### PR TITLE
Downgrade slf4j to 1.7.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,3 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
-  ignore:
-    - dependency-name: org.slf4j:*
-      update-types: ["version-update:semver-major", "version-update:semver-minor"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,6 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  ignore:
+    - dependency-name: org.slf4j:*
+      update-types: ["version-update:semver-major", "version-update:semver-minor"]

--- a/Source/JNA/pom.xml
+++ b/Source/JNA/pom.xml
@@ -174,7 +174,7 @@
         <jopt-simple.version>5.0.4</jopt-simple.version>
         <jsr305.version>3.0.2</jsr305.version>
         <junit.version>5.8.2</junit.version>
-        <slf4j.version>2.0.0-alpha5</slf4j.version>
+        <slf4j.version>1.7.32</slf4j.version>
 
         <!-- Plugins -->
         <antrun.plugin>3.0.0</antrun.plugin>

--- a/Source/JNA/waffle-demo/pom.xml
+++ b/Source/JNA/waffle-demo/pom.xml
@@ -63,7 +63,7 @@
 
     <properties>
         <!-- Dependencies -->
-        <logback.version>1.3.0-alpha10</logback.version>
+        <logback.version>1.2.7</logback.version>
         <servlet.version>4.0.4</servlet.version>
 
         <!-- Plugins -->

--- a/Source/JNA/waffle-demo/waffle-spring-boot-filter2/pom.xml
+++ b/Source/JNA/waffle-demo/waffle-spring-boot-filter2/pom.xml
@@ -50,7 +50,7 @@
     <properties>
         <!-- Dependencies -->
         <jna.version>5.10.0</jna.version>
-        <logback.version>1.2.6</logback.version>
+        <logback.version>1.2.7</logback.version>
         <spring-boot.version>2.6.1</spring-boot.version>
 
         <!-- Automatic Module Name for JPMS -->

--- a/Source/JNA/waffle-distro/pom.xml
+++ b/Source/JNA/waffle-distro/pom.xml
@@ -52,7 +52,7 @@
         <!-- Dependencies -->
         <caffeine.version>2.9.2</caffeine.version>
         <jna.version>5.10.0</jna.version>
-        <logback.version>1.3.0-alpha10</logback.version>
+        <logback.version>1.2.7</logback.version>
 
         <!-- Automatic Module Name for JPMS -->
         <module.name>waffle.distro</module.name>


### PR DESCRIPTION
Versions 1.8.x and 2.x are incompatible with older versions. The vast majority of libraries are still using 1.7.x because the 2.x releases are still in beta.

This PR downgrades SLF4J to the latest 1.7.x and updates the dependabot configuration to prevent upgrades to the 1.8.x and 2.x versions.