### PR TITLE
[docs] Remove version strings and point to distro instead

### DIFF
--- a/Docs/GettingStartedWithWaffleAPI.md
+++ b/Docs/GettingStartedWithWaffleAPI.md
@@ -33,13 +33,13 @@ set windowsAuthProviderImpl = CreateObject("Waffle.Windows.AuthProvider")
 Getting Started in Java
 -----------------------
 
-Add `waffle-jna-2.1.0.jar`, `caffeine-2.8.0`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar`, and `slf4j-api-2.0.0-alpha1.jar` to your `CLASSPATH` or, if you use Maven, add the following to your `pom.xml`.
+Add `waffle-jna.jar`, `caffeine`, `jna.jar`, `jna-platform.jar`, and `slf4j-api.jar` to your `CLASSPATH` or, if you use Maven, add the following to your `pom.xml`.
 
-- For latest snapshot instead use `waffle-jna-2.1.1-SNAPSHOT`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar` and `slf4j-api-2.0.0-alpha1.jar`.
+- Use specific versions as bundled in waffle-distro
 
 ``` xml
 <properties>
-    <waffle.version>1.8.2</waffle.version>
+    <waffle.version>3.1.0</waffle.version>
 </properties>
 
 <dependency>

--- a/Docs/MavenReleaseGuide.md
+++ b/Docs/MavenReleaseGuide.md
@@ -6,7 +6,7 @@ This is a guide for WAFFLE developers hoping to publish a release to Maven Centr
 Building with Maven
 -------------------
 
-In order to build with [Maven][], you'll need Java 8+ and [Maven][] 3.6.3+.  Download and install them, and then run `mvn --version` to check that it's working.  If you don't already have it, also get Git and a clone of the WAFFLE repository.  Once you have this, run `mvn package` in the `Source/JNA/waffle-parent` directory.  This command compiles, unit tests, and JARs all of the WAFFLE components that are currently Maven-enabled.
+In order to build with [Maven][], you'll need Java 11+ and [Maven][] 3.8.6+.  Download and install them, and then run `mvn --version` to check that it's working.  If you don't already have it, also get Git and a clone of the WAFFLE repository.  Once you have this, run `mvn package` in the `Source/JNA/waffle-parent` directory.  This command compiles, unit tests, and JARs all of the WAFFLE components that are currently Maven-enabled.
 
 If you don't want to run the unit tests (which can be useful if you're trying to compile on a non-Windows platform), use `mvn package -DskipTests=true` instead.  This isn't recommended for release builds.
 

--- a/Docs/ServletSingleSignOnSecurityFilter.md
+++ b/Docs/ServletSingleSignOnSecurityFilter.md
@@ -10,9 +10,9 @@ Configuring Web Servers
 
 The following steps are required to configure a web server with the Waffle Servlet Security Filter. These instructions work for Tomcat, Jetty, WebSphere and possibly others.
 
-Package Waffle JARs (1.8.4), including `waffle-jna-2.1.1.jar`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar` and `slf4j-2.0.0-alpha1.jar` in the application's `lib` directory or copy them to your web server's lib. 
+Package Waffle JARs, including `waffle-jna.jar`, `caffeine.jar`, `jna.jar`, `jna-platform.jar` and `slf4j.jar` in the application's `lib` directory or copy them to your web server's lib. 
 
-- For latest snapshot instead use `waffle-jna-2.1.2-SNAPSHOT`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar` and `slf4j-2.0.0-alpha1.jar`.
+- Use specific versions as bundled in waffle-distro
 
 Add a security filter to `WEB-INF\web.xml` of your application. 
 

--- a/Docs/spring/SpringSecurityAuthenticationProvider.md
+++ b/Docs/spring/SpringSecurityAuthenticationProvider.md
@@ -28,16 +28,16 @@ We'll assume that Spring-Security is configured via `web.xml` with a filter chai
 </listener>
 ```
 
-Copy Waffle JARs, including `waffle-jna-2.1.1.jar`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar`, `slf4j-api-2.0.0-alpha1.jar` and `waffle-spring-security4-2.1.1.jar` in the application's `lib` directory along with Spring and Spring-Security JARs. Or, if you use Maven, add the following to your `pom.xml`:
+Copy Waffle JARs, including `waffle-jna.jar`, `caffeine.jar`, `jna.jar`, `jna-platform.jar`, `slf4j-api.jar` and `waffle-spring-security5.jar` in the application's `lib` directory along with Spring and Spring-Security JARs. Or, if you use Maven, add the following to your `pom.xml`:
 
-- For latest snapshot instead use `waffle-jna-2.1.2-SNAPSHOT`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar`, `slf4j-api-2.0.0-alpha1.jar` and `waffle-spring-security4-2.1.2-SNAPSHOT.jar`
+- Use specific versions as bundled in waffle-distro
 
 ``` xml
 <dependency>
     <groupId>com.github.dblock.waffle</groupId>
-    <artifactId>waffle-spring-security4</artifactId>
+    <artifactId>waffle-spring-security5</artifactId>
     <version>${waffle.version}</version>
-</dependency>            
+</dependency>
 ```
 
 Declare a Waffle Windows authentication provider. This is the link between Waffle and the operating system. 

--- a/Docs/spring/SpringSecuritySingleSignOnFilter.md
+++ b/Docs/spring/SpringSecuritySingleSignOnFilter.md
@@ -28,9 +28,9 @@ We'll assume that Spring-Security is configured via `web.xml` with a filter chai
 </listener>
 ```
 
-Copy Waffle JARs, including `waffle-jna-2.1.1.jar`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar`, `slf4j-api-2.0.0-alpha1.jar` and `waffle-spring-security4-2.1.1.jar` in the application's `lib` directory along with Spring and Spring-Security JARs. Or, if you use Maven, add the following to your `pom.xml`:
+Copy Waffle JARs, including `waffle-jna.jar`, `caffeine.jar`, `jna.jar`, `jna-platform.jar`, `slf4j-api.jar` and `waffle-spring-security5.jar` in the application's `lib` directory along with Spring and Spring-Security JARs. Or, if you use Maven, add the following to your `pom.xml`:
 
-- For latest snapshot instead use `waffle-jna-2.1.2-SNAPSHOT`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar`, `slf4j-api-2.0.0-alpha1.jar` and `waffle-spring-security4-2.1.2-SNAPSHOT.jar`
+- Use specific versions as bundled in waffle-distro
 
 ``` xml
 <dependency>

--- a/Docs/tomcat/TomcatMixedSingleSignOnAndFormAuthenticatorValve.md
+++ b/Docs/tomcat/TomcatMixedSingleSignOnAndFormAuthenticatorValve.md
@@ -8,9 +8,9 @@ Configuring Tomcat
 
 The following steps are required to configure Tomcat with Waffle Mixed Authenticator. 
 
-Place  `waffle-jna-2.1.1.jar`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar`, `slf4j-api-2.0.0-alpha1.jar` and `waffle-tomcat[tomcat version]-2.1.1.jar` into your Tomcat's `lib` directory. It is *not* possible to place these files in `WEB-INF\lib`!
+Place  `waffle-jna.jar`, `caffeine.jar`, `jna.jar`, `jna-platform.jar`, `slf4j-api.jar` and `waffle-tomcat[tomcat version].jar` into your Tomcat's `lib` directory. It is *not* possible to place these files in `WEB-INF\lib`!
 
-- For latest snapshot instead use `waffle-jna-2.1.2-SNAPSHOT`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar`, `slf4j-api-2.0.0-alpha1.jar` and `waffle-tomcat[tomcat version]-2.1.2-SNAPSHOT.jar`
+- Use specific versions as bundled in waffle-distro
 
 If you are using Eclipse, you can see which files tomcat is importing by going to Java Recources: `src / Libraries / Apache Tomcat vx.x`. If you've placed it in the tomcat directory and still don't see it, restart Eclipse.
 

--- a/Docs/tomcat/TomcatSingleSignOnValve.md
+++ b/Docs/tomcat/TomcatSingleSignOnValve.md
@@ -8,9 +8,9 @@ Configuring Tomcat
 
 The following steps are required to configure Tomcat with Waffle authenticator. 
 
-Package Waffle JARs, including `waffle-jna-2.1.1.jar`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar`, `slf4j-api-2.0.0-alpha1.jar` and `waffle-tomcat[tomcat version]-2.1.1.jar` in the application's lib directory or copy them to Tomcat's lib.
+Package Waffle JARs, including `waffle-jna.jar`, `caffeine.jar`, `jna.jar`, `jna-platform.jar`, `slf4j-api.jar` and `waffle-tomcat[tomcat version].jar` in the application's lib directory or copy them to Tomcat's lib.
 
-- For latest snapshot instead use `waffle-jna-2.1.2-SNAPSHOT`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar`, `slf4j-api-2.0.0-alpha1.jar` and `waffle-tomcat[tomcat version]-2.1.2-SNAPSHOT.jar`
+- Use specific versions as bundled in waffle-distro
 
 Add a valve and a realm to the application context. For an application, modify `META-INF\context.xml`.
 

--- a/Docs/tomcat/TomcatWindowsLoginJAASAuthenticator.md
+++ b/Docs/tomcat/TomcatWindowsLoginJAASAuthenticator.md
@@ -8,9 +8,9 @@ Configuring Tomcat
 
 The following steps are required to configure Tomcat with Waffle authenticator. 
 
-Package Waffle JARs, including `waffle-jna-2.1.1.jar`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar`, and `slf4j-api-2.0.0-alpha1.jar` in the application's lib directory or copy them to Tomcat's lib.
+Package Waffle JARs, including `waffle-jna.jar`, `caffeine.jar`, `jna.jar`, `jna-platform.jar`, and `slf4j-api.jar` in the application's lib directory or copy them to Tomcat's lib.
 
-- For latest snapshot instead use `waffle-jna-2.1.2-SNAPSHOT`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar` and `slf4j-api-2.0.0-alpha1.jar`.
+- Use specific versions as bundled in waffle-distro
 
 Add a JAAS realm to the application context. Modify `META-INF\context.xml`.
  

--- a/Docs/wildfly/WildFlySecurityDomain.md
+++ b/Docs/wildfly/WildFlySecurityDomain.md
@@ -8,9 +8,9 @@ Configuring WildFly
 
 The following steps are required to configure WildFly with Waffle authenticator.
 
-Include the Waffle JARs, `waffle-jna-2.1.1.jar`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar`, and `slf4j-api-2.0.0-alpha1.jar` in your war's `WEB-INF\lib` directory. Alternatively you may place them in the `standalone/lib/ext` folder within the wildfly installation.
+Include the Waffle JARs, `waffle-jna.jar`, `caffeine.jar`, `jna.jar`, `jna-platform.jar`, and `slf4j-api.jar` in your war's `WEB-INF\lib` directory. Alternatively you may place them in the `standalone/lib/ext` folder within the wildfly installation.
 
-- For latest snapshot instead use `waffle-jna-2.1.2-SNAPSHOT`, `caffeine-2.8.0.jar`, `jna-5.5.0.jar`, `jna-platform-5.5.0.jar` and `slf4j-api-2.0.0-alpha1.jar`.
+- Use specific versions as bundled in waffle-distro
 
 Create a security domain using the Waffle `WindowsLoginModule`. It is recommended you keep the principal and role formats to `fqn`. 
 ```xml


### PR DESCRIPTION
these get out of sync often, just call out looking at distro for specific versions.

update spring 4 to 5.

update java usage to build and maven usage to build