### PR TITLE
[pom] Force spring boot 2 to slf4j 2 and logback 1.5

### DIFF
--- a/Source/JNA/waffle-spring-boot2/pom.xml
+++ b/Source/JNA/waffle-spring-boot2/pom.xml
@@ -61,8 +61,8 @@
         <jna.version>5.18.1</jna.version>
         <junit.version>6.0.1</junit.version>
         <log4j.version>2.25.2</log4j.version>
-        <logback.version>1.2.13</logback.version>
-        <slf4j.version>1.7.36</slf4j.version>
+        <logback.version>1.5.21</logback.version>
+        <slf4j.version>2.0.17</slf4j.version>
         <snakeyaml.version>2.5</snakeyaml.version>
         <spring.version>5.3.39</spring.version>
         <spring-boot.version>2.7.18</spring-boot.version>
@@ -86,7 +86,7 @@
             <!-- External Dependencies -->
             <dependency>
                 <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-simple</artifactId>
+                <artifactId>slf4j-api</artifactId>
                 <version>${slf4j.version}</version>
             </dependency>
 


### PR DESCRIPTION
rest are unsupported / highly vulnerable, just move on. Downstream users can decide what they want and its easy to just tell spring to set to none for logging.  See demo for how.