### PR TITLE
[dotnet] Upgrade to wix 4.0.6

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,5 +1,13 @@
 {
   "version": 1,
   "isRoot": true,
-  "tools": {}
+  "tools": {
+    "wix": {
+      "version": "4.0.6",
+      "commands": [
+        "wix"
+      ],
+      "rollForward": false
+    }
+  }
 }

--- a/Docs/SettingUpDevelopmentEnvironment.md
+++ b/Docs/SettingUpDevelopmentEnvironment.md
@@ -49,9 +49,9 @@ Download NUnit from [here](https://nunit.org).
 
 Download and install MSBuild Community Tasks from [here](https://github.com/loresoft/msbuildtasks/releases).
 
-### Wix Toolset 3.10.3
+### Wix Toolset 4.0.6
 
-Download and install the Wix toolset from [here](https://wix.codeplex.com/releases/view/624906).
+WiX is restored as a local .NET tool by bootstrap.cmd. The WiX MSBuild SDK is restored automatically when the WiX project is built.
 
 Building the Project the First Time
 -----------------------------------
@@ -123,12 +123,12 @@ MSBuild Community Tasks are missing.
 ```
 "E:\waffle\Waffle.proj" (all target) (1) ->
 "E:\waffle\Waffle.sln" (Clean target) (2) ->
-(Clean target) ->  E:\waffle\Source\WindowsAuthProviderMergeModule\WindowsAuthProviderMergeModule.wixproj(107,11):
-error MSB4019: The imported project "C:\Program Files\MSBuild\Microsoft\WiX\v3.x\Wix.targets" was not found.
+(Clean target) ->  E:\waffle\Source\WindowsAuthProviderMergeModule\WindowsAuthProviderMergeModule.wixproj(3,3):
+error MSB4019: The imported project "..\..\.nuget\packages\WixToolset.Sdk.4.0.6\tools\wix.props" was not found.
 Confirm that the path in the <Import> declaration is correct, and that the file exists on disk.
 ```
 
-Wix is missing.
+WiX package restore is missing. Re-run `bootstrap.cmd`.
 
 ### Product Version
 

--- a/Source/WindowsAuthProviderMergeModule/WindowsAuthProviderMergeModule.wixproj
+++ b/Source/WindowsAuthProviderMergeModule/WindowsAuthProviderMergeModule.wixproj
@@ -1,37 +1,31 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
-  <Import Project="..\..\.nuget\packages\WiX.4.0.0.5512-pre\build\wix.props" Condition="Exists('..\..\.nuget\packages\WiX.4.0.0.5512-pre\build\wix.props')" />
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="WixToolset.Sdk/4.0.6">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <ProductVersion>3.0</ProductVersion>
     <ProjectGuid>{8e2e9431-3fd1-41e9-97cf-cc96dd32386f}</ProjectGuid>
     <SchemaVersion>2.0</SchemaVersion>
     <OutputName>Waffle.Windows.AuthProvider</OutputName>
     <OutputType>Module</OutputType>
-    <WixToolPath>..\..\.nuget\packages\WiX.4.0.0.5512-pre\tools</WixToolPath>
     <RunWixToolsOutOfProc>true</RunWixToolsOutOfProc>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <OutputPath>bin\Debug\</OutputPath>
     <IntermediateOutputPath>obj\Debug\</IntermediateOutputPath>
     <DefineConstants>Debug</DefineConstants>
-    <IncludeSearchPaths>
-    </IncludeSearchPaths>
+    <IncludeSearchPaths />
     <Pedantic>False</Pedantic>
     <ShowSourceTrace>False</ShowSourceTrace>
     <SuppressSchemaValidation>False</SuppressSchemaValidation>
-    <SuppressSpecificWarnings>
-    </SuppressSpecificWarnings>
+    <SuppressSpecificWarnings />
     <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
     <VerboseOutput>False</VerboseOutput>
     <AllowIdenticalRows>False</AllowIdenticalRows>
-    <CabinetCachePath>
-    </CabinetCachePath>
+    <CabinetCachePath />
     <CabinetCreationThreadCount>-1</CabinetCreationThreadCount>
-    <Cultures>
-    </Cultures>
+    <Cultures />
     <LeaveTemporaryFiles>False</LeaveTemporaryFiles>
     <LinkerPedantic>False</LinkerPedantic>
     <ReuseCabinetCache>False</ReuseCabinetCache>
@@ -44,40 +38,33 @@
     <SuppressDroppingUnrealTables>False</SuppressDroppingUnrealTables>
     <SuppressFileHashAndInfo>False</SuppressFileHashAndInfo>
     <SuppressFiles>False</SuppressFiles>
-    <SuppressIces>
-    </SuppressIces>
+    <SuppressIces />
     <LinkerSuppressIntermediateFileVersionMatching>False</LinkerSuppressIntermediateFileVersionMatching>
     <SuppressLayout>False</SuppressLayout>
     <SuppressMsiAssemblyTableProcessing>False</SuppressMsiAssemblyTableProcessing>
     <LinkerSuppressSchemaValidation>False</LinkerSuppressSchemaValidation>
-    <LinkerSuppressSpecificWarnings>
-    </LinkerSuppressSpecificWarnings>
+    <LinkerSuppressSpecificWarnings />
     <SuppressValidation>False</SuppressValidation>
     <LinkerTreatWarningsAsErrors>False</LinkerTreatWarningsAsErrors>
     <LinkerVerboseOutput>False</LinkerVerboseOutput>
-    <WixVariables>
-    </WixVariables>
+    <WixVariables />
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <OutputPath>bin\Release\</OutputPath>
     <IntermediateOutputPath>obj\Release\</IntermediateOutputPath>
-    <DefineConstants>
-    </DefineConstants>
-    <IncludeSearchPaths>
-    </IncludeSearchPaths>
+    <DefineConstants />
+    <IncludeSearchPaths />
     <Pedantic>False</Pedantic>
     <ShowSourceTrace>False</ShowSourceTrace>
     <SuppressSchemaValidation>False</SuppressSchemaValidation>
-    <SuppressSpecificWarnings>
-    </SuppressSpecificWarnings>
+    <SuppressSpecificWarnings />
     <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
     <VerboseOutput>False</VerboseOutput>
     <AllowIdenticalRows>False</AllowIdenticalRows>
-    <CabinetCachePath>
-    </CabinetCachePath>
+    <CabinetCachePath />
     <CabinetCreationThreadCount>-1</CabinetCreationThreadCount>
-    <Cultures>
-    </Cultures>
+    <Cultures />
     <LeaveTemporaryFiles>False</LeaveTemporaryFiles>
     <LinkerPedantic>False</LinkerPedantic>
     <ReuseCabinetCache>False</ReuseCabinetCache>
@@ -90,39 +77,31 @@
     <SuppressDroppingUnrealTables>False</SuppressDroppingUnrealTables>
     <SuppressFileHashAndInfo>False</SuppressFileHashAndInfo>
     <SuppressFiles>False</SuppressFiles>
-    <SuppressIces>
-    </SuppressIces>
+    <SuppressIces />
     <LinkerSuppressIntermediateFileVersionMatching>False</LinkerSuppressIntermediateFileVersionMatching>
     <SuppressLayout>False</SuppressLayout>
     <SuppressMsiAssemblyTableProcessing>False</SuppressMsiAssemblyTableProcessing>
     <LinkerSuppressSchemaValidation>False</LinkerSuppressSchemaValidation>
-    <LinkerSuppressSpecificWarnings>
-    </LinkerSuppressSpecificWarnings>
+    <LinkerSuppressSpecificWarnings />
     <SuppressValidation>False</SuppressValidation>
     <LinkerTreatWarningsAsErrors>False</LinkerTreatWarningsAsErrors>
     <LinkerVerboseOutput>False</LinkerVerboseOutput>
-    <WixVariables>
-    </WixVariables>
+    <WixVariables />
   </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="WindowsAuthProviderMergeModule.wxs" />
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="packages.config" />
-  </ItemGroup>
-  <Import Project="$(WixTargetsPath)" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\.nuget\packages\WiX.4.0.0.5512-pre\build\wix.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\.nuget\packages\WiX.4.0.0.5512-pre\build\wix.props'))" />
-  </Target>
+
   <!--
-    To modify your build process, add your task inside one of the targets below and uncomment it.
-    Other similar extension points exist, see Wix.targets.
+    To modify your build process, add your task inside one of the targets below
+    and uncomment it. Other similar extension points exist in Wix.targets.
+
     <Target Name="BeforeBuild">
     </Target>
+
     <Target Name="AfterBuild">
     </Target>
-    -->
+  -->
+
 </Project>

--- a/Source/WindowsAuthProviderMergeModule/WindowsAuthProviderMergeModule.wixproj
+++ b/Source/WindowsAuthProviderMergeModule/WindowsAuthProviderMergeModule.wixproj
@@ -89,10 +89,6 @@
     <WixVariables />
   </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include="WindowsAuthProviderMergeModule.wxs" />
-  </ItemGroup>
-
   <!--
     To modify your build process, add your task inside one of the targets below
     and uncomment it. Other similar extension points exist in Wix.targets.

--- a/Source/WindowsAuthProviderMergeModule/WindowsAuthProviderMergeModule.wxs
+++ b/Source/WindowsAuthProviderMergeModule/WindowsAuthProviderMergeModule.wxs
@@ -7,60 +7,63 @@
   <?define Configuration=Release?>
  <?endif ?>
 <?endif ?>
+
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
-    <Module Id="WindowsAuthProviderMSM" Language="1033" Version="$(var.ProductVersion)">
-        <Package Id="80101f8b-1c44-4c7d-969b-0731b162d54b" Manufacturer="$(var.CompanyName)" InstallerVersion="200" />
-        <Directory Id="TARGETDIR" Name="SourceDir">
-            <Directory Id="MergeRedirectFolder">
-                <Component Id="WindowsAuthProvider" Guid="74ad70ef-aa1a-4d8f-a31c-dda1716b7dd1">
-                    <File Id="WindowsAuthProviderDll" Source="$(var.MSBuildProjectDirectory)\Source\WindowsAuthProvider\bin\$(var.Configuration)\Waffle.Windows.AuthProvider.dll" KeyPath="yes" Name="Waffle.Windows.AuthProvider.dll" />
-                    <RegistryKey Id="RegAdvapi32.LogonType" Root="HKCR" Key="Record\{FA3F1B69-D60F-4CBF-9A44-8CE47E5C9FF3}\$(var.ProductVersion)" ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes">
-                        <RegistryValue Type="string" Name="Class" Value="Waffle.Windows.Advapi32+LogonType" />
-                        <RegistryValue Type="string" Name="Assembly" Value="Waffle.Windows.AuthProvider" />
-                        <RegistryValue Type="string" Name="RuntimeVersion" Value="v2.0.50727" />
-                        <RegistryValue Type="string" Name="CodeBase" Value="[#WindowsAuthProviderDll]" />
-                    </RegistryKey>
-                    <RegistryKey Id="RegAdvapi32.LogonProvider" Root="HKCR" Key="Record\{32843EC8-13A5-499A-AED3-EAEB08C3381A}\$(var.ProductVersion)" ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes">
-                        <RegistryValue Type="string" Name="Class" Value="Waffle.Windows.Advapi32+LogonProvider" />
-                        <RegistryValue Type="string" Name="Assembly" Value="Waffle.Windows.AuthProvider" />
-                        <RegistryValue Type="string" Name="RuntimeVersion" Value="v2.0.50727" />
-                        <RegistryValue Type="string" Name="CodeBase" Value="[#WindowsAuthProviderDll]" />
-                    </RegistryKey>
-                    <RegistryKey Id="RegAdvapi32.SID_NAME_USE" Root="HKCR" Key="Record\{673D9C4F-13FD-430C-AFD1-4E706FFC0DC4}\$(var.ProductVersion)" ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes">
-                        <RegistryValue Type="string" Name="Class" Value="Waffle.Windows.Advapi32+SID_NAME_USE" />
-                        <RegistryValue Type="string" Name="Assembly" Value="Waffle.Windows.AuthProvider" />
-                        <RegistryValue Type="string" Name="RuntimeVersion" Value="v2.0.50727" />
-                        <RegistryValue Type="string" Name="CodeBase" Value="[#WindowsAuthProviderDll]" />
-                    </RegistryKey>
-                    <RegistryKey Id="RegAuth" Root="HKCR" Key="Waffle.Windows.AuthProvider" ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes">
-                        <RegistryValue Type="string" Value="Waffle.Windows.AuthProvider.WindowsAuthProviderImpl" />
-                    </RegistryKey>
-                    <RegistryKey Id="RegAuthCLSID" Root="HKCR" Key="Waffle.Windows.AuthProvider\CLSID" ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes">
-                        <RegistryValue Type="string" Value="{78FA881E-5141-3B68-A76C-487871F4846A}" />
-                    </RegistryKey>
-                    <RegistryKey Id="RegAuthCLSIDGuid" Root="HKCR" Key="CLSID\{78FA881E-5141-3B68-A76C-487871F4846A}" ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes">
-                        <RegistryValue Type="string" Value="Waffle.Windows.AuthProvider.WindowsAuthProviderImpl" />
-                    </RegistryKey>
-                    <RegistryKey Id="RegAuthCLSIDGuidIS32" Root="HKCR" Key="CLSID\{78FA881E-5141-3B68-A76C-487871F4846A}\InprocServer32" ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes">
-                        <RegistryValue Type="string" Value="mscoree.dll" />
-                        <RegistryValue Type="string" Name="ThreadingModel" Value="Both" />
-                        <RegistryValue Type="string" Name="Class" Value="Waffle.Windows.AuthProvider.WindowsAuthProviderImpl" />
-                        <RegistryValue Type="string" Name="Assembly" Value="Waffle.Windows.AuthProvider" />
-                        <RegistryValue Type="string" Name="RuntimeVersion" Value="v2.0.50727" />
-                        <RegistryValue Type="string" Name="CodeBase" Value="[#WindowsAuthProviderDll]" />
-                    </RegistryKey>
-                    <RegistryKey Id="RegAuthCLSIDGuidIS32Ver" Root="HKCR" Key="CLSID\{78FA881E-5141-3B68-A76C-487871F4846A}\InprocServer32\$(var.ProductVersion)" ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes">
-                        <RegistryValue Type="string" Name="Class" Value="Waffle.Windows.AuthProvider.WindowsAuthProviderImpl" />
-                        <RegistryValue Type="string" Name="Assembly" Value="Waffle.Windows.AuthProvider" />
-                        <RegistryValue Type="string" Name="RuntimeVersion" Value="v2.0.50727" />
-                        <RegistryValue Type="string" Name="CodeBase" Value="[#WindowsAuthProviderDll]" />
-                    </RegistryKey>
-                    <RegistryKey Id="RegAuthCLSIDProgId" Root="HKCR" Key="CLSID\{78FA881E-5141-3B68-A76C-487871F4846A}\ProgId" ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes">
-                        <RegistryValue Type="string" Value="Waffle.Windows.AuthProvider" />
-                    </RegistryKey>
-                    <RegistryKey Id="RegAuthCLSIDCategories" Root="HKCR" Key="CLSID\{78FA881E-5141-3B68-A76C-487871F4846A}\Implemented Categories\{62C8FE65-4EBB-45E7-B440-6E39B2CDBF29}" ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes" />
-                </Component>
-            </Directory>
+    <Module Id="WindowsAuthProviderMSM"
+            Guid="80101f8b-1c44-4c7d-969b-0731b162d54b"
+            Language="1033"
+            Version="$(var.ProductVersion)"
+            InstallerVersion="200">
+        <SummaryInformation Manufacturer="$(var.CompanyName)" />
+        <Directory Id="MergeRedirectFolder">
+            <Component Id="WindowsAuthProvider" Guid="74ad70ef-aa1a-4d8f-a31c-dda1716b7dd1">
+                <File Id="WindowsAuthProviderDll" Source="$(var.MSBuildProjectDirectory)\Source\WindowsAuthProvider\bin\$(var.Configuration)\Waffle.Windows.AuthProvider.dll" KeyPath="yes" Name="Waffle.Windows.AuthProvider.dll" />
+                <RegistryKey Id="RegAdvapi32.LogonType" Root="HKCR" Key="Record\{FA3F1B69-D60F-4CBF-9A44-8CE47E5C9FF3}\$(var.ProductVersion)" ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes">
+                    <RegistryValue Type="string" Name="Class" Value="Waffle.Windows.Advapi32+LogonType" />
+                    <RegistryValue Type="string" Name="Assembly" Value="Waffle.Windows.AuthProvider" />
+                    <RegistryValue Type="string" Name="RuntimeVersion" Value="v2.0.50727" />
+                    <RegistryValue Type="string" Name="CodeBase" Value="[#WindowsAuthProviderDll]" />
+                </RegistryKey>
+                <RegistryKey Id="RegAdvapi32.LogonProvider" Root="HKCR" Key="Record\{32843EC8-13A5-499A-AED3-EAEB08C3381A}\$(var.ProductVersion)" ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes">
+                    <RegistryValue Type="string" Name="Class" Value="Waffle.Windows.Advapi32+LogonProvider" />
+                    <RegistryValue Type="string" Name="Assembly" Value="Waffle.Windows.AuthProvider" />
+                    <RegistryValue Type="string" Name="RuntimeVersion" Value="v2.0.50727" />
+                    <RegistryValue Type="string" Name="CodeBase" Value="[#WindowsAuthProviderDll]" />
+                </RegistryKey>
+                <RegistryKey Id="RegAdvapi32.SID_NAME_USE" Root="HKCR" Key="Record\{673D9C4F-13FD-430C-AFD1-4E706FFC0DC4}\$(var.ProductVersion)" ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes">
+                    <RegistryValue Type="string" Name="Class" Value="Waffle.Windows.Advapi32+SID_NAME_USE" />
+                    <RegistryValue Type="string" Name="Assembly" Value="Waffle.Windows.AuthProvider" />
+                    <RegistryValue Type="string" Name="RuntimeVersion" Value="v2.0.50727" />
+                    <RegistryValue Type="string" Name="CodeBase" Value="[#WindowsAuthProviderDll]" />
+                </RegistryKey>
+                <RegistryKey Id="RegAuth" Root="HKCR" Key="Waffle.Windows.AuthProvider" ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes">
+                    <RegistryValue Type="string" Value="Waffle.Windows.AuthProvider.WindowsAuthProviderImpl" />
+                </RegistryKey>
+                <RegistryKey Id="RegAuthCLSID" Root="HKCR" Key="Waffle.Windows.AuthProvider\CLSID" ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes">
+                    <RegistryValue Type="string" Value="{78FA881E-5141-3B68-A76C-487871F4846A}" />
+                </RegistryKey>
+                <RegistryKey Id="RegAuthCLSIDGuid" Root="HKCR" Key="CLSID\{78FA881E-5141-3B68-A76C-487871F4846A}" ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes">
+                    <RegistryValue Type="string" Value="Waffle.Windows.AuthProvider.WindowsAuthProviderImpl" />
+                </RegistryKey>
+                <RegistryKey Id="RegAuthCLSIDGuidIS32" Root="HKCR" Key="CLSID\{78FA881E-5141-3B68-A76C-487871F4846A}\InprocServer32" ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes">
+                    <RegistryValue Type="string" Value="mscoree.dll" />
+                    <RegistryValue Type="string" Name="ThreadingModel" Value="Both" />
+                    <RegistryValue Type="string" Name="Class" Value="Waffle.Windows.AuthProvider.WindowsAuthProviderImpl" />
+                    <RegistryValue Type="string" Name="Assembly" Value="Waffle.Windows.AuthProvider" />
+                    <RegistryValue Type="string" Name="RuntimeVersion" Value="v2.0.50727" />
+                    <RegistryValue Type="string" Name="CodeBase" Value="[#WindowsAuthProviderDll]" />
+                </RegistryKey>
+                <RegistryKey Id="RegAuthCLSIDGuidIS32Ver" Root="HKCR" Key="CLSID\{78FA881E-5141-3B68-A76C-487871F4846A}\InprocServer32\$(var.ProductVersion)" ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes">
+                    <RegistryValue Type="string" Name="Class" Value="Waffle.Windows.AuthProvider.WindowsAuthProviderImpl" />
+                    <RegistryValue Type="string" Name="Assembly" Value="Waffle.Windows.AuthProvider" />
+                    <RegistryValue Type="string" Name="RuntimeVersion" Value="v2.0.50727" />
+                    <RegistryValue Type="string" Name="CodeBase" Value="[#WindowsAuthProviderDll]" />
+                </RegistryKey>
+                <RegistryKey Id="RegAuthCLSIDProgId" Root="HKCR" Key="CLSID\{78FA881E-5141-3B68-A76C-487871F4846A}\ProgId" ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes">
+                    <RegistryValue Type="string" Value="Waffle.Windows.AuthProvider" />
+                </RegistryKey>
+                <RegistryKey Id="RegAuthCLSIDCategories" Root="HKCR" Key="CLSID\{78FA881E-5141-3B68-A76C-487871F4846A}\Implemented Categories\{62C8FE65-4EBB-45E7-B440-6E39B2CDBF29}" ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes" />
+            </Component>
         </Directory>
     </Module>
 </Wix>

--- a/Source/WindowsAuthProviderMergeModule/packages.config
+++ b/Source/WindowsAuthProviderMergeModule/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="WiX" version="4.0.0.4506-pre" />
-</packages>

--- a/Waffle.proj
+++ b/Waffle.proj
@@ -63,7 +63,7 @@
       <Output TaskParameter="Include" ItemName="UnitTestAssemblies"/>
     </CreateItem>
     <Message Text="@(UnitTestAssemblies)" />
-    <exec Command="$(NUnitConsoleRunnerPath)\nunit3-console.exe &quot;@(UnitTestAssemblies)&quot;"/>
+    <exec Command="$(NUnitConsoleRunnerPath)\nunit3-console.exe &quot;@(UnitTestAssemblies)&quot; --work=target\nunit"/>
   </Target>
   <Target Name="drop" DependsOnTargets="version;configurations" Inputs="@(Configuration)" Outputs="target\%(Configuration.FileName)">
     <CreateItem Include="Source\**\%(Configuration.Identity)/Waffle.*.dll" Exclude="Source\**\%(Configuration.Identity)/Waffle.*UnitTests.dll">

--- a/Waffle.proj
+++ b/Waffle.proj
@@ -1,15 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="all" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" >
-
   <PropertyGroup>
     <BuildFolder>$(MSBuildProjectDirectory)\Build</BuildFolder>
     <PackagesFolder>$(MSBuildProjectDirectory)\.nuget\packages</PackagesFolder>
     <SourceFolder>$(MSBuildProjectDirectory)\Source</SourceFolder>
-    
     <MSBuildCommunityTasksPath>$(PackagesFolder)\MSBuildTasks.1.5.0.235\tools</MSBuildCommunityTasksPath>
     <NUnitConsoleRunnerPath>$(PackagesFolder)\NUnit.ConsoleRunner.3.17.0\tools</NUnitConsoleRunnerPath>
   </PropertyGroup>
-
   <Import Project="$(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.Targets"/>
   <Import Project="Version.proj"/>
   <PropertyGroup Condition="'$(Configuration)'==''">
@@ -58,6 +55,7 @@
   <Target Name="build" DependsOnTargets="version;configurations" Inputs="@(Configuration)" Outputs="target\%(Configuration.FileName)">
     <Message Importance="high" Text="Compiling and linking project, %(Configuration.Identity) ..." />
     <MSBuild Projects="Waffle.sln" Targets="Build" Properties="Configuration=%(Configuration.Identity)" />
+    <Exec Command="dotnet msbuild Source\WindowsAuthProviderMergeModule\WindowsAuthProviderMergeModule.wixproj /t:Build /p:Configuration=%(Configuration.Identity)" />
   </Target>
   <Target Name="test" DependsOnTargets="configurations" Inputs="@(Configuration)" Outputs="target\%(Configuration.FileName)">
     <Message Importance="high" Text="Running tests, %(Configuration.Identity) ..." />
@@ -65,7 +63,7 @@
       <Output TaskParameter="Include" ItemName="UnitTestAssemblies"/>
     </CreateItem>
     <Message Text="@(UnitTestAssemblies)" />
-	<exec Command="$(NUnitConsoleRunnerPath)\nunit3-console.exe &quot;@(UnitTestAssemblies)&quot;"/>
+    <exec Command="$(NUnitConsoleRunnerPath)\nunit3-console.exe &quot;@(UnitTestAssemblies)&quot;"/>
   </Target>
   <Target Name="drop" DependsOnTargets="version;configurations" Inputs="@(Configuration)" Outputs="target\%(Configuration.FileName)">
     <CreateItem Include="Source\**\%(Configuration.Identity)/Waffle.*.dll" Exclude="Source\**\%(Configuration.Identity)/Waffle.*UnitTests.dll">

--- a/Waffle.sln
+++ b/Waffle.sln
@@ -22,12 +22,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WindowsAuthProviderUnitTest
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Version", "Source\Version\Version.csproj", "{1DA8F5AA-2EE1-4204-A72F-0373BF541395}"
 EndProject
-Project("{930C7802-8A8C-48F9-8165-68863BCCD9DD}") = "WindowsAuthProviderMergeModule", "Source\WindowsAuthProviderMergeModule\WindowsAuthProviderMergeModule.wixproj", "{8E2E9431-3FD1-41E9-97CF-CC96DD32386F}"
-	ProjectSection(ProjectDependencies) = postProject
-		{1DA8F5AA-2EE1-4204-A72F-0373BF541395} = {1DA8F5AA-2EE1-4204-A72F-0373BF541395}
-		{CD4002DB-54D8-4186-8E78-AEA1AE226D7B} = {CD4002DB-54D8-4186-8E78-AEA1AE226D7B}
-	EndProjectSection
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -46,10 +40,6 @@ Global
 		{1DA8F5AA-2EE1-4204-A72F-0373BF541395}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1DA8F5AA-2EE1-4204-A72F-0373BF541395}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1DA8F5AA-2EE1-4204-A72F-0373BF541395}.Release|Any CPU.Build.0 = Release|Any CPU
-		{8E2E9431-3FD1-41E9-97CF-CC96DD32386F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{8E2E9431-3FD1-41E9-97CF-CC96DD32386F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{8E2E9431-3FD1-41E9-97CF-CC96DD32386F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{8E2E9431-3FD1-41E9-97CF-CC96DD32386F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/bootstrap.cmd
+++ b/bootstrap.cmd
@@ -1,6 +1,8 @@
 @echo off
-Rmdir .nuget\packages\ /s /q
+if exist .nuget\packages\ rmdir .nuget\packages\ /s /q
+
 NuGet.exe install MSBuildTasks        -OutputDirectory .nuget\packages\ -NonInteractive -Version 1.5.0.235
 NuGet.exe install NUnit               -OutputDirectory .nuget\packages\ -NonInteractive -Version 4.6.1
 NuGet.exe install NUnit.ConsoleRunner -OutputDirectory .nuget\packages\ -NonInteractive -Version 3.17.0
-NuGet.exe install WiX                 -OutputDirectory .nuget\packages\ -NonInteractive -Version 4.0.0.5512-pre -Pre
+
+dotnet tool restore


### PR DESCRIPTION
- Upgraded WiX from the old pre-release 4.0.0.5512-pre to WiX 4.0.6.
- Migrated the merge-module project/source from the old WiX syntax to proper WiX 4 syntax.
- The pre-release project had existing migration problems, including the old Package structure, missing Module/@Guid, and obsolete TARGETDIR usage.
- Changed how WiX is built: instead of having legacy .NET Framework MSBuild try to build the WiX 4 SDK-style project through Waffle.sln, the main build now invokes it explicitly with modern dotnet msbuild.
- Removed the WiX project from Waffle.sln, since that solution is still driven by MSBuild 4.x for the legacy .NET Framework projects.
- Kept the existing artifact pipeline intact — the generated .msm still lands in the existing drop and ZIP packaging.****