### PR TITLE
[cleanup] Remove deprecated author tag from javadocs

### DIFF
--- a/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/jaas/RolePrincipal.java
+++ b/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/jaas/RolePrincipal.java
@@ -28,8 +28,6 @@ import java.security.Principal;
 
 /**
  * Role principal.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class RolePrincipal implements Principal, Serializable {
 

--- a/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/jaas/UserPrincipal.java
+++ b/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/jaas/UserPrincipal.java
@@ -28,8 +28,6 @@ import java.security.Principal;
 
 /**
  * User Principal.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class UserPrincipal implements Principal, Serializable {
 

--- a/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/jaas/WindowsLoginModule.java
+++ b/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/jaas/WindowsLoginModule.java
@@ -53,8 +53,6 @@ import waffle.windows.auth.impl.WindowsAuthProviderImpl;
 /**
  * A Java Security login module for Windows authentication.
  *
- * @author dblock[at]dblock[dot]org
- *
  * @see javax.security.auth.spi.LoginModule
  */
 public class WindowsLoginModule implements LoginModule {

--- a/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/servlet/NegotiateRequestWrapper.java
+++ b/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/servlet/NegotiateRequestWrapper.java
@@ -30,8 +30,6 @@ import java.security.Principal;
 
 /**
  * Negotiate Request wrapper.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class NegotiateRequestWrapper extends HttpServletRequestWrapper {
 

--- a/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/servlet/NegotiateSecurityFilter.java
+++ b/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/servlet/NegotiateSecurityFilter.java
@@ -59,8 +59,6 @@ import waffle.windows.auth.impl.WindowsAuthProviderImpl;
 
 /**
  * A Negotiate (NTLM/Kerberos) Security Filter.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class NegotiateSecurityFilter implements Filter {
 

--- a/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/servlet/WindowsPrincipal.java
+++ b/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/servlet/WindowsPrincipal.java
@@ -37,8 +37,6 @@ import waffle.windows.auth.WindowsAccount;
 
 /**
  * A Windows Principal.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class WindowsPrincipal implements Principal, Serializable {
 

--- a/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/servlet/spi/BasicSecurityFilterProvider.java
+++ b/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/servlet/spi/BasicSecurityFilterProvider.java
@@ -39,8 +39,6 @@ import waffle.windows.auth.IWindowsIdentity;
 
 /**
  * A Basic authentication security filter provider. https://tools.ietf.org/html/rfc2617
- *
- * @author dblock[at]dblock[dot]org
  */
 public class BasicSecurityFilterProvider implements SecurityFilterProvider {
 

--- a/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/servlet/spi/NegotiateSecurityFilterProvider.java
+++ b/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/servlet/spi/NegotiateSecurityFilterProvider.java
@@ -43,8 +43,6 @@ import waffle.windows.auth.IWindowsSecurityContext;
 
 /**
  * A negotiate security filter provider.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class NegotiateSecurityFilterProvider implements SecurityFilterProvider {
 

--- a/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/servlet/spi/SecurityFilterProvider.java
+++ b/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/servlet/spi/SecurityFilterProvider.java
@@ -32,8 +32,6 @@ import waffle.windows.auth.IWindowsIdentity;
 
 /**
  * A security filter provider.
- *
- * @author dblock[at]dblock[dot]org
  */
 public interface SecurityFilterProvider {
 

--- a/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/servlet/spi/SecurityFilterProviderCollection.java
+++ b/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/servlet/spi/SecurityFilterProviderCollection.java
@@ -43,8 +43,6 @@ import waffle.windows.auth.IWindowsIdentity;
 
 /**
  * A collection of security filter providers.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class SecurityFilterProviderCollection {
 

--- a/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/util/AuthorizationHeader.java
+++ b/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/util/AuthorizationHeader.java
@@ -33,8 +33,6 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Authorization header.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class AuthorizationHeader {
 

--- a/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/util/NtlmMessage.java
+++ b/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/util/NtlmMessage.java
@@ -25,8 +25,6 @@ package waffle.util;
 
 /**
  * Rudimentary NTLM message utility.
- *
- * @author dblock[at]dblock[dot]org
  */
 public final class NtlmMessage {
 

--- a/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/util/NtlmServletRequest.java
+++ b/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/util/NtlmServletRequest.java
@@ -27,8 +27,6 @@ import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * The Class NtlmServletRequest.
- *
- * @author dblock[at]dblock[dot]org
  */
 public final class NtlmServletRequest {
 

--- a/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/windows/auth/IWindowsAccount.java
+++ b/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/windows/auth/IWindowsAccount.java
@@ -25,8 +25,6 @@ package waffle.windows.auth;
 
 /**
  * Windows account.
- *
- * @author dblock[at]dblock[dot]org
  */
 public interface IWindowsAccount {
 

--- a/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/windows/auth/IWindowsAuthProvider.java
+++ b/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/windows/auth/IWindowsAuthProvider.java
@@ -25,8 +25,6 @@ package waffle.windows.auth;
 
 /**
  * Implements Windows authentication functions.
- *
- * @author dblock[at]dblock[dot]org
  */
 public interface IWindowsAuthProvider {
 

--- a/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/windows/auth/IWindowsComputer.java
+++ b/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/windows/auth/IWindowsComputer.java
@@ -25,8 +25,6 @@ package waffle.windows.auth;
 
 /**
  * A Windows Computer.
- *
- * @author dblock[at]dblock[dot]org
  */
 public interface IWindowsComputer {
 

--- a/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/windows/auth/IWindowsCredentialsHandle.java
+++ b/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/windows/auth/IWindowsCredentialsHandle.java
@@ -27,8 +27,6 @@ import com.sun.jna.platform.win32.Sspi.CredHandle;
 
 /**
  * Windows credentials handle.
- *
- * @author dblock[at]dblock[dot]org
  */
 public interface IWindowsCredentialsHandle {
     /**

--- a/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/windows/auth/IWindowsDomain.java
+++ b/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/windows/auth/IWindowsDomain.java
@@ -25,8 +25,6 @@ package waffle.windows.auth;
 
 /**
  * A Windows Domain.
- *
- * @author dblock[at]dblock[dot]org
  */
 public interface IWindowsDomain {
 

--- a/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/windows/auth/IWindowsIdentity.java
+++ b/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/windows/auth/IWindowsIdentity.java
@@ -25,8 +25,6 @@ package waffle.windows.auth;
 
 /**
  * A Windows Identity.
- *
- * @author dblock[at]dblock[dot]org
  */
 public interface IWindowsIdentity {
 

--- a/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/windows/auth/IWindowsImpersonationContext.java
+++ b/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/windows/auth/IWindowsImpersonationContext.java
@@ -25,8 +25,6 @@ package waffle.windows.auth;
 
 /**
  * A Windows impersonation context.
- *
- * @author dblock[at]dblock[dot]org
  */
 public interface IWindowsImpersonationContext {
 

--- a/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/windows/auth/IWindowsSecurityContext.java
+++ b/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/windows/auth/IWindowsSecurityContext.java
@@ -29,8 +29,6 @@ import com.sun.jna.platform.win32.Sspi.SecBufferDesc;
 
 /**
  * A Windows security context.
- *
- * @author dblock[at]dblock[dot]org
  */
 public interface IWindowsSecurityContext {
 

--- a/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/windows/auth/PrincipalFormat.java
+++ b/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/windows/auth/PrincipalFormat.java
@@ -25,8 +25,6 @@ package waffle.windows.auth;
 
 /**
  * The Enum PrincipalFormat.
- *
- * @author dblock[at]dblock[dot]org
  */
 public enum PrincipalFormat {
 

--- a/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/windows/auth/WindowsAccount.java
+++ b/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/windows/auth/WindowsAccount.java
@@ -27,8 +27,6 @@ import java.io.Serializable;
 
 /**
  * A flattened Windows Account used in a Windows principal.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class WindowsAccount implements Serializable {
 

--- a/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/windows/auth/impl/WindowsAccountImpl.java
+++ b/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/windows/auth/impl/WindowsAccountImpl.java
@@ -32,8 +32,6 @@ import waffle.windows.auth.IWindowsAccount;
 
 /**
  * Windows Account.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class WindowsAccountImpl implements IWindowsAccount {
 

--- a/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/windows/auth/impl/WindowsAuthProviderImpl.java
+++ b/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/windows/auth/impl/WindowsAuthProviderImpl.java
@@ -53,8 +53,6 @@ import waffle.windows.auth.IWindowsSecurityContext;
 
 /**
  * Windows Auth Provider.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class WindowsAuthProviderImpl implements IWindowsAuthProvider {
 

--- a/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/windows/auth/impl/WindowsComputerImpl.java
+++ b/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/windows/auth/impl/WindowsComputerImpl.java
@@ -34,8 +34,6 @@ import waffle.windows.auth.IWindowsComputer;
 
 /**
  * Windows Computer.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class WindowsComputerImpl implements IWindowsComputer {
 

--- a/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/windows/auth/impl/WindowsCredentialsHandleImpl.java
+++ b/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/windows/auth/impl/WindowsCredentialsHandleImpl.java
@@ -35,8 +35,6 @@ import waffle.windows.auth.IWindowsCredentialsHandle;
 /**
  * Pre-existing credentials of a security principal. This is a handle to a previously authenticated logon data used by a
  * security principal to establish its own identity, such as a password, or a Kerberos protocol ticket.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class WindowsCredentialsHandleImpl implements IWindowsCredentialsHandle {
 

--- a/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/windows/auth/impl/WindowsDomainImpl.java
+++ b/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/windows/auth/impl/WindowsDomainImpl.java
@@ -29,8 +29,6 @@ import waffle.windows.auth.IWindowsDomain;
 
 /**
  * Windows Domain.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class WindowsDomainImpl implements IWindowsDomain {
 

--- a/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/windows/auth/impl/WindowsIdentityImpersonationContextImpl.java
+++ b/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/windows/auth/impl/WindowsIdentityImpersonationContextImpl.java
@@ -32,8 +32,6 @@ import waffle.windows.auth.IWindowsImpersonationContext;
 
 /**
  * The Class WindowsIdentityImpersonationContextImpl.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class WindowsIdentityImpersonationContextImpl implements IWindowsImpersonationContext {
 

--- a/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/windows/auth/impl/WindowsIdentityImpl.java
+++ b/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/windows/auth/impl/WindowsIdentityImpl.java
@@ -38,8 +38,6 @@ import waffle.windows.auth.IWindowsImpersonationContext;
 
 /**
  * Windows Identity.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class WindowsIdentityImpl implements IWindowsIdentity {
 

--- a/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/windows/auth/impl/WindowsSecurityContextImpersonationContextImpl.java
+++ b/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/windows/auth/impl/WindowsSecurityContextImpersonationContextImpl.java
@@ -32,8 +32,6 @@ import waffle.windows.auth.IWindowsImpersonationContext;
 
 /**
  * The Class WindowsSecurityContextImpersonationContextImpl.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class WindowsSecurityContextImpersonationContextImpl implements IWindowsImpersonationContext {
 

--- a/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/windows/auth/impl/WindowsSecurityContextImpl.java
+++ b/Source/JNA/waffle-jna-jakarta/src/main/java/waffle/windows/auth/impl/WindowsSecurityContextImpl.java
@@ -40,8 +40,6 @@ import waffle.windows.auth.IWindowsSecurityContext;
 
 /**
  * Windows Security Context.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class WindowsSecurityContextImpl implements IWindowsSecurityContext {
 

--- a/Source/JNA/waffle-jna-jakarta/src/test/java/waffle/jaas/RolePrincipalTest.java
+++ b/Source/JNA/waffle-jna-jakarta/src/test/java/waffle/jaas/RolePrincipalTest.java
@@ -38,8 +38,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * The Class RolePrincipalTest.
- *
- * @author dblock[at]dblock[dot]org
  */
 class RolePrincipalTest {
 

--- a/Source/JNA/waffle-jna-jakarta/src/test/java/waffle/jaas/UserPrincipalTest.java
+++ b/Source/JNA/waffle-jna-jakarta/src/test/java/waffle/jaas/UserPrincipalTest.java
@@ -38,8 +38,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * The Class UserPrincipalTest.
- *
- * @author dblock[at]dblock[dot]org
  */
 class UserPrincipalTest {
 

--- a/Source/JNA/waffle-jna-jakarta/src/test/java/waffle/jaas/UsernamePasswordCallbackHandler.java
+++ b/Source/JNA/waffle-jna-jakarta/src/test/java/waffle/jaas/UsernamePasswordCallbackHandler.java
@@ -33,8 +33,6 @@ import javax.security.auth.callback.UnsupportedCallbackException;
 
 /**
  * The Class UsernamePasswordCallbackHandler.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class UsernamePasswordCallbackHandler implements CallbackHandler {
 

--- a/Source/JNA/waffle-jna-jakarta/src/test/java/waffle/servlet/WindowsPrincipalTest.java
+++ b/Source/JNA/waffle-jna-jakarta/src/test/java/waffle/servlet/WindowsPrincipalTest.java
@@ -34,8 +34,6 @@ import waffle.windows.auth.IWindowsIdentity;
 
 /**
  * The Class WindowsPrincipalTest.
- *
- * @author dblock[at]dblock[dot]org
  */
 class WindowsPrincipalTest {
 

--- a/Source/JNA/waffle-jna-jakarta/src/test/java/waffle/servlet/spi/SecurityFilterProviderCollectionTest.java
+++ b/Source/JNA/waffle-jna-jakarta/src/test/java/waffle/servlet/spi/SecurityFilterProviderCollectionTest.java
@@ -30,8 +30,6 @@ import waffle.windows.auth.impl.WindowsAuthProviderImpl;
 
 /**
  * The Class SecurityFilterProviderCollectionTest.
- *
- * @author dblock[at]dblock[dot]org
  */
 class SecurityFilterProviderCollectionTest {
 

--- a/Source/JNA/waffle-jna-jakarta/src/test/java/waffle/util/NtlmMessageTest.java
+++ b/Source/JNA/waffle-jna-jakarta/src/test/java/waffle/util/NtlmMessageTest.java
@@ -28,8 +28,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * The Class NtlmMessageTest.
- *
- * @author dblock[at]dblock[dot]org
  */
 class NtlmMessageTest {
 

--- a/Source/JNA/waffle-jna-jakarta/src/test/java/waffle/windows/auth/PrincipalFormatTest.java
+++ b/Source/JNA/waffle-jna-jakarta/src/test/java/waffle/windows/auth/PrincipalFormatTest.java
@@ -28,8 +28,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * The Class PrincipalFormatTest.
- *
- * @author dblock[at]dblock[dot]org
  */
 class PrincipalFormatTest {
 

--- a/Source/JNA/waffle-jna-jakarta/src/test/java/waffle/windows/auth/WindowsAccountTest.java
+++ b/Source/JNA/waffle-jna-jakarta/src/test/java/waffle/windows/auth/WindowsAccountTest.java
@@ -34,8 +34,6 @@ import waffle.windows.auth.impl.WindowsAccountImpl;
 
 /**
  * The Class WindowsAccountTest.
- *
- * @author dblock[at]dblock[dot]org
  */
 class WindowsAccountTest {
 

--- a/Source/JNA/waffle-jna-jakarta/src/test/java/waffle/windows/auth/WindowsCredentialsHandleTest.java
+++ b/Source/JNA/waffle-jna-jakarta/src/test/java/waffle/windows/auth/WindowsCredentialsHandleTest.java
@@ -30,8 +30,6 @@ import waffle.windows.auth.impl.WindowsCredentialsHandleImpl;
 
 /**
  * The Class WindowsCredentialsHandleTest.
- *
- * @author dblock[at]dblock[dot]org
  */
 class WindowsCredentialsHandleTest {
 

--- a/Source/JNA/waffle-jna-jakarta/src/test/java/waffle/windows/auth/WindowsSecurityContextTest.java
+++ b/Source/JNA/waffle-jna-jakarta/src/test/java/waffle/windows/auth/WindowsSecurityContextTest.java
@@ -33,8 +33,6 @@ import waffle.windows.auth.impl.WindowsSecurityContextImpl;
 
 /**
  * The Class WindowsSecurityContextTest.
- *
- * @author dblock[at]dblock[dot]org
  */
 class WindowsSecurityContextTest {
 

--- a/Source/JNA/waffle-jna/src/main/java/waffle/jaas/RolePrincipal.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/jaas/RolePrincipal.java
@@ -28,8 +28,6 @@ import java.security.Principal;
 
 /**
  * Role principal.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class RolePrincipal implements Principal, Serializable {
 

--- a/Source/JNA/waffle-jna/src/main/java/waffle/jaas/UserPrincipal.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/jaas/UserPrincipal.java
@@ -28,8 +28,6 @@ import java.security.Principal;
 
 /**
  * User Principal.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class UserPrincipal implements Principal, Serializable {
 

--- a/Source/JNA/waffle-jna/src/main/java/waffle/jaas/WindowsLoginModule.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/jaas/WindowsLoginModule.java
@@ -53,8 +53,6 @@ import waffle.windows.auth.impl.WindowsAuthProviderImpl;
 /**
  * A Java Security login module for Windows authentication.
  *
- * @author dblock[at]dblock[dot]org
- *
  * @see javax.security.auth.spi.LoginModule
  */
 public class WindowsLoginModule implements LoginModule {

--- a/Source/JNA/waffle-jna/src/main/java/waffle/servlet/NegotiateRequestWrapper.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/servlet/NegotiateRequestWrapper.java
@@ -30,8 +30,6 @@ import javax.servlet.http.HttpServletRequestWrapper;
 
 /**
  * Negotiate Request wrapper.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class NegotiateRequestWrapper extends HttpServletRequestWrapper {
 

--- a/Source/JNA/waffle-jna/src/main/java/waffle/servlet/NegotiateSecurityFilter.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/servlet/NegotiateSecurityFilter.java
@@ -58,8 +58,6 @@ import waffle.windows.auth.impl.WindowsAuthProviderImpl;
 
 /**
  * A Negotiate (NTLM/Kerberos) Security Filter.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class NegotiateSecurityFilter implements Filter {
 

--- a/Source/JNA/waffle-jna/src/main/java/waffle/servlet/WindowsPrincipal.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/servlet/WindowsPrincipal.java
@@ -37,8 +37,6 @@ import waffle.windows.auth.WindowsAccount;
 
 /**
  * A Windows Principal.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class WindowsPrincipal implements Principal, Serializable {
 

--- a/Source/JNA/waffle-jna/src/main/java/waffle/servlet/spi/BasicSecurityFilterProvider.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/servlet/spi/BasicSecurityFilterProvider.java
@@ -39,8 +39,6 @@ import waffle.windows.auth.IWindowsIdentity;
 
 /**
  * A Basic authentication security filter provider. https://tools.ietf.org/html/rfc2617
- *
- * @author dblock[at]dblock[dot]org
  */
 public class BasicSecurityFilterProvider implements SecurityFilterProvider {
 

--- a/Source/JNA/waffle-jna/src/main/java/waffle/servlet/spi/NegotiateSecurityFilterProvider.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/servlet/spi/NegotiateSecurityFilterProvider.java
@@ -43,8 +43,6 @@ import waffle.windows.auth.IWindowsSecurityContext;
 
 /**
  * A negotiate security filter provider.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class NegotiateSecurityFilterProvider implements SecurityFilterProvider {
 

--- a/Source/JNA/waffle-jna/src/main/java/waffle/servlet/spi/SecurityFilterProvider.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/servlet/spi/SecurityFilterProvider.java
@@ -32,8 +32,6 @@ import waffle.windows.auth.IWindowsIdentity;
 
 /**
  * A security filter provider.
- *
- * @author dblock[at]dblock[dot]org
  */
 public interface SecurityFilterProvider {
 

--- a/Source/JNA/waffle-jna/src/main/java/waffle/servlet/spi/SecurityFilterProviderCollection.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/servlet/spi/SecurityFilterProviderCollection.java
@@ -43,8 +43,6 @@ import waffle.windows.auth.IWindowsIdentity;
 
 /**
  * A collection of security filter providers.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class SecurityFilterProviderCollection {
 

--- a/Source/JNA/waffle-jna/src/main/java/waffle/util/AuthorizationHeader.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/util/AuthorizationHeader.java
@@ -33,8 +33,6 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Authorization header.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class AuthorizationHeader {
 

--- a/Source/JNA/waffle-jna/src/main/java/waffle/util/NtlmMessage.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/util/NtlmMessage.java
@@ -25,8 +25,6 @@ package waffle.util;
 
 /**
  * Rudimentary NTLM message utility.
- *
- * @author dblock[at]dblock[dot]org
  */
 public final class NtlmMessage {
 

--- a/Source/JNA/waffle-jna/src/main/java/waffle/util/NtlmServletRequest.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/util/NtlmServletRequest.java
@@ -27,8 +27,6 @@ import javax.servlet.http.HttpServletRequest;
 
 /**
  * The Class NtlmServletRequest.
- *
- * @author dblock[at]dblock[dot]org
  */
 public final class NtlmServletRequest {
 

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/IWindowsAccount.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/IWindowsAccount.java
@@ -25,8 +25,6 @@ package waffle.windows.auth;
 
 /**
  * Windows account.
- *
- * @author dblock[at]dblock[dot]org
  */
 public interface IWindowsAccount {
 

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/IWindowsAuthProvider.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/IWindowsAuthProvider.java
@@ -25,8 +25,6 @@ package waffle.windows.auth;
 
 /**
  * Implements Windows authentication functions.
- *
- * @author dblock[at]dblock[dot]org
  */
 public interface IWindowsAuthProvider {
 

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/IWindowsComputer.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/IWindowsComputer.java
@@ -25,8 +25,6 @@ package waffle.windows.auth;
 
 /**
  * A Windows Computer.
- *
- * @author dblock[at]dblock[dot]org
  */
 public interface IWindowsComputer {
 

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/IWindowsCredentialsHandle.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/IWindowsCredentialsHandle.java
@@ -27,8 +27,6 @@ import com.sun.jna.platform.win32.Sspi.CredHandle;
 
 /**
  * Windows credentials handle.
- *
- * @author dblock[at]dblock[dot]org
  */
 public interface IWindowsCredentialsHandle {
     /**

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/IWindowsDomain.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/IWindowsDomain.java
@@ -25,8 +25,6 @@ package waffle.windows.auth;
 
 /**
  * A Windows Domain.
- *
- * @author dblock[at]dblock[dot]org
  */
 public interface IWindowsDomain {
 

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/IWindowsIdentity.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/IWindowsIdentity.java
@@ -25,8 +25,6 @@ package waffle.windows.auth;
 
 /**
  * A Windows Identity.
- *
- * @author dblock[at]dblock[dot]org
  */
 public interface IWindowsIdentity {
 

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/IWindowsImpersonationContext.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/IWindowsImpersonationContext.java
@@ -25,8 +25,6 @@ package waffle.windows.auth;
 
 /**
  * A Windows impersonation context.
- *
- * @author dblock[at]dblock[dot]org
  */
 public interface IWindowsImpersonationContext {
 

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/IWindowsSecurityContext.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/IWindowsSecurityContext.java
@@ -29,8 +29,6 @@ import com.sun.jna.platform.win32.Sspi.SecBufferDesc;
 
 /**
  * A Windows security context.
- *
- * @author dblock[at]dblock[dot]org
  */
 public interface IWindowsSecurityContext {
 

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/PrincipalFormat.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/PrincipalFormat.java
@@ -25,8 +25,6 @@ package waffle.windows.auth;
 
 /**
  * The Enum PrincipalFormat.
- *
- * @author dblock[at]dblock[dot]org
  */
 public enum PrincipalFormat {
 

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/WindowsAccount.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/WindowsAccount.java
@@ -27,8 +27,6 @@ import java.io.Serializable;
 
 /**
  * A flattened Windows Account used in a Windows principal.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class WindowsAccount implements Serializable {
 

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsAccountImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsAccountImpl.java
@@ -32,8 +32,6 @@ import waffle.windows.auth.IWindowsAccount;
 
 /**
  * Windows Account.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class WindowsAccountImpl implements IWindowsAccount {
 

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsAuthProviderImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsAuthProviderImpl.java
@@ -53,8 +53,6 @@ import waffle.windows.auth.IWindowsSecurityContext;
 
 /**
  * Windows Auth Provider.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class WindowsAuthProviderImpl implements IWindowsAuthProvider {
 

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsComputerImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsComputerImpl.java
@@ -34,8 +34,6 @@ import waffle.windows.auth.IWindowsComputer;
 
 /**
  * Windows Computer.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class WindowsComputerImpl implements IWindowsComputer {
 

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsCredentialsHandleImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsCredentialsHandleImpl.java
@@ -35,8 +35,6 @@ import waffle.windows.auth.IWindowsCredentialsHandle;
 /**
  * Pre-existing credentials of a security principal. This is a handle to a previously authenticated logon data used by a
  * security principal to establish its own identity, such as a password, or a Kerberos protocol ticket.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class WindowsCredentialsHandleImpl implements IWindowsCredentialsHandle {
 

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsDomainImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsDomainImpl.java
@@ -29,8 +29,6 @@ import waffle.windows.auth.IWindowsDomain;
 
 /**
  * Windows Domain.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class WindowsDomainImpl implements IWindowsDomain {
 

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsIdentityImpersonationContextImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsIdentityImpersonationContextImpl.java
@@ -32,8 +32,6 @@ import waffle.windows.auth.IWindowsImpersonationContext;
 
 /**
  * The Class WindowsIdentityImpersonationContextImpl.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class WindowsIdentityImpersonationContextImpl implements IWindowsImpersonationContext {
 

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsIdentityImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsIdentityImpl.java
@@ -38,8 +38,6 @@ import waffle.windows.auth.IWindowsImpersonationContext;
 
 /**
  * Windows Identity.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class WindowsIdentityImpl implements IWindowsIdentity {
 

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsSecurityContextImpersonationContextImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsSecurityContextImpersonationContextImpl.java
@@ -32,8 +32,6 @@ import waffle.windows.auth.IWindowsImpersonationContext;
 
 /**
  * The Class WindowsSecurityContextImpersonationContextImpl.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class WindowsSecurityContextImpersonationContextImpl implements IWindowsImpersonationContext {
 

--- a/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsSecurityContextImpl.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/windows/auth/impl/WindowsSecurityContextImpl.java
@@ -40,8 +40,6 @@ import waffle.windows.auth.IWindowsSecurityContext;
 
 /**
  * Windows Security Context.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class WindowsSecurityContextImpl implements IWindowsSecurityContext {
 

--- a/Source/JNA/waffle-jna/src/test/java/waffle/jaas/RolePrincipalTest.java
+++ b/Source/JNA/waffle-jna/src/test/java/waffle/jaas/RolePrincipalTest.java
@@ -38,8 +38,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * The Class RolePrincipalTest.
- *
- * @author dblock[at]dblock[dot]org
  */
 class RolePrincipalTest {
 

--- a/Source/JNA/waffle-jna/src/test/java/waffle/jaas/UserPrincipalTest.java
+++ b/Source/JNA/waffle-jna/src/test/java/waffle/jaas/UserPrincipalTest.java
@@ -38,8 +38,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * The Class UserPrincipalTest.
- *
- * @author dblock[at]dblock[dot]org
  */
 class UserPrincipalTest {
 

--- a/Source/JNA/waffle-jna/src/test/java/waffle/jaas/UsernamePasswordCallbackHandler.java
+++ b/Source/JNA/waffle-jna/src/test/java/waffle/jaas/UsernamePasswordCallbackHandler.java
@@ -33,8 +33,6 @@ import javax.security.auth.callback.UnsupportedCallbackException;
 
 /**
  * The Class UsernamePasswordCallbackHandler.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class UsernamePasswordCallbackHandler implements CallbackHandler {
 

--- a/Source/JNA/waffle-jna/src/test/java/waffle/servlet/WindowsPrincipalTest.java
+++ b/Source/JNA/waffle-jna/src/test/java/waffle/servlet/WindowsPrincipalTest.java
@@ -34,8 +34,6 @@ import waffle.windows.auth.IWindowsIdentity;
 
 /**
  * The Class WindowsPrincipalTest.
- *
- * @author dblock[at]dblock[dot]org
  */
 class WindowsPrincipalTest {
 

--- a/Source/JNA/waffle-jna/src/test/java/waffle/servlet/spi/SecurityFilterProviderCollectionTest.java
+++ b/Source/JNA/waffle-jna/src/test/java/waffle/servlet/spi/SecurityFilterProviderCollectionTest.java
@@ -30,8 +30,6 @@ import waffle.windows.auth.impl.WindowsAuthProviderImpl;
 
 /**
  * The Class SecurityFilterProviderCollectionTest.
- *
- * @author dblock[at]dblock[dot]org
  */
 class SecurityFilterProviderCollectionTest {
 

--- a/Source/JNA/waffle-jna/src/test/java/waffle/util/NtlmMessageTest.java
+++ b/Source/JNA/waffle-jna/src/test/java/waffle/util/NtlmMessageTest.java
@@ -28,8 +28,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * The Class NtlmMessageTest.
- *
- * @author dblock[at]dblock[dot]org
  */
 class NtlmMessageTest {
 

--- a/Source/JNA/waffle-jna/src/test/java/waffle/windows/auth/PrincipalFormatTest.java
+++ b/Source/JNA/waffle-jna/src/test/java/waffle/windows/auth/PrincipalFormatTest.java
@@ -28,8 +28,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * The Class PrincipalFormatTest.
- *
- * @author dblock[at]dblock[dot]org
  */
 class PrincipalFormatTest {
 

--- a/Source/JNA/waffle-jna/src/test/java/waffle/windows/auth/WindowsAccountTest.java
+++ b/Source/JNA/waffle-jna/src/test/java/waffle/windows/auth/WindowsAccountTest.java
@@ -34,8 +34,6 @@ import waffle.windows.auth.impl.WindowsAccountImpl;
 
 /**
  * The Class WindowsAccountTest.
- *
- * @author dblock[at]dblock[dot]org
  */
 class WindowsAccountTest {
 

--- a/Source/JNA/waffle-jna/src/test/java/waffle/windows/auth/WindowsCredentialsHandleTest.java
+++ b/Source/JNA/waffle-jna/src/test/java/waffle/windows/auth/WindowsCredentialsHandleTest.java
@@ -30,8 +30,6 @@ import waffle.windows.auth.impl.WindowsCredentialsHandleImpl;
 
 /**
  * The Class WindowsCredentialsHandleTest.
- *
- * @author dblock[at]dblock[dot]org
  */
 class WindowsCredentialsHandleTest {
 

--- a/Source/JNA/waffle-jna/src/test/java/waffle/windows/auth/WindowsSecurityContextTest.java
+++ b/Source/JNA/waffle-jna/src/test/java/waffle/windows/auth/WindowsSecurityContextTest.java
@@ -33,8 +33,6 @@ import waffle.windows.auth.impl.WindowsSecurityContextImpl;
 
 /**
  * The Class WindowsSecurityContextTest.
- *
- * @author dblock[at]dblock[dot]org
  */
 class WindowsSecurityContextTest {
 

--- a/Source/JNA/waffle-spring-security5/src/main/java/waffle/spring/GuestLoginDisabledAuthenticationException.java
+++ b/Source/JNA/waffle-spring-security5/src/main/java/waffle/spring/GuestLoginDisabledAuthenticationException.java
@@ -27,8 +27,6 @@ import org.springframework.security.core.AuthenticationException;
 
 /**
  * Guest login is disabled authentication exception.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class GuestLoginDisabledAuthenticationException extends AuthenticationException {
 

--- a/Source/JNA/waffle-spring-security5/src/main/java/waffle/spring/NegotiateSecurityFilter.java
+++ b/Source/JNA/waffle-spring-security5/src/main/java/waffle/spring/NegotiateSecurityFilter.java
@@ -50,8 +50,6 @@ import waffle.windows.auth.PrincipalFormat;
 
 /**
  * A Spring Negotiate security filter.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class NegotiateSecurityFilter extends GenericFilterBean {
 

--- a/Source/JNA/waffle-spring-security5/src/main/java/waffle/spring/NegotiateSecurityFilterEntryPoint.java
+++ b/Source/JNA/waffle-spring-security5/src/main/java/waffle/spring/NegotiateSecurityFilterEntryPoint.java
@@ -38,8 +38,6 @@ import waffle.servlet.spi.SecurityFilterProviderCollection;
 
 /**
  * Sends back a request for a Negotiate Authentication to the browser.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class NegotiateSecurityFilterEntryPoint implements AuthenticationEntryPoint {
 

--- a/Source/JNA/waffle-spring-security5/src/main/java/waffle/spring/WindowsAuthenticationProvider.java
+++ b/Source/JNA/waffle-spring-security5/src/main/java/waffle/spring/WindowsAuthenticationProvider.java
@@ -42,8 +42,6 @@ import waffle.windows.auth.PrincipalFormat;
 
 /**
  * A Waffle authentication provider for Spring-security.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class WindowsAuthenticationProvider implements AuthenticationProvider {
 

--- a/Source/JNA/waffle-spring-security5/src/main/java/waffle/spring/WindowsAuthenticationToken.java
+++ b/Source/JNA/waffle-spring-security5/src/main/java/waffle/spring/WindowsAuthenticationToken.java
@@ -35,8 +35,6 @@ import waffle.windows.auth.WindowsAccount;
 
 /**
  * A Windows authentication token.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class WindowsAuthenticationToken implements Authentication {
 

--- a/Source/JNA/waffle-spring-security5/src/test/java/waffle/spring/NegotiateSecurityFilterEntryPointTest.java
+++ b/Source/JNA/waffle-spring-security5/src/test/java/waffle/spring/NegotiateSecurityFilterEntryPointTest.java
@@ -40,8 +40,6 @@ import waffle.mock.http.SimpleHttpResponse;
 
 /**
  * The Class NegotiateSecurityFilterEntryPointTest.
- *
- * @author dblock[at]dblock[dot]org
  */
 class NegotiateSecurityFilterEntryPointTest {
 

--- a/Source/JNA/waffle-spring-security5/src/test/java/waffle/spring/NegotiateSecurityFilterTest.java
+++ b/Source/JNA/waffle-spring-security5/src/test/java/waffle/spring/NegotiateSecurityFilterTest.java
@@ -55,8 +55,6 @@ import waffle.windows.auth.impl.WindowsAccountImpl;
 
 /**
  * The Class NegotiateSecurityFilterTest.
- *
- * @author dblock[at]dblock[dot]org
  */
 class NegotiateSecurityFilterTest {
 

--- a/Source/JNA/waffle-spring-security5/src/test/java/waffle/spring/WindowsAuthenticationProviderTest.java
+++ b/Source/JNA/waffle-spring-security5/src/test/java/waffle/spring/WindowsAuthenticationProviderTest.java
@@ -47,8 +47,6 @@ import waffle.windows.auth.impl.WindowsAccountImpl;
 
 /**
  * The Class WindowsAuthenticationProviderTest.
- *
- * @author dblock[at]dblock[dot]org
  */
 class WindowsAuthenticationProviderTest {
 

--- a/Source/JNA/waffle-spring-security5/src/test/java/waffle/spring/WindowsAuthenticationTokenTest.java
+++ b/Source/JNA/waffle-spring-security5/src/test/java/waffle/spring/WindowsAuthenticationTokenTest.java
@@ -38,8 +38,6 @@ import waffle.servlet.WindowsPrincipal;
 
 /**
  * The Class WindowsAuthenticationTokenTest.
- *
- * @author dblock[at]dblock[dot]org
  */
 class WindowsAuthenticationTokenTest {
 

--- a/Source/JNA/waffle-spring-security6/src/main/java/waffle/spring/GuestLoginDisabledAuthenticationException.java
+++ b/Source/JNA/waffle-spring-security6/src/main/java/waffle/spring/GuestLoginDisabledAuthenticationException.java
@@ -27,8 +27,6 @@ import org.springframework.security.core.AuthenticationException;
 
 /**
  * Guest login is disabled authentication exception.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class GuestLoginDisabledAuthenticationException extends AuthenticationException {
 

--- a/Source/JNA/waffle-spring-security6/src/main/java/waffle/spring/NegotiateSecurityFilter.java
+++ b/Source/JNA/waffle-spring-security6/src/main/java/waffle/spring/NegotiateSecurityFilter.java
@@ -50,8 +50,6 @@ import waffle.windows.auth.PrincipalFormat;
 
 /**
  * A Spring Negotiate security filter.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class NegotiateSecurityFilter extends GenericFilterBean {
 

--- a/Source/JNA/waffle-spring-security6/src/main/java/waffle/spring/NegotiateSecurityFilterEntryPoint.java
+++ b/Source/JNA/waffle-spring-security6/src/main/java/waffle/spring/NegotiateSecurityFilterEntryPoint.java
@@ -38,8 +38,6 @@ import waffle.servlet.spi.SecurityFilterProviderCollection;
 
 /**
  * Sends back a request for a Negotiate Authentication to the browser.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class NegotiateSecurityFilterEntryPoint implements AuthenticationEntryPoint {
 

--- a/Source/JNA/waffle-spring-security6/src/main/java/waffle/spring/WindowsAuthenticationProvider.java
+++ b/Source/JNA/waffle-spring-security6/src/main/java/waffle/spring/WindowsAuthenticationProvider.java
@@ -42,8 +42,6 @@ import waffle.windows.auth.PrincipalFormat;
 
 /**
  * A Waffle authentication provider for Spring-security.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class WindowsAuthenticationProvider implements AuthenticationProvider {
 

--- a/Source/JNA/waffle-spring-security6/src/main/java/waffle/spring/WindowsAuthenticationToken.java
+++ b/Source/JNA/waffle-spring-security6/src/main/java/waffle/spring/WindowsAuthenticationToken.java
@@ -35,8 +35,6 @@ import waffle.windows.auth.WindowsAccount;
 
 /**
  * A Windows authentication token.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class WindowsAuthenticationToken implements Authentication {
 

--- a/Source/JNA/waffle-spring-security6/src/test/java/waffle/spring/NegotiateSecurityFilterEntryPointTest.java
+++ b/Source/JNA/waffle-spring-security6/src/test/java/waffle/spring/NegotiateSecurityFilterEntryPointTest.java
@@ -40,8 +40,6 @@ import waffle.mock.http.SimpleHttpResponse;
 
 /**
  * The Class NegotiateSecurityFilterEntryPointTest.
- *
- * @author dblock[at]dblock[dot]org
  */
 class NegotiateSecurityFilterEntryPointTest {
 

--- a/Source/JNA/waffle-spring-security6/src/test/java/waffle/spring/NegotiateSecurityFilterTest.java
+++ b/Source/JNA/waffle-spring-security6/src/test/java/waffle/spring/NegotiateSecurityFilterTest.java
@@ -55,8 +55,6 @@ import waffle.windows.auth.impl.WindowsAccountImpl;
 
 /**
  * The Class NegotiateSecurityFilterTest.
- *
- * @author dblock[at]dblock[dot]org
  */
 class NegotiateSecurityFilterTest {
 

--- a/Source/JNA/waffle-spring-security6/src/test/java/waffle/spring/WindowsAuthenticationProviderTest.java
+++ b/Source/JNA/waffle-spring-security6/src/test/java/waffle/spring/WindowsAuthenticationProviderTest.java
@@ -47,8 +47,6 @@ import waffle.windows.auth.impl.WindowsAccountImpl;
 
 /**
  * The Class WindowsAuthenticationProviderTest.
- *
- * @author dblock[at]dblock[dot]org
  */
 class WindowsAuthenticationProviderTest {
 

--- a/Source/JNA/waffle-spring-security6/src/test/java/waffle/spring/WindowsAuthenticationTokenTest.java
+++ b/Source/JNA/waffle-spring-security6/src/test/java/waffle/spring/WindowsAuthenticationTokenTest.java
@@ -38,8 +38,6 @@ import waffle.servlet.WindowsPrincipal;
 
 /**
  * The Class WindowsAuthenticationTokenTest.
- *
- * @author dblock[at]dblock[dot]org
  */
 class WindowsAuthenticationTokenTest {
 

--- a/Source/JNA/waffle-tests-jakarta/src/main/java/waffle/mock/MockWindowsAccount.java
+++ b/Source/JNA/waffle-tests-jakarta/src/main/java/waffle/mock/MockWindowsAccount.java
@@ -27,8 +27,6 @@ import waffle.windows.auth.IWindowsAccount;
 
 /**
  * The Class MockWindowsAccount.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class MockWindowsAccount implements IWindowsAccount {
 

--- a/Source/JNA/waffle-tests-jakarta/src/main/java/waffle/mock/MockWindowsAuthProvider.java
+++ b/Source/JNA/waffle-tests-jakarta/src/main/java/waffle/mock/MockWindowsAuthProvider.java
@@ -39,8 +39,6 @@ import waffle.windows.auth.IWindowsSecurityContext;
 
 /**
  * The Class MockWindowsAuthProvider.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class MockWindowsAuthProvider implements IWindowsAuthProvider {
 

--- a/Source/JNA/waffle-tests-jakarta/src/main/java/waffle/mock/MockWindowsIdentity.java
+++ b/Source/JNA/waffle-tests-jakarta/src/main/java/waffle/mock/MockWindowsIdentity.java
@@ -32,8 +32,6 @@ import waffle.windows.auth.IWindowsImpersonationContext;
 
 /**
  * A Mock windows identity.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class MockWindowsIdentity implements IWindowsIdentity {
 

--- a/Source/JNA/waffle-tests-jakarta/src/main/java/waffle/mock/MockWindowsImpersonationContext.java
+++ b/Source/JNA/waffle-tests-jakarta/src/main/java/waffle/mock/MockWindowsImpersonationContext.java
@@ -27,8 +27,6 @@ import waffle.windows.auth.IWindowsImpersonationContext;
 
 /**
  * The Class MockWindowsImpersonationContext.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class MockWindowsImpersonationContext implements IWindowsImpersonationContext {
 

--- a/Source/JNA/waffle-tests-jakarta/src/main/java/waffle/mock/MockWindowsSecurityContext.java
+++ b/Source/JNA/waffle-tests-jakarta/src/main/java/waffle/mock/MockWindowsSecurityContext.java
@@ -35,8 +35,6 @@ import waffle.windows.auth.IWindowsSecurityContext;
 
 /**
  * The Class MockWindowsSecurityContext.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class MockWindowsSecurityContext implements IWindowsSecurityContext {
 

--- a/Source/JNA/waffle-tests-jakarta/src/main/java/waffle/mock/http/SimpleFilterChain.java
+++ b/Source/JNA/waffle-tests-jakarta/src/main/java/waffle/mock/http/SimpleFilterChain.java
@@ -32,8 +32,6 @@ import java.io.IOException;
 
 /**
  * Simple filter chain.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class SimpleFilterChain implements FilterChain {
 

--- a/Source/JNA/waffle-tests-jakarta/src/main/java/waffle/mock/http/SimpleFilterConfig.java
+++ b/Source/JNA/waffle-tests-jakarta/src/main/java/waffle/mock/http/SimpleFilterConfig.java
@@ -35,8 +35,6 @@ import java.util.TreeMap;
 
 /**
  * The Class SimpleFilterConfig.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class SimpleFilterConfig implements FilterConfig {
 

--- a/Source/JNA/waffle-tests-jakarta/src/main/java/waffle/mock/http/SimpleHttpRequest.java
+++ b/Source/JNA/waffle-tests-jakarta/src/main/java/waffle/mock/http/SimpleHttpRequest.java
@@ -37,8 +37,6 @@ import org.mockito.Mockito;
 
 /**
  * The Class SimpleHttpRequest.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class SimpleHttpRequest extends HttpServletRequestWrapper {
 

--- a/Source/JNA/waffle-tests-jakarta/src/main/java/waffle/mock/http/SimpleHttpResponse.java
+++ b/Source/JNA/waffle-tests-jakarta/src/main/java/waffle/mock/http/SimpleHttpResponse.java
@@ -44,8 +44,6 @@ import org.slf4j.LoggerFactory;
 
 /**
  * The Class SimpleHttpResponse.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class SimpleHttpResponse extends HttpServletResponseWrapper {
 

--- a/Source/JNA/waffle-tests-jakarta/src/main/java/waffle/mock/http/SimpleHttpSession.java
+++ b/Source/JNA/waffle-tests-jakarta/src/main/java/waffle/mock/http/SimpleHttpSession.java
@@ -32,8 +32,6 @@ import java.util.Map;
 
 /**
  * Simple Http Session.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class SimpleHttpSession implements HttpSession {
 

--- a/Source/JNA/waffle-tests-jakarta/src/main/java/waffle/mock/http/SimpleRequestDispatcher.java
+++ b/Source/JNA/waffle-tests-jakarta/src/main/java/waffle/mock/http/SimpleRequestDispatcher.java
@@ -33,8 +33,6 @@ import java.io.IOException;
 
 /**
  * The Class SimpleRequestDispatcher.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class SimpleRequestDispatcher implements RequestDispatcher {
 

--- a/Source/JNA/waffle-tests-jakarta/src/test/java/waffle/jaas/UsernamePasswordCallbackHandler.java
+++ b/Source/JNA/waffle-tests-jakarta/src/test/java/waffle/jaas/UsernamePasswordCallbackHandler.java
@@ -33,8 +33,6 @@ import javax.security.auth.callback.UnsupportedCallbackException;
 
 /**
  * The Class UsernamePasswordCallbackHandler.
- *
- * @author dblock[at]dblock[dot]org
  */
 class UsernamePasswordCallbackHandler implements CallbackHandler {
 

--- a/Source/JNA/waffle-tests-jakarta/src/test/java/waffle/jaas/WindowsLoginModuleTest.java
+++ b/Source/JNA/waffle-tests-jakarta/src/test/java/waffle/jaas/WindowsLoginModuleTest.java
@@ -41,8 +41,6 @@ import waffle.windows.auth.impl.WindowsAccountImpl;
 
 /**
  * The Class WindowsLoginModuleTest.
- *
- * @author dblock[at]dblock[dot]org
  */
 class WindowsLoginModuleTest {
 

--- a/Source/JNA/waffle-tests-jakarta/src/test/java/waffle/servlet/BasicSecurityFilterTest.java
+++ b/Source/JNA/waffle-tests-jakarta/src/test/java/waffle/servlet/BasicSecurityFilterTest.java
@@ -47,8 +47,6 @@ import waffle.windows.auth.impl.WindowsAccountImpl;
 
 /**
  * Waffle Tomcat Security Filter Test.
- *
- * @author dblock[at]dblock[dot]org
  */
 class BasicSecurityFilterTest {
 

--- a/Source/JNA/waffle-tests-jakarta/src/test/java/waffle/servlet/NegotiateSecurityFilterLoadTest.java
+++ b/Source/JNA/waffle-tests-jakarta/src/test/java/waffle/servlet/NegotiateSecurityFilterLoadTest.java
@@ -41,8 +41,6 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 /**
  * The Class NegotiateSecurityFilterLoadTest.
- *
- * @author dblock[at]dblock[dot]org
  */
 class NegotiateSecurityFilterLoadTest {
 

--- a/Source/JNA/waffle-tests-jakarta/src/test/java/waffle/servlet/NegotiateSecurityFilterTest.java
+++ b/Source/JNA/waffle-tests-jakarta/src/test/java/waffle/servlet/NegotiateSecurityFilterTest.java
@@ -59,8 +59,6 @@ import waffle.windows.auth.impl.WindowsSecurityContextImpl;
 
 /**
  * Waffle Tomcat Security Filter Test.
- *
- * @author dblock[at]dblock[dot]org
  */
 class NegotiateSecurityFilterTest {
 

--- a/Source/JNA/waffle-tests-jakarta/src/test/java/waffle/servlet/WindowsPrincipalTest.java
+++ b/Source/JNA/waffle-tests-jakarta/src/test/java/waffle/servlet/WindowsPrincipalTest.java
@@ -41,8 +41,6 @@ import waffle.mock.MockWindowsSecurityContext;
 
 /**
  * The Class WindowsPrincipalTest.
- *
- * @author dblock[at]dblock[dot]org
  */
 class WindowsPrincipalTest {
 

--- a/Source/JNA/waffle-tests-jakarta/src/test/java/waffle/util/AuthorizationHeaderTest.java
+++ b/Source/JNA/waffle-tests-jakarta/src/test/java/waffle/util/AuthorizationHeaderTest.java
@@ -31,8 +31,6 @@ import waffle.mock.http.SimpleHttpRequest;
 
 /**
  * The Class AuthorizationHeaderTest.
- *
- * @author dblock[at]dblock[dot]org
  */
 class AuthorizationHeaderTest {
 

--- a/Source/JNA/waffle-tests-jakarta/src/test/java/waffle/util/NtlmServletRequestTest.java
+++ b/Source/JNA/waffle-tests-jakarta/src/test/java/waffle/util/NtlmServletRequestTest.java
@@ -30,8 +30,6 @@ import waffle.mock.http.SimpleHttpRequest;
 
 /**
  * The Class NtlmServletRequestTest.
- *
- * @author dblock[at]dblock[dot]org
  */
 class NtlmServletRequestTest {
 

--- a/Source/JNA/waffle-tests-jakarta/src/test/java/waffle/windows/auth/WindowsAuthProviderLoadTest.java
+++ b/Source/JNA/waffle-tests-jakarta/src/test/java/waffle/windows/auth/WindowsAuthProviderLoadTest.java
@@ -38,8 +38,6 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 /**
  * The Class WindowsAuthProviderLoadTest.
- *
- * @author dblock[at]dblock[dot]org
  */
 class WindowsAuthProviderLoadTest {
 

--- a/Source/JNA/waffle-tests-jakarta/src/test/java/waffle/windows/auth/WindowsAuthProviderTest.java
+++ b/Source/JNA/waffle-tests-jakarta/src/test/java/waffle/windows/auth/WindowsAuthProviderTest.java
@@ -52,8 +52,6 @@ import waffle.windows.auth.impl.WindowsSecurityContextImpl;
 
 /**
  * The Class WindowsAuthProviderTest.
- *
- * @author dblock[at]dblock[dot]org
  */
 class WindowsAuthProviderTest {
 

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsAccount.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsAccount.java
@@ -27,8 +27,6 @@ import waffle.windows.auth.IWindowsAccount;
 
 /**
  * The Class MockWindowsAccount.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class MockWindowsAccount implements IWindowsAccount {
 

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsAuthProvider.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsAuthProvider.java
@@ -39,8 +39,6 @@ import waffle.windows.auth.IWindowsSecurityContext;
 
 /**
  * The Class MockWindowsAuthProvider.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class MockWindowsAuthProvider implements IWindowsAuthProvider {
 

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsIdentity.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsIdentity.java
@@ -32,8 +32,6 @@ import waffle.windows.auth.IWindowsImpersonationContext;
 
 /**
  * A Mock windows identity.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class MockWindowsIdentity implements IWindowsIdentity {
 

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsImpersonationContext.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsImpersonationContext.java
@@ -27,8 +27,6 @@ import waffle.windows.auth.IWindowsImpersonationContext;
 
 /**
  * The Class MockWindowsImpersonationContext.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class MockWindowsImpersonationContext implements IWindowsImpersonationContext {
 

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsSecurityContext.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/MockWindowsSecurityContext.java
@@ -35,8 +35,6 @@ import waffle.windows.auth.IWindowsSecurityContext;
 
 /**
  * The Class MockWindowsSecurityContext.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class MockWindowsSecurityContext implements IWindowsSecurityContext {
 

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleFilterChain.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleFilterChain.java
@@ -32,8 +32,6 @@ import javax.servlet.ServletResponse;
 
 /**
  * Simple filter chain.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class SimpleFilterChain implements FilterChain {
 

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleFilterConfig.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleFilterConfig.java
@@ -35,8 +35,6 @@ import javax.servlet.ServletContext;
 
 /**
  * The Class SimpleFilterConfig.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class SimpleFilterConfig implements FilterConfig {
 

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleHttpRequest.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleHttpRequest.java
@@ -37,8 +37,6 @@ import org.mockito.Mockito;
 
 /**
  * The Class SimpleHttpRequest.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class SimpleHttpRequest extends HttpServletRequestWrapper {
 

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleHttpResponse.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleHttpResponse.java
@@ -44,8 +44,6 @@ import org.slf4j.LoggerFactory;
 
 /**
  * The Class SimpleHttpResponse.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class SimpleHttpResponse extends HttpServletResponseWrapper {
 

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleHttpSession.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleHttpSession.java
@@ -35,8 +35,6 @@ import javax.servlet.http.HttpSessionContext;
 
 /**
  * Simple Http Session.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class SimpleHttpSession implements HttpSession {
 

--- a/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleRequestDispatcher.java
+++ b/Source/JNA/waffle-tests/src/main/java/waffle/mock/http/SimpleRequestDispatcher.java
@@ -33,8 +33,6 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * The Class SimpleRequestDispatcher.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class SimpleRequestDispatcher implements RequestDispatcher {
 

--- a/Source/JNA/waffle-tests/src/test/java/waffle/jaas/UsernamePasswordCallbackHandler.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/jaas/UsernamePasswordCallbackHandler.java
@@ -33,8 +33,6 @@ import javax.security.auth.callback.UnsupportedCallbackException;
 
 /**
  * The Class UsernamePasswordCallbackHandler.
- *
- * @author dblock[at]dblock[dot]org
  */
 class UsernamePasswordCallbackHandler implements CallbackHandler {
 

--- a/Source/JNA/waffle-tests/src/test/java/waffle/jaas/WindowsLoginModuleTest.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/jaas/WindowsLoginModuleTest.java
@@ -41,8 +41,6 @@ import waffle.windows.auth.impl.WindowsAccountImpl;
 
 /**
  * The Class WindowsLoginModuleTest.
- *
- * @author dblock[at]dblock[dot]org
  */
 class WindowsLoginModuleTest {
 

--- a/Source/JNA/waffle-tests/src/test/java/waffle/servlet/BasicSecurityFilterTest.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/servlet/BasicSecurityFilterTest.java
@@ -46,8 +46,6 @@ import waffle.windows.auth.impl.WindowsAccountImpl;
 
 /**
  * Waffle Tomcat Security Filter Test.
- *
- * @author dblock[at]dblock[dot]org
  */
 class BasicSecurityFilterTest {
 

--- a/Source/JNA/waffle-tests/src/test/java/waffle/servlet/NegotiateSecurityFilterLoadTest.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/servlet/NegotiateSecurityFilterLoadTest.java
@@ -41,8 +41,6 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 /**
  * The Class NegotiateSecurityFilterLoadTest.
- *
- * @author dblock[at]dblock[dot]org
  */
 class NegotiateSecurityFilterLoadTest {
 

--- a/Source/JNA/waffle-tests/src/test/java/waffle/servlet/NegotiateSecurityFilterTest.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/servlet/NegotiateSecurityFilterTest.java
@@ -58,8 +58,6 @@ import waffle.windows.auth.impl.WindowsSecurityContextImpl;
 
 /**
  * Waffle Tomcat Security Filter Test.
- *
- * @author dblock[at]dblock[dot]org
  */
 class NegotiateSecurityFilterTest {
 

--- a/Source/JNA/waffle-tests/src/test/java/waffle/servlet/WindowsPrincipalTest.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/servlet/WindowsPrincipalTest.java
@@ -41,8 +41,6 @@ import waffle.mock.MockWindowsSecurityContext;
 
 /**
  * The Class WindowsPrincipalTest.
- *
- * @author dblock[at]dblock[dot]org
  */
 class WindowsPrincipalTest {
 

--- a/Source/JNA/waffle-tests/src/test/java/waffle/util/AuthorizationHeaderTest.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/util/AuthorizationHeaderTest.java
@@ -31,8 +31,6 @@ import waffle.mock.http.SimpleHttpRequest;
 
 /**
  * The Class AuthorizationHeaderTest.
- *
- * @author dblock[at]dblock[dot]org
  */
 class AuthorizationHeaderTest {
 

--- a/Source/JNA/waffle-tests/src/test/java/waffle/util/NtlmServletRequestTest.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/util/NtlmServletRequestTest.java
@@ -30,8 +30,6 @@ import waffle.mock.http.SimpleHttpRequest;
 
 /**
  * The Class NtlmServletRequestTest.
- *
- * @author dblock[at]dblock[dot]org
  */
 class NtlmServletRequestTest {
 

--- a/Source/JNA/waffle-tests/src/test/java/waffle/windows/auth/WindowsAuthProviderLoadTest.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/windows/auth/WindowsAuthProviderLoadTest.java
@@ -38,8 +38,6 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 /**
  * The Class WindowsAuthProviderLoadTest.
- *
- * @author dblock[at]dblock[dot]org
  */
 class WindowsAuthProviderLoadTest {
 

--- a/Source/JNA/waffle-tests/src/test/java/waffle/windows/auth/WindowsAuthProviderTest.java
+++ b/Source/JNA/waffle-tests/src/test/java/waffle/windows/auth/WindowsAuthProviderTest.java
@@ -52,8 +52,6 @@ import waffle.windows.auth.impl.WindowsSecurityContextImpl;
 
 /**
  * The Class WindowsAuthProviderTest.
- *
- * @author dblock[at]dblock[dot]org
  */
 class WindowsAuthProviderTest {
 

--- a/Source/JNA/waffle-tomcat10/src/main/java/waffle/apache/GenericWindowsPrincipal.java
+++ b/Source/JNA/waffle-tomcat10/src/main/java/waffle/apache/GenericWindowsPrincipal.java
@@ -37,8 +37,6 @@ import waffle.windows.auth.WindowsAccount;
 
 /**
  * A Windows Principal.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class GenericWindowsPrincipal extends GenericPrincipal {
 

--- a/Source/JNA/waffle-tomcat10/src/main/java/waffle/apache/MixedAuthenticator.java
+++ b/Source/JNA/waffle-tomcat10/src/main/java/waffle/apache/MixedAuthenticator.java
@@ -48,8 +48,6 @@ import waffle.windows.auth.IWindowsSecurityContext;
 
 /**
  * Mixed Negotiate + Form Authenticator.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class MixedAuthenticator extends WaffleAuthenticatorBase {
 

--- a/Source/JNA/waffle-tomcat10/src/main/java/waffle/apache/NegotiateAuthenticator.java
+++ b/Source/JNA/waffle-tomcat10/src/main/java/waffle/apache/NegotiateAuthenticator.java
@@ -44,8 +44,6 @@ import waffle.windows.auth.IWindowsSecurityContext;
 
 /**
  * An Apache Negotiate (NTLM, Kerberos) Authenticator.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
 

--- a/Source/JNA/waffle-tomcat10/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
+++ b/Source/JNA/waffle-tomcat10/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
@@ -46,8 +46,6 @@ import waffle.windows.auth.impl.WindowsAuthProviderImpl;
 
 /**
  * The Class WaffleAuthenticatorBase.
- *
- * @author dblock[at]dblock[dot]org
  */
 abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
 

--- a/Source/JNA/waffle-tomcat10/src/main/java/waffle/apache/WindowsRealm.java
+++ b/Source/JNA/waffle-tomcat10/src/main/java/waffle/apache/WindowsRealm.java
@@ -31,8 +31,6 @@ import org.apache.catalina.realm.RealmBase;
 
 /**
  * A rudimentary Windows realm.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class WindowsRealm extends RealmBase {
 

--- a/Source/JNA/waffle-tomcat10/src/test/java/waffle/apache/MixedAuthenticatorTest.java
+++ b/Source/JNA/waffle-tomcat10/src/test/java/waffle/apache/MixedAuthenticatorTest.java
@@ -57,8 +57,6 @@ import waffle.windows.auth.impl.WindowsSecurityContextImpl;
 
 /**
  * Waffle Tomcat Mixed Authenticator Test.
- *
- * @author dblock[at]dblock[dot]org
  */
 class MixedAuthenticatorTest {
 

--- a/Source/JNA/waffle-tomcat10/src/test/java/waffle/apache/NegotiateAuthenticatorTest.java
+++ b/Source/JNA/waffle-tomcat10/src/test/java/waffle/apache/NegotiateAuthenticatorTest.java
@@ -52,8 +52,6 @@ import waffle.windows.auth.impl.WindowsSecurityContextImpl;
 
 /**
  * Waffle Tomcat Authenticator Test.
- *
- * @author dblock[at]dblock[dot]org
  */
 class NegotiateAuthenticatorTest {
 

--- a/Source/JNA/waffle-tomcat10/src/test/java/waffle/apache/WaffleAuthenticatorBaseTest.java
+++ b/Source/JNA/waffle-tomcat10/src/test/java/waffle/apache/WaffleAuthenticatorBaseTest.java
@@ -35,8 +35,6 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Waffle Authenticator Base Test.
- *
- * @author dblock[at]dblock[dot]org
  */
 class WaffleAuthenticatorBaseTest {
 

--- a/Source/JNA/waffle-tomcat10/src/test/java/waffle/apache/WindowsAccountTest.java
+++ b/Source/JNA/waffle-tomcat10/src/test/java/waffle/apache/WindowsAccountTest.java
@@ -41,8 +41,6 @@ import waffle.windows.auth.WindowsAccount;
 
 /**
  * Windows Account Test.
- *
- * @author dblock[at]dblock[dot]org
  */
 class WindowsAccountTest {
 

--- a/Source/JNA/waffle-tomcat10/src/test/java/waffle/apache/WindowsRealmTest.java
+++ b/Source/JNA/waffle-tomcat10/src/test/java/waffle/apache/WindowsRealmTest.java
@@ -28,8 +28,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Windows Realm Test.
- *
- * @author dblock[at]dblock[dot]org
  */
 class WindowsRealmTest {
 

--- a/Source/JNA/waffle-tomcat10/src/test/java/waffle/apache/catalina/SimpleHttpRequest.java
+++ b/Source/JNA/waffle-tomcat10/src/test/java/waffle/apache/catalina/SimpleHttpRequest.java
@@ -35,8 +35,6 @@ import org.apache.catalina.connector.Request;
 
 /**
  * Simple HTTP Request.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class SimpleHttpRequest extends Request {
 

--- a/Source/JNA/waffle-tomcat10/src/test/java/waffle/apache/catalina/SimpleHttpResponse.java
+++ b/Source/JNA/waffle-tomcat10/src/test/java/waffle/apache/catalina/SimpleHttpResponse.java
@@ -35,8 +35,6 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Simple HTTP Response.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class SimpleHttpResponse extends Response {
 

--- a/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/GenericWindowsPrincipal.java
+++ b/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/GenericWindowsPrincipal.java
@@ -37,8 +37,6 @@ import waffle.windows.auth.WindowsAccount;
 
 /**
  * A Windows Principal.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class GenericWindowsPrincipal extends GenericPrincipal {
 

--- a/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/MixedAuthenticator.java
+++ b/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/MixedAuthenticator.java
@@ -48,8 +48,6 @@ import waffle.windows.auth.IWindowsSecurityContext;
 
 /**
  * Mixed Negotiate + Form Authenticator.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class MixedAuthenticator extends WaffleAuthenticatorBase {
 

--- a/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/NegotiateAuthenticator.java
+++ b/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/NegotiateAuthenticator.java
@@ -44,8 +44,6 @@ import waffle.windows.auth.IWindowsSecurityContext;
 
 /**
  * An Apache Negotiate (NTLM, Kerberos) Authenticator.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
 

--- a/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
+++ b/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
@@ -46,8 +46,6 @@ import waffle.windows.auth.impl.WindowsAuthProviderImpl;
 
 /**
  * The Class WaffleAuthenticatorBase.
- *
- * @author dblock[at]dblock[dot]org
  */
 abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
 

--- a/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/WindowsRealm.java
+++ b/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/WindowsRealm.java
@@ -31,8 +31,6 @@ import org.apache.catalina.realm.RealmBase;
 
 /**
  * A rudimentary Windows realm.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class WindowsRealm extends RealmBase {
 

--- a/Source/JNA/waffle-tomcat85/src/test/java/waffle/apache/MixedAuthenticatorTest.java
+++ b/Source/JNA/waffle-tomcat85/src/test/java/waffle/apache/MixedAuthenticatorTest.java
@@ -57,8 +57,6 @@ import waffle.windows.auth.impl.WindowsSecurityContextImpl;
 
 /**
  * Waffle Tomcat Mixed Authenticator Test.
- *
- * @author dblock[at]dblock[dot]org
  */
 class MixedAuthenticatorTest {
 

--- a/Source/JNA/waffle-tomcat85/src/test/java/waffle/apache/NegotiateAuthenticatorTest.java
+++ b/Source/JNA/waffle-tomcat85/src/test/java/waffle/apache/NegotiateAuthenticatorTest.java
@@ -52,8 +52,6 @@ import waffle.windows.auth.impl.WindowsSecurityContextImpl;
 
 /**
  * Waffle Tomcat Authenticator Test.
- *
- * @author dblock[at]dblock[dot]org
  */
 class NegotiateAuthenticatorTest {
 

--- a/Source/JNA/waffle-tomcat85/src/test/java/waffle/apache/WaffleAuthenticatorBaseTest.java
+++ b/Source/JNA/waffle-tomcat85/src/test/java/waffle/apache/WaffleAuthenticatorBaseTest.java
@@ -35,8 +35,6 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Waffle Authenticator Base Test.
- *
- * @author dblock[at]dblock[dot]org
  */
 class WaffleAuthenticatorBaseTest {
 

--- a/Source/JNA/waffle-tomcat85/src/test/java/waffle/apache/WindowsAccountTest.java
+++ b/Source/JNA/waffle-tomcat85/src/test/java/waffle/apache/WindowsAccountTest.java
@@ -41,8 +41,6 @@ import waffle.windows.auth.WindowsAccount;
 
 /**
  * Windows Account Test.
- *
- * @author dblock[at]dblock[dot]org
  */
 class WindowsAccountTest {
 

--- a/Source/JNA/waffle-tomcat85/src/test/java/waffle/apache/WindowsRealmTest.java
+++ b/Source/JNA/waffle-tomcat85/src/test/java/waffle/apache/WindowsRealmTest.java
@@ -28,8 +28,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Windows Realm Test.
- *
- * @author dblock[at]dblock[dot]org
  */
 class WindowsRealmTest {
 

--- a/Source/JNA/waffle-tomcat85/src/test/java/waffle/apache/catalina/SimpleHttpRequest.java
+++ b/Source/JNA/waffle-tomcat85/src/test/java/waffle/apache/catalina/SimpleHttpRequest.java
@@ -35,8 +35,6 @@ import org.apache.catalina.connector.Request;
 
 /**
  * Simple HTTP Request.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class SimpleHttpRequest extends Request {
 

--- a/Source/JNA/waffle-tomcat85/src/test/java/waffle/apache/catalina/SimpleHttpResponse.java
+++ b/Source/JNA/waffle-tomcat85/src/test/java/waffle/apache/catalina/SimpleHttpResponse.java
@@ -35,8 +35,6 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Simple HTTP Response.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class SimpleHttpResponse extends Response {
 

--- a/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/GenericWindowsPrincipal.java
+++ b/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/GenericWindowsPrincipal.java
@@ -37,8 +37,6 @@ import waffle.windows.auth.WindowsAccount;
 
 /**
  * A Windows Principal.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class GenericWindowsPrincipal extends GenericPrincipal {
 

--- a/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/MixedAuthenticator.java
+++ b/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/MixedAuthenticator.java
@@ -48,8 +48,6 @@ import waffle.windows.auth.IWindowsSecurityContext;
 
 /**
  * Mixed Negotiate + Form Authenticator.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class MixedAuthenticator extends WaffleAuthenticatorBase {
 

--- a/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/NegotiateAuthenticator.java
+++ b/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/NegotiateAuthenticator.java
@@ -44,8 +44,6 @@ import waffle.windows.auth.IWindowsSecurityContext;
 
 /**
  * An Apache Negotiate (NTLM, Kerberos) Authenticator.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
 

--- a/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
+++ b/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/WaffleAuthenticatorBase.java
@@ -46,8 +46,6 @@ import waffle.windows.auth.impl.WindowsAuthProviderImpl;
 
 /**
  * The Class WaffleAuthenticatorBase.
- *
- * @author dblock[at]dblock[dot]org
  */
 abstract class WaffleAuthenticatorBase extends AuthenticatorBase {
 

--- a/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/WindowsRealm.java
+++ b/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/WindowsRealm.java
@@ -31,8 +31,6 @@ import org.apache.catalina.realm.RealmBase;
 
 /**
  * A rudimentary Windows realm.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class WindowsRealm extends RealmBase {
 

--- a/Source/JNA/waffle-tomcat9/src/test/java/waffle/apache/MixedAuthenticatorTest.java
+++ b/Source/JNA/waffle-tomcat9/src/test/java/waffle/apache/MixedAuthenticatorTest.java
@@ -57,8 +57,6 @@ import waffle.windows.auth.impl.WindowsSecurityContextImpl;
 
 /**
  * Waffle Tomcat Mixed Authenticator Test.
- *
- * @author dblock[at]dblock[dot]org
  */
 class MixedAuthenticatorTest {
 

--- a/Source/JNA/waffle-tomcat9/src/test/java/waffle/apache/NegotiateAuthenticatorTest.java
+++ b/Source/JNA/waffle-tomcat9/src/test/java/waffle/apache/NegotiateAuthenticatorTest.java
@@ -52,8 +52,6 @@ import waffle.windows.auth.impl.WindowsSecurityContextImpl;
 
 /**
  * Waffle Tomcat Authenticator Test.
- *
- * @author dblock[at]dblock[dot]org
  */
 class NegotiateAuthenticatorTest {
 

--- a/Source/JNA/waffle-tomcat9/src/test/java/waffle/apache/WaffleAuthenticatorBaseTest.java
+++ b/Source/JNA/waffle-tomcat9/src/test/java/waffle/apache/WaffleAuthenticatorBaseTest.java
@@ -35,8 +35,6 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Waffle Authenticator Base Test.
- *
- * @author dblock[at]dblock[dot]org
  */
 class WaffleAuthenticatorBaseTest {
 

--- a/Source/JNA/waffle-tomcat9/src/test/java/waffle/apache/WindowsAccountTest.java
+++ b/Source/JNA/waffle-tomcat9/src/test/java/waffle/apache/WindowsAccountTest.java
@@ -41,8 +41,6 @@ import waffle.windows.auth.WindowsAccount;
 
 /**
  * Windows Account Test.
- *
- * @author dblock[at]dblock[dot]org
  */
 class WindowsAccountTest {
 

--- a/Source/JNA/waffle-tomcat9/src/test/java/waffle/apache/WindowsRealmTest.java
+++ b/Source/JNA/waffle-tomcat9/src/test/java/waffle/apache/WindowsRealmTest.java
@@ -28,8 +28,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Windows Realm Test.
- *
- * @author dblock[at]dblock[dot]org
  */
 class WindowsRealmTest {
 

--- a/Source/JNA/waffle-tomcat9/src/test/java/waffle/apache/catalina/SimpleHttpRequest.java
+++ b/Source/JNA/waffle-tomcat9/src/test/java/waffle/apache/catalina/SimpleHttpRequest.java
@@ -35,8 +35,6 @@ import org.apache.catalina.connector.Request;
 
 /**
  * Simple HTTP Request.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class SimpleHttpRequest extends Request {
 

--- a/Source/JNA/waffle-tomcat9/src/test/java/waffle/apache/catalina/SimpleHttpResponse.java
+++ b/Source/JNA/waffle-tomcat9/src/test/java/waffle/apache/catalina/SimpleHttpResponse.java
@@ -35,8 +35,6 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Simple HTTP Response.
- *
- * @author dblock[at]dblock[dot]org
  */
 public class SimpleHttpResponse extends Response {
 


### PR DESCRIPTION
git shows us this history, this signals individual(s) wrote all the code which is never completely true, and it further leads to blaming author.  Proper open source should not point people out but rather allow focus on the source code itself.   Deleting all this.