### PR TITLE
Update AuthorizationHeader.java

### DIFF
--- a/Source/JNA/waffle-jna/src/main/java/waffle/util/AuthorizationHeader.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/util/AuthorizationHeader.java
@@ -58,7 +58,14 @@ public class AuthorizationHeader {
      * @return the header
      */
     public String getHeader() {
-        return this.request.getHeader("Authorization");
+        Enumeration<String> headerNames = request.getHeaderNames();
+        while (headerNames.hasMoreElements()) {
+            String headerName = headerNames.nextElement();
+            if ("authorization".equalsIgnoreCase(headerName)) {
+                return request.getHeader(headerName);
+            }
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
Kerberos Authentication Fails Due to Case Sensitivity in Authorization Header

[https://github.com/Waffle/waffle/issues/2933](url)