### PR TITLE
[cleanup] Use simpleName from class instead of string/1.0 just as tom…

### DIFF
--- a/Source/JNA/waffle-tomcat10/src/main/java/waffle/apache/MixedAuthenticator.java
+++ b/Source/JNA/waffle-tomcat10/src/main/java/waffle/apache/MixedAuthenticator.java
@@ -57,7 +57,7 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
     public MixedAuthenticator() {
         super();
         this.log = LoggerFactory.getLogger(MixedAuthenticator.class);
-        this.info = "waffle.apache.MixedAuthenticator/1.0";
+        this.info = MixedAuthenticator.class.getSimpleName();
         this.log.debug("[waffle.apache.MixedAuthenticator] loaded");
     }
 

--- a/Source/JNA/waffle-tomcat10/src/main/java/waffle/apache/NegotiateAuthenticator.java
+++ b/Source/JNA/waffle-tomcat10/src/main/java/waffle/apache/NegotiateAuthenticator.java
@@ -53,7 +53,7 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
     public NegotiateAuthenticator() {
         super();
         this.log = LoggerFactory.getLogger(NegotiateAuthenticator.class);
-        this.info = "waffle.apache.NegotiateAuthenticator/1.0";
+        this.info = NegotiateAuthenticator.class.getSimpleName();
         this.log.debug("[waffle.apache.NegotiateAuthenticator] loaded");
     }
 

--- a/Source/JNA/waffle-tomcat10/src/main/java/waffle/apache/WindowsRealm.java
+++ b/Source/JNA/waffle-tomcat10/src/main/java/waffle/apache/WindowsRealm.java
@@ -23,8 +23,6 @@
  */
 package waffle.apache;
 
-import com.google.errorprone.annotations.InlineMe;
-
 import java.security.Principal;
 
 import org.apache.catalina.realm.RealmBase;
@@ -33,27 +31,6 @@ import org.apache.catalina.realm.RealmBase;
  * A rudimentary Windows realm.
  */
 public class WindowsRealm extends RealmBase {
-
-    /** The Constant NAME. */
-    protected static final String NAME = "waffle.apache.WindowsRealm/1.0";
-
-    /**
-     * Gets the name.
-     * <p>
-     * 'waffle.apache.WindowsRealm/1.0' will no longer be logged. We don't internally use this so we must go with
-     * standard java way that tomcat has accepted. This means, going to tomcat 9.0.0.M15+ will result simply in
-     * 'WaffleRealm' or better stated the actual simple class name. Simple class name strips off the package name which
-     * is what we were applying along with version 1.0 which is inaccurate based on our release version.
-     *
-     * @return a short name for this Realm implementation, for use in log messages.
-     *
-     * @deprecated This will be removed in Tomcat 9 onwards. Use {@link Class#getSimpleName()} instead.
-     */
-    @Deprecated
-    @InlineMe(replacement = "WindowsRealm.NAME", imports = "waffle.apache.WindowsRealm")
-    protected final String getName() {
-        return WindowsRealm.NAME;
-    }
 
     @Override
     protected String getPassword(final String value) {

--- a/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/MixedAuthenticator.java
+++ b/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/MixedAuthenticator.java
@@ -57,7 +57,7 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
     public MixedAuthenticator() {
         super();
         this.log = LoggerFactory.getLogger(MixedAuthenticator.class);
-        this.info = "waffle.apache.MixedAuthenticator/1.0";
+        this.info = MixedAuthenticator.class.getSimpleName();
         this.log.debug("[waffle.apache.MixedAuthenticator] loaded");
     }
 

--- a/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/NegotiateAuthenticator.java
+++ b/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/NegotiateAuthenticator.java
@@ -53,7 +53,7 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
     public NegotiateAuthenticator() {
         super();
         this.log = LoggerFactory.getLogger(NegotiateAuthenticator.class);
-        this.info = "waffle.apache.NegotiateAuthenticator/1.0";
+        this.info = NegotiateAuthenticator.class.getSimpleName();
         this.log.debug("[waffle.apache.NegotiateAuthenticator] loaded");
     }
 

--- a/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/WindowsRealm.java
+++ b/Source/JNA/waffle-tomcat85/src/main/java/waffle/apache/WindowsRealm.java
@@ -34,26 +34,18 @@ import org.apache.catalina.realm.RealmBase;
  */
 public class WindowsRealm extends RealmBase {
 
-    /** The Constant NAME. */
-    protected static final String NAME = "waffle.apache.WindowsRealm/1.0";
-
     /**
-     * Gets the name.
-     * <p>
-     * 'waffle.apache.WindowsRealm/1.0' will no longer be logged. We don't internally use this so we must go with
-     * standard java way that tomcat has accepted. This means, going to tomcat 9.0.0.M15+ will result simply in
-     * 'WaffleRealm' or better stated the actual simple class name. Simple class name strips off the package name which
-     * is what we were applying along with version 1.0 which is inaccurate based on our release version.
+     * Gets the name simple class name.
      *
      * @return a short name for this Realm implementation, for use in log messages.
      *
      * @deprecated This will be removed in Tomcat 9 onwards. Use {@link Class#getSimpleName()} instead.
      */
     @Deprecated
-    @InlineMe(replacement = "WindowsRealm.NAME", imports = "waffle.apache.WindowsRealm")
+    @InlineMe(replacement = "WindowsRealm.class.getSimpleName()", imports = "waffle.apache.WindowsRealm")
     @Override
     protected final String getName() {
-        return WindowsRealm.NAME;
+        return WindowsRealm.class.getSimpleName();
     }
 
     @Override

--- a/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/MixedAuthenticator.java
+++ b/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/MixedAuthenticator.java
@@ -57,7 +57,7 @@ public class MixedAuthenticator extends WaffleAuthenticatorBase {
     public MixedAuthenticator() {
         super();
         this.log = LoggerFactory.getLogger(MixedAuthenticator.class);
-        this.info = "waffle.apache.MixedAuthenticator/1.0";
+        this.info = MixedAuthenticator.class.getSimpleName();
         this.log.debug("[waffle.apache.MixedAuthenticator] loaded");
     }
 

--- a/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/NegotiateAuthenticator.java
+++ b/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/NegotiateAuthenticator.java
@@ -53,7 +53,7 @@ public class NegotiateAuthenticator extends WaffleAuthenticatorBase {
     public NegotiateAuthenticator() {
         super();
         this.log = LoggerFactory.getLogger(NegotiateAuthenticator.class);
-        this.info = "waffle.apache.NegotiateAuthenticator/1.0";
+        this.info = NegotiateAuthenticator.class.getSimpleName();
         this.log.debug("[waffle.apache.NegotiateAuthenticator] loaded");
     }
 

--- a/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/WindowsRealm.java
+++ b/Source/JNA/waffle-tomcat9/src/main/java/waffle/apache/WindowsRealm.java
@@ -23,8 +23,6 @@
  */
 package waffle.apache;
 
-import com.google.errorprone.annotations.InlineMe;
-
 import java.security.Principal;
 
 import org.apache.catalina.realm.RealmBase;
@@ -33,27 +31,6 @@ import org.apache.catalina.realm.RealmBase;
  * A rudimentary Windows realm.
  */
 public class WindowsRealm extends RealmBase {
-
-    /** The Constant NAME. */
-    protected static final String NAME = "waffle.apache.WindowsRealm/1.0";
-
-    /**
-     * Gets the name.
-     * <p>
-     * 'waffle.apache.WindowsRealm/1.0' will no longer be logged. We don't internally use this so we must go with
-     * standard java way that tomcat has accepted. This means, going to tomcat 9.0.0.M15+ will result simply in
-     * 'WaffleRealm' or better stated the actual simple class name. Simple class name strips off the package name which
-     * is what we were applying along with version 1.0 which is inaccurate based on our release version.
-     *
-     * @return a short name for this Realm implementation, for use in log messages.
-     *
-     * @deprecated This will be removed in Tomcat 9 onwards. Use {@link Class#getSimpleName()} instead.
-     */
-    @Deprecated
-    @InlineMe(replacement = "WindowsRealm.NAME", imports = "waffle.apache.WindowsRealm")
-    protected final String getName() {
-        return WindowsRealm.NAME;
-    }
 
     @Override
     protected String getPassword(final String value) {


### PR DESCRIPTION
…cat did

For tomcat 9+ this just needed removed.  It was abstract before that.  For the others, that is our invention as 'info' so just switch to simple name as that makes most sense.