### PR TITLE
[pom] Configure required java version for enforcer more strictly

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-2019, windows-latest]
-        java: [11, 17, 18, 19-ea]
+        java: [11, 17, 19, 20-ea]
       fail-fast: false
       max-parallel: 4
     name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}

--- a/Source/JNA/pom.xml
+++ b/Source/JNA/pom.xml
@@ -372,7 +372,7 @@
                                 <maxJdkVersion>${java.version}</maxJdkVersion>
                             </enforceBytecodeVersion>
                             <requireJavaVersion>
-                                <version>11,17,18,19,20</version>
+                                <version>[11,12),[17,18),[19,20),[20,21)</version>
                             </requireJavaVersion>
                             <requireMavenVersion>
                                 <version>[${maven.min-version},)</version>


### PR DESCRIPTION
prior setup allowed any 11 or better.  intent was to lock it down to what we confirmed works while getting rid of old builds from github actions.  Thus fix to lock ranges to any 11, any 17, any 19, and any 20 and block all others.